### PR TITLE
Add filters and disable logic to magic item selection

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -69,7 +69,7 @@ You can also use our [Datasets editor](https://old-world-builder.com/datasets), 
       "name_de": String,
       "name_de": String,
       "points": Number,
-      "stackable": Boolean, // Allows multiple selectins of this option
+      "stackable": Boolean, // Allows multiple selections of this option
       "minimum": Number, // Minimum number of this option
       "maximum": Number, // Maximum number of this option
     }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "workbox-strategies": "^5.1.4",
     "workbox-streams": "^5.1.4"
   },
+  "devDependencies": {
+    "eslint": "^7.11.0"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build && yarn sentry:sourcemaps",

--- a/public/games/the-old-world/magic-items.json
+++ b/public/games/the-old-world/magic-items.json
@@ -563,12 +563,6 @@
       "type": "knightly-virtue-character"
     },
     {
-      "name_en": "No Knightly Virtue",
-      "name_de": "No Knightly Virtue",
-      "points": 0,
-      "type": "knightly-virtue"
-    },
-    {
       "name_en": "Virtue of Knightly Temper",
       "name_de": "Virtue of Knightly Temper",
       "points": 70,

--- a/public/games/the-old-world/magic-items.json
+++ b/public/games/the-old-world/magic-items.json
@@ -788,13 +788,17 @@
       "name_de": "Rune of Parrying",
       "name_en": "Rune of Parrying",
       "points": 35,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "stackable": true,
+      "maximum": 1
     },
     {
       "name_de": "Rune of Banishment",
       "name_en": "Rune of Banishment",
       "points": 25,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "stackable": true,
+      "maximum": 1
     },
     {
       "name_de": "Rune of Fury*",
@@ -802,7 +806,6 @@
       "stackable": true,
       "points": 25,
       "type": "weapon-runes",
-      "minimum": 0,
       "maximum": 3
     },
     {
@@ -811,7 +814,6 @@
       "stackable": true,
       "points": 20,
       "type": "weapon-runes",
-      "minimum": 0,
       "maximum": 3
     },
     {
@@ -820,7 +822,6 @@
       "stackable": true,
       "points": 20,
       "type": "weapon-runes",
-      "minimum": 0,
       "maximum": 3
     },
     {
@@ -829,7 +830,6 @@
       "stackable": true,
       "points": 15,
       "type": "weapon-runes",
-      "minimum": 0,
       "maximum": 3
     },
     {
@@ -838,14 +838,15 @@
       "stackable": true,
       "points": 15,
       "type": "weapon-runes",
-      "minimum": 0,
       "maximum": 3
     },
     {
       "name_de": "Rune of Fire",
       "name_en": "Rune of Fire",
       "points": 10,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "stackable": true,
+      "maximum": 1
     },
     {
       "name_de": "Rune of Speed*",
@@ -853,7 +854,6 @@
       "stackable": true,
       "points": 5,
       "type": "weapon-runes",
-      "minimum": 0,
       "maximum": 3
     },
     {
@@ -872,7 +872,9 @@
       "name_de": "Rune of Iron",
       "name_en": "Rune of Iron",
       "points": 35,
-      "type": "armor-runes"
+      "type": "armor-runes",
+      "stackable": true,
+      "maximum": 1
     },
     {
       "name_de": "Rune of Fortitude*",
@@ -880,14 +882,15 @@
       "stackable": true,
       "points": 30,
       "type": "armor-runes",
-      "minimum": 0,
       "maximum": 3
     },
     {
       "name_de": "Rune of Preservation",
       "name_en": "Rune of Preservation",
       "points": 25,
-      "type": "armor-runes"
+      "type": "armor-runes",
+      "stackable": true,
+      "maximum": 1
     },
     {
       "name_de": "Rune of Shielding*",
@@ -895,7 +898,6 @@
       "stackable": true,
       "points": 15,
       "type": "armor-runes",
-      "minimum": 0,
       "maximum": 3
     },
     {
@@ -904,7 +906,6 @@
       "stackable": true,
       "points": 5,
       "type": "armor-runes",
-      "minimum": 0,
       "maximum": 3
     },
     {
@@ -931,7 +932,6 @@
       "stackable": true,
       "points": 25,
       "type": "talismanic-runes",
-      "minimum": 0,
       "maximum": 3
     },
     {
@@ -940,7 +940,6 @@
       "stackable": true,
       "points": 20,
       "type": "talismanic-runes",
-      "minimum": 0,
       "maximum": 3
     },
     {
@@ -949,20 +948,23 @@
       "stackable": true,
       "points": 15,
       "type": "talismanic-runes",
-      "minimum": 0,
       "maximum": 3
     },
     {
       "name_de": "Rune of the Furnace",
       "name_en": "Rune of the Furnace",
       "points": 5,
-      "type": "talismanic-runes"
+      "type": "talismanic-runes",
+      "stackable": true,
+      "maximum": 1
     },
     {
       "name_de": "Rune of Passage",
       "name_en": "Rune of Passage",
       "points": 5,
-      "type": "talismanic-runes"
+      "type": "talismanic-runes",
+      "stackable": true,
+      "maximum": 1
     },
     {
       "name_de": "Master Rune of Grungni",
@@ -986,31 +988,41 @@
       "name_de": "Rune of Confusion",
       "name_en": "Rune of Confusion",
       "points": 35,
-      "type": "banner-runes"
+      "type": "banner-runes",
+      "stackable": true,
+      "maximum": 1
     },
     {
       "name_de": "Rune of Fear",
       "name_en": "Rune of Fear",
       "points": 30,
-      "type": "banner-runes"
+      "type": "banner-runes",
+      "stackable": true,
+      "maximum": 1
     },
     {
       "name_de": "Rune of Battle",
       "name_en": "Rune of Battle",
       "points": 25,
-      "type": "banner-runes"
+      "type": "banner-runes",
+      "stackable": true,
+      "maximum": 1
     },
     {
       "name_de": "Strollaz' Rune",
       "name_en": "Strollaz' Rune",
       "points": 25,
-      "type": "banner-runes"
+      "type": "banner-runes",
+      "stackable": true,
+      "maximum": 1
     },
     {
       "name_de": "Rune of Courage",
       "name_en": "Rune of Courage",
       "points": 15,
-      "type": "banner-runes"
+      "type": "banner-runes",
+      "stackable": true,
+      "maximum": 1
     },
     {
       "name_de": "Master Rune of Immolation",
@@ -1028,7 +1040,9 @@
       "name_de": "Rune of Skewering",
       "name_en": "Rune of Skewering",
       "points": 20,
-      "type": "engineering-runes"
+      "type": "engineering-runes",
+      "stackable": true,
+      "maximum": 1
     },
     {
       "name_de": "Rune of Forging*",
@@ -1036,26 +1050,31 @@
       "stackable": true,
       "points": 15,
       "type": "engineering-runes",
-      "minimum": 0,
       "maximum": 3
     },
     {
       "name_de": "Rune of Burning",
       "name_en": "Rune of Burning",
       "points": 10,
-      "type": "engineering-runes"
+      "type": "engineering-runes",
+      "stackable": true,
+      "maximum": 1
     },
     {
       "name_de": "Rune of Reloading",
       "name_en": "Rune of Reloading",
       "points": 5,
-      "type": "engineering-runes"
+      "type": "engineering-runes",
+      "stackable": true,
+      "maximum": 1
     },
     {
       "name_de": "Stalwart Rune",
       "name_en": "Stalwart Rune",
       "points": 5,
-      "type": "engineering-runes"
+      "type": "engineering-runes",
+      "stackable": true,
+      "maximum": 1
     }
   ],
   "orc-and-goblin-tribes": [

--- a/public/games/the-old-world/magic-items.json
+++ b/public/games/the-old-world/magic-items.json
@@ -172,12 +172,6 @@
       "type": "talisman"
     },
     {
-      "name_de": "No banner",
-      "name_en": "No banner",
-      "points": 0,
-      "type": "banner"
-    },
-    {
       "name_de": "Banner of Iron Resolve",
       "name_en": "Banner of Iron Resolve",
       "points": 50,
@@ -1857,16 +1851,18 @@
       "type": "enchanted-item"
     },
     {
-      "name_de": "Hail of Doom Arrow",
-      "name_en": "Hail of Doom Arrow",
+      "name_de": "Hail of Doom Arrow*",
+      "name_en": "Hail of Doom Arrow*",
       "points": 35,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "stackable": true
     },
     {
-      "name_de": "Wailling Arrow",
-      "name_en": "Wailling Arrow",
+      "name_de": "Wailing Arrow*",
+      "name_en": "Wailing Arrow*",
       "points": 20,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "stackable": true
     },
     {
       "name_de": "Deepwood Sphere",

--- a/src/App.css
+++ b/src/App.css
@@ -216,6 +216,11 @@ hr {
   align-items: center;
 }
 
+.radio__input:disabled + .radio__label,
+.checkbox__input:disabled + .checkbox__label {
+  opacity: 0.3;
+}
+
 .input {
   background-color: var(--color-white);
   display: block;

--- a/src/App.css
+++ b/src/App.css
@@ -219,6 +219,7 @@ hr {
 .radio__input:disabled + .radio__label,
 .checkbox__input:disabled + .checkbox__label {
   opacity: 0.3;
+  cursor: default;
 }
 
 .input {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,0 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/pages/magic/Magic.css
+++ b/src/pages/magic/Magic.css
@@ -10,9 +10,3 @@
 .header .magic__header-points {
   color: var(--color-font-light);
 }
-
-.magic__header-points--error,
-.header .magic__header-points--error {
-  color: var(--color-error);
-  font-weight: bold;
-}

--- a/src/pages/magic/Magic.js
+++ b/src/pages/magic/Magic.js
@@ -342,7 +342,6 @@ export const Magic = ({ isMobile }) => {
     );
   };
 
-  let hasPointsError = false;
   let unitMagicPoints = 0;
   const hasCommandMagicItems = Boolean(
     unit?.command &&
@@ -356,13 +355,11 @@ export const Magic = ({ isMobile }) => {
     unitMagicPoints = getUnitMagicPoints({
       selected: unit.command[command].magic.selected,
     });
-    hasPointsError = unitMagicPoints > maxMagicPoints && maxMagicPoints > 0;
   } else if (hasMagicItems) {
     maxMagicPoints = unit.items[group].maxPoints;
     unitMagicPoints = getUnitMagicPoints({
       selected: unit.items[group].selected,
     });
-    hasPointsError = unitMagicPoints > maxMagicPoints && maxMagicPoints > 0;
   }
 
   const unitPointsRemaining = maxMagicPoints - unitMagicPoints;
@@ -386,19 +383,13 @@ export const Magic = ({ isMobile }) => {
           }
           subheadline={
             <>
-              <span
-                className={classNames(
-                  "magic__header-points",
-                  hasPointsError && "magic__header-points--error"
-                )}
-              >
-                {`${unitMagicPoints}`}&nbsp;
+              <span className="magic__header-points">
+                {unitMagicPoints}&nbsp;
               </span>
               {maxMagicPoints > 0 && `/ ${maxMagicPoints} `}
               <FormattedMessage id="app.points" />
             </>
           }
-          hasPointsError={hasPointsError}
         />
       )}
 
@@ -417,19 +408,13 @@ export const Magic = ({ isMobile }) => {
             }
             subheadline={
               <>
-                <span
-                  className={classNames(
-                    "magic__header-points",
-                    hasPointsError && "magic__header-points--error"
-                  )}
-                >
-                  {`${unitMagicPoints}`}&nbsp;
+                <span className="magic__header-points">
+                  {unitMagicPoints}&nbsp;
                 </span>
                 {maxMagicPoints > 0 && `/ ${maxMagicPoints} `}
                 <FormattedMessage id="app.points" />
               </>
             }
-            hasPointsError={hasPointsError}
           />
         )}
         {items.map((itemGroup) => {

--- a/src/pages/magic/Magic.js
+++ b/src/pages/magic/Magic.js
@@ -276,7 +276,7 @@ export const Magic = ({ isMobile }) => {
     isConditional,
     isTypeLimitReached,
   }) => {
-    const isCommand = Boolean(unit?.command[command]);
+    const isCommand = Boolean(unit?.command[command]?.magic?.maxpoints);
 
     // If an item is stackable, we need to check how many of the item are already selected.
     const allowedMaxOfStackableItem = Math.min(

--- a/src/pages/magic/Magic.js
+++ b/src/pages/magic/Magic.js
@@ -280,7 +280,7 @@ export const Magic = ({ isMobile }) => {
     isConditional,
     isTypeLimitReached,
   }) => {
-    const isCommand = Boolean(unit?.command[command]?.magic?.maxpoints);
+    const isCommand = Boolean(unit?.command[command]?.magic?.types.length);
 
     const max = !maxMagicPoints
       ? // No maximum of this item if there is no point max.

--- a/src/utils/magic-item-limitations.js
+++ b/src/utils/magic-item-limitations.js
@@ -1,0 +1,43 @@
+/**
+ * Returns whether the magic item can be taken multiple times.
+ *
+ * Typically, these are common potions, scrolls or runes
+ *
+ * @param {object} magicItem
+ * @param {string} magicItem.type
+ * @param {boolean} [magicItem.stackable]
+ * @param {number} [magicItem.maximum]
+ * @returns {boolean}
+ */
+export const isMultipleAllowedItem = ({ type, stackable, maximum }) =>
+  Boolean(stackable || maximum) &&
+  // You can have more than 1 scrolls, potions, runes etc for a unit.
+  (type.endsWith("-runes") || ["arcane-item", "enchanted-item"].includes(type));
+//
+
+/**
+ * Calculates the maximum amount of a magic item that can be taken given the remaining points.
+ *
+ * @param {object} magicItem
+ * @param {number} selectedAmount
+ * @param {number} unitPointsRemaining
+ * @returns
+ */
+export const maxAllowedOfItem = (
+  magicItem,
+  selectedAmount,
+  unitPointsRemaining
+) => {
+  if (!magicItem.stackable && !magicItem.maximum) {
+    return 1;
+  }
+
+  const pointsRemainingMax =
+    Math.floor(unitPointsRemaining / magicItem.points) + selectedAmount;
+
+  if (magicItem.maximum) {
+    return Math.min(magicItem.maximum, pointsRemainingMax);
+  }
+
+  return pointsRemainingMax;
+};

--- a/src/utils/magic-item-limitations.js
+++ b/src/utils/magic-item-limitations.js
@@ -10,10 +10,7 @@
  * @returns {boolean}
  */
 export const isMultipleAllowedItem = ({ type, stackable, maximum }) =>
-  Boolean(stackable || maximum) &&
-  // You can have more than 1 scrolls, potions, runes etc for a unit.
-  (type.endsWith("-runes") || ["arcane-item", "enchanted-item"].includes(type));
-//
+  Boolean(stackable || maximum);
 
 /**
  * Calculates the maximum amount of a magic item that can be taken given the remaining points.

--- a/src/utils/magic-item-limitations.test.js
+++ b/src/utils/magic-item-limitations.test.js
@@ -1,0 +1,77 @@
+import {
+  isMultipleAllowedItem,
+  maxAllowedOfItem,
+} from "./magic-item-limitations";
+import magicItems from "../../public/games/the-old-world/magic-items.json";
+
+describe("isMultipleAllowedItem", () => {
+  test("Normally, you should not be able to have multiple of the same magic item.", () => {
+    const item = magicItems.general.find(
+      (item) => item.name_en === "Flying Carpet"
+    );
+
+    expect(isMultipleAllowedItem(item)).toBe(false);
+  });
+
+  test("You can have more than 1 magic scroll per unit.", () => {
+    const item = magicItems.general.find(
+      (item) => item.name_en === "Power Scroll*"
+    );
+
+    expect(isMultipleAllowedItem(item)).toBe(true);
+  });
+
+  test("You can have more than 1 magic potion per unit.", () => {
+    const item = magicItems.general.find(
+      (item) => item.name_en === "Healing Potion*"
+    );
+
+    expect(isMultipleAllowedItem(item)).toBe(true);
+  });
+
+  test("You can still only select 1 magic weapon even if it's very common.", () => {
+    const item = magicItems.general.find(
+      (item) => item.name_en === "Sword of Might*"
+    );
+
+    expect(isMultipleAllowedItem(item)).toBe(false);
+  });
+
+  test("Some Dwarfen runes can be taken multiple times", () => {
+    const item = magicItems["dwarfen-mountain-holds"].find(
+      (item) => item.name_en === "Rune of Might*"
+    );
+    expect(isMultipleAllowedItem(item)).toBe(true);
+  });
+});
+
+describe("maxAllowedOfItem", () => {
+  test("If you have 100 points remaining, you can take 5 power scrolls.", () => {
+    const item = magicItems.general.find(
+      (item) => item.name_en === "Power Scroll*"
+    ); // 20 points
+    const selectedAmount = 0;
+    const unitPointsRemaining = 100;
+    expect(maxAllowedOfItem(item, selectedAmount, unitPointsRemaining)).toBe(5);
+  });
+
+  test("If you have 30 points remaining and already have 2, you can have up to 3 power scrolls.", () => {
+    const item = magicItems.general.find(
+      (item) => item.name_en === "Power Scroll*"
+    ); // 20 points
+    const selectedAmount = 2;
+    const unitPointsRemaining = 30;
+
+    expect(maxAllowedOfItem(item, selectedAmount, unitPointsRemaining)).toBe(3);
+  });
+
+  test("You can never have more than 3 of the same runes, even if enough points", () => {
+    const item = magicItems["dwarfen-mountain-holds"].find(
+      (item) => item.name_en === "Rune of Might*"
+    ); // 20 points
+    const selectedAmount = 0;
+    const unitPointsRemaining = 100;
+
+    expect(maxAllowedOfItem(item, selectedAmount, unitPointsRemaining)).toBe(3);
+  });
+});

--- a/src/utils/magic-item-limitations.test.js
+++ b/src/utils/magic-item-limitations.test.js
@@ -29,14 +29,6 @@ describe("isMultipleAllowedItem", () => {
     expect(isMultipleAllowedItem(item)).toBe(true);
   });
 
-  test("You can still only select 1 magic weapon even if it's very common.", () => {
-    const item = magicItems.general.find(
-      (item) => item.name_en === "Sword of Might*"
-    );
-
-    expect(isMultipleAllowedItem(item)).toBe(false);
-  });
-
   test("Some Dwarfen runes can be taken multiple times", () => {
     const item = magicItems["dwarfen-mountain-holds"].find(
       (item) => item.name_en === "Rune of Might*"


### PR DESCRIPTION
- A unit does not see magic items anymore that are higher than its allowed maximum.
- All items that are above the currently available left over points are disabled
- All items of a currently selected type (except stackable) are disabled.
- Added a maximum for the stackable input based on the points remaining (or an existing configured maximum)
- The radio variant (and the no-banner option) is removed since we now have stricter limitation rules.
- Add some simple styling for a disabled checkbox state.

<img width="638" alt="Scherm­afbeelding 2024-01-24 om 07 51 49" src="https://github.com/nthiebes/old-world-builder/assets/3833962/ada197e6-43c7-49df-a3ed-d157915d4d55">
<img width="631" alt="Scherm­afbeelding 2024-01-24 om 07 55 51" src="https://github.com/nthiebes/old-world-builder/assets/3833962/6ceea3a5-9de1-40e5-969b-4511e9ae365d">
