### PR TITLE
Fix Dwarf Quarrellers/Thunderers great weapons cost

### DIFF
--- a/public/games/the-old-world/dwarfen-mountain-holds.json
+++ b/public/games/the-old-world/dwarfen-mountain-holds.json
@@ -944,7 +944,7 @@
         {
           "name_en": "Great weapons",
           "name_de": "Great weapons",
-          "points": 1,
+          "points": 2,
           "stackable": false,
           "minimum": 0,
           "maximum": 0,
@@ -1024,7 +1024,7 @@
         {
           "name_en": "Great weapons",
           "name_de": "Great weapons",
-          "points": 1,
+          "points": 2,
           "stackable": false,
           "minimum": 0,
           "maximum": 0,


### PR DESCRIPTION
Adjusted Quarrellers/Thunderers great weapons cost from 1 to 2 points.

<img width="617" alt="image" src="https://github.com/nthiebes/old-world-builder/assets/32199245/625f180e-3089-466c-b112-e6ff5909b111">
