### PR TITLE
Separate Vampire Counts Magic Banner from other magic items

### DIFF
--- a/public/games/the-old-world/vampire-counts.json
+++ b/public/games/the-old-world/vampire-counts.json
@@ -1060,8 +1060,8 @@
           "name_fr": "Standard Bearer",
           "points": 5,
           "magic": {
-            "types": [],
-            "maxPoints": 0
+            "types": ["banner"],
+            "maxPoints": 50
           }
         },
         {
@@ -1384,8 +1384,8 @@
           "name_fr": "Standard Bearer",
           "points": 6,
           "magic": {
-            "types": [],
-            "maxPoints": 0
+            "types": ["banner"],
+            "maxPoints": 50
           }
         },
         {
@@ -1505,7 +1505,6 @@
               "weapon",
               "armor",
               "talisman",
-              "banner",
               "arcane-item",
               "enchanted-item"
             ],
@@ -1519,8 +1518,8 @@
           "name_fr": "Standard Bearer",
           "points": 6,
           "magic": {
-            "types": [],
-            "maxPoints": 0
+            "types": ["banner"],
+            "maxPoints": 50
           }
         },
         {
@@ -1631,7 +1630,6 @@
               "weapon",
               "armor",
               "talisman",
-              "banner",
               "arcane-item",
               "enchanted-item"
             ],
@@ -1766,7 +1764,6 @@
               "weapon",
               "armor",
               "talisman",
-              "banner",
               "arcane-item",
               "enchanted-item"
             ],
@@ -2409,7 +2406,6 @@
               "weapon",
               "armor",
               "talisman",
-              "banner",
               "arcane-item",
               "enchanted-item"
             ],
@@ -2423,8 +2419,8 @@
           "name_fr": "Standard Bearer",
           "points": 7,
           "magic": {
-            "types": [],
-            "maxPoints": 0
+            "types": ["banner"],
+            "maxPoints": 50
           }
         },
         {

--- a/public/games/the-old-world/vampire-counts.json
+++ b/public/games/the-old-world/vampire-counts.json
@@ -333,13 +333,21 @@
             "armor",
             "armor-mages",
             "talisman",
-            "banner",
             "arcane-item",
             "enchanted-item"
           ],
           "selected": [],
           "mutuallyExclusive": false,
           "maxPoints": 50
+        },
+        {
+          "name_en": "Magic Standard (BSB)",
+          "name_de": "Magic Standard (BSB)",
+          "name_fr": "Bannière Magique (PGB)",
+          "types": ["banner"],
+          "selected": [],
+          "maxPoints": 0,
+          "mutuallyExclusive": true
         },
         {
           "name_en": "Vampiric Powers",
@@ -948,13 +956,21 @@
             "weapon",
             "armor",
             "talisman",
-            "banner",
             "arcane-item",
             "enchanted-item"
           ],
           "selected": [],
           "mutuallyExclusive": false,
           "maxPoints": 50
+        },
+        {
+          "name_en": "Magic Standard (BSB)",
+          "name_de": "Magic Standard (BSB)",
+          "name_fr": "Bannière Magique (PGB)",
+          "types": ["banner"],
+          "selected": [],
+          "maxPoints": 0,
+          "mutuallyExclusive": true
         }
       ],
       "lores": [],


### PR DESCRIPTION
Separate Vampire Counts Magic Banner from other magic items so BSB banners don't count towards the Magic Items points cap.