### PR TITLE
Fix dark-elves.json

### DIFF
--- a/games/the-old-world/dark-elves.json
+++ b/games/the-old-world/dark-elves.json
@@ -1578,6 +1578,14 @@
       ],
       "armor": [
         {
+          "name_en": "No armour",
+          "name_de": "No armour",
+          "name_es": "No armour",
+          "name_fr": "Armure non",
+          "points": 0,
+          "perModel": true
+        },
+        {
           "name_en": "Light armour",
           "name_de": "Light armour",
           "name_es": "Light armour",


### PR DESCRIPTION
Allow option to reset armor to none for Shades.
Previously you had to delete the Shade unit to reset it.