### PR TITLE
Adding magic item types to ogre wizards

### DIFF
--- a/public/games/the-old-world/ogre-kingdoms.json
+++ b/public/games/the-old-world/ogre-kingdoms.json
@@ -262,7 +262,13 @@
       "items": [
         {
           "name_en": "Magic Items",
-          "types": [],
+          "types": [
+            "enchanted-item",
+            "talisman",
+            "armor",
+            "weapon",
+            "arcane-item"
+        ],
           "selected": [],
           "mutuallyExclusive": false,
           "maxPoints": 100
@@ -322,7 +328,13 @@
       "items": [
         {
           "name_en": "Magic Items",
-          "types": [],
+          "types": [
+            "enchanted-item",
+            "talisman",
+            "armor",
+            "weapon",
+            "arcane-item"
+          ],
           "selected": [],
           "mutuallyExclusive": false,
           "maxPoints": 50


### PR DESCRIPTION
Butcher and slaughtmaster had the correct magic item points allowances but not magic item types were specified so i have added them.

(I used the Beastmen Great-Bray shaman as the 'source of truth' for which types should be allowed, if that was wrong my bad).