### PR TITLE
Update name-map.js

### DIFF
--- a/src/pages/magic/name-map.js
+++ b/src/pages/magic/name-map.js
@@ -228,10 +228,6 @@ export const nameMap = {
     name_en: "Vampire Counts",
     name_de: "Vampire Counts",
   },
-  "vampiric-powers": {
-    name_en: "Vampiric Powers",
-    name_de: "Vampiric Powers",
-  },
   "vampiric-power": {
     name_en: "Vampiric Power",
     name_de: "Vampiric Power",
@@ -327,14 +323,6 @@ export const nameMap = {
   "daemonic-icon-tzeentch": {
     name_en: "Icon Of Tzeentch",
     name_de: "Icon Of Tzeentch",
-  },
-  "forbidden-poisons": {
-    name_en: "Forbidden Poisons",
-    name_de: "Forbidden Poisons",
-  },
-  "gifts-of-khaine": {
-    name_en: "Gifts of Khaine",
-    name_de: "Gifts of Khaine",
   },
   "forbidden-poison": {
     name_en: "Forbidden Poison",


### PR DESCRIPTION
removed some plural types 
Are we keeping the types as singular or not? Also do the names need to be singular too?  Can you add a comment somewhere in the file to avoid this?