### PR TITLE
fixing missing point values and erroneous item choice

### DIFF
--- a/public/games/the-old-world/daemons-of-chaos.json
+++ b/public/games/the-old-world/daemons-of-chaos.json
@@ -1833,7 +1833,7 @@
           "points": 6,
           "magic": {
             "types": ["daemonic-icon-common", "daemonic-icon-tzeentch"],
-            "maxPoints": 0
+            "maxPoints": 50
           }
         },
         {
@@ -2631,19 +2631,7 @@
         }
       ],
       "mounts": [],
-      "items": [
-        {
-          "name_en": "Daemonic Icon",
-          "name_de": "Daemonic Icon",
-          "name_es": "Daemonic Icon",
-          "name_fr": "Icône Démoniaque",
-          "name_it": "Daemonic Icon",
-          "name_pl": "Daemonic Icon",
-          "types": [],
-          "selected": [],
-          "maxPoints": 50
-        }
-      ],
+      "items": [],
       "lores": [],
       "specialRules": {
         "name_en": "Armour Bane (2 - Rot Fly Only), Daemonic, Daemons of Nurgle, Fly (9), Poisoned Attacks, Regeneration (6+), Skirmishers, Swiftstride",
@@ -2954,7 +2942,7 @@
           "points": 6,
           "magic": {
             "types": ["daemonic-icon-common", "daemonic-icon-tzeentch"],
-            "maxPoints": 0
+            "maxPoints": 50
           }
         },
         {
@@ -3464,19 +3452,7 @@
         }
       ],
       "mounts": [],
-      "items": [
-        {
-          "name_en": "Daemonic Icon",
-          "name_de": "Daemonic Icon",
-          "name_es": "Daemonic Icon",
-          "name_fr": "Icône Démoniaque",
-          "name_it": "Daemonic Icon",
-          "name_pl": "Daemonic Icon",
-          "types": [],
-          "selected": [],
-          "maxPoints": 50
-        }
-      ],
+      "items": [],
       "lores": [],
       "specialRules": {
         "name_en": "Armour Bane (2 - Rot Fly Only), Daemonic, Daemons of Nurgle, Fly (9), Poisoned Attacks, Regeneration (6+), Skirmishers, Swiftstride",


### PR DESCRIPTION
the pink horrors were missing a max points value for their icons
the plague drones had a duplicate item entry for daemonic icons