### PR TITLE
daemonic gifts are non exclusive

### DIFF
--- a/public/games/the-old-world/magic-items.json
+++ b/public/games/the-old-world/magic-items.json
@@ -3980,7 +3980,8 @@
       "name_fr": "Lame d'Éther",
       "name_it": "Æther Lama",
       "points": 55,
-      "type": "daemonic-gift-common"
+      "type": "daemonic-gift-common",
+      "nonExclusive": true
     },
     {
       "name-fr": "Nombreux Bras*",
@@ -3989,7 +3990,8 @@
       "name_it": "Many Arms*",
       "points": 55,
       "stackable": true,
-      "type": "daemonic-gift-common"
+      "type": "daemonic-gift-common",
+      "nonExclusive": true
     },
     {
       "name_de": "Winged Horror",
@@ -3997,7 +3999,8 @@
       "name_fr": "Horreur Ailée",
       "name_it": "Winged Horror",
       "points": 45,
-      "type": "daemonic-gift-common"
+      "type": "daemonic-gift-common",
+      "nonExclusive": true
     },
     {
       "name_de": "Daemonic Robes",
@@ -4005,7 +4008,8 @@
       "name_fr": "Robes Démoniaques",
       "name_it": "Daemonic Robes",
       "points": 35,
-      "type": "daemonic-gift-common"
+      "type": "daemonic-gift-common",
+      "nonExclusive": true
     }
   ],
   "daemonic-icons-common": [
@@ -4041,7 +4045,8 @@
       "name_fr": "Mange-sort",
       "name_it": "Spell Eater",
       "points": 50,
-      "type": "daemonic-gift-khorne"
+      "type": "daemonic-gift-khorne",
+      "nonExclusive": true
     },
     {
       "name_de": "Armour Of Khorne",
@@ -4049,7 +4054,8 @@
       "name_fr": "Armure de Khorne",
       "name_it": "Armour Of Khorne",
       "points": 40,
-      "type": "daemonic-gift-khorne"
+      "type": "daemonic-gift-khorne",
+      "nonExclusive": true
     },
     {
       "name_de": "Axe Of Khorne*",
@@ -4058,7 +4064,8 @@
       "name_it": "Axe Of Khorne*",
       "points": 35,
       "stackable": true,
-      "type": "daemonic-gift-khorne"
+      "type": "daemonic-gift-khorne",
+      "nonExclusive": true
     },
     {
       "name_de": "Might Of Khorne",
@@ -4066,7 +4073,8 @@
       "name_fr": "Carrure de Khorne",
       "name_it": "Might Of Khorne",
       "points": 25,
-      "type": "daemonic-gift-khorne"
+      "type": "daemonic-gift-khorne",
+      "nonExclusive": true
     },
     {
       "name_de": "Collar Of Khorne*",
@@ -4075,7 +4083,8 @@
       "name_it": "Collar Of Khorne*",
       "points": 25,
       "stackable": true,
-      "type": "daemonic-gift-khorne"
+      "type": "daemonic-gift-khorne",
+      "nonExclusive": true
     }
   ],
   "daemonic-icons-khorne": [
@@ -4111,7 +4120,8 @@
       "name_fr": "Infestation de Nurglings",
       "name_it": "Nurgling Infestation",
       "points": 45,
-      "type": "daemonic-gift-nurgle"
+      "type": "daemonic-gift-nurgle",
+      "nonExclusive": true
     },
     {
       "name_de": "Sloppity Bilepiper",
@@ -4119,7 +4129,8 @@
       "name_fr": "Cornemuse Bilieuse",
       "name_it": "Sloppity Bilepiper",
       "points": 35,
-      "type": "daemonic-gift-nurgle"
+      "type": "daemonic-gift-nurgle",
+      "nonExclusive": true
     },
     {
       "name_de": "Spoilpox Scrivener",
@@ -4127,7 +4138,8 @@
       "name_fr": "Scribe Véroleux",
       "name_it": "Spoilpox Scrivener",
       "points": 30,
-      "type": "daemonic-gift-nurgle"
+      "type": "daemonic-gift-nurgle",
+      "nonExclusive": true
     },
     {
       "name_de": "Trappings Of Nurgle",
@@ -4135,7 +4147,8 @@
       "name_fr": "Étreinte de Nurgle",
       "name_it": "Trappings Of Nurgle",
       "points": 30,
-      "type": "daemonic-gift-nurgle"
+      "type": "daemonic-gift-nurgle",
+      "nonExclusive": true
     },
     {
       "name_de": "Stream Of Contagion*",
@@ -4144,7 +4157,8 @@
       "name_it": "Stream Of Contagion*",
       "points": 25,
       "stackable": true,
-      "type": "daemonic-gift-nurgle"
+      "type": "daemonic-gift-nurgle",
+      "nonExclusive": true
     }
   ],
   "daemonic-icons-nurgle": [
@@ -4180,7 +4194,8 @@
       "name_fr": "Fascination Infernale",
       "name_it": "Infernal Enrapturess",
       "points": 50,
-      "type": "daemonic-gift-slaanesh"
+      "type": "daemonic-gift-slaanesh",
+      "nonExclusive": true
     },
     {
       "name_de": "Allure Of Slaanesh",
@@ -4188,7 +4203,8 @@
       "name_fr": "Aura de Slannesh",
       "name_it": "Allure Of Slaanesh",
       "points": 35,
-      "type": "daemonic-gift-slaanesh"
+      "type": "daemonic-gift-slaanesh",
+      "nonExclusive": true
     },
     {
       "name_de": "Siren Song",
@@ -4196,7 +4212,8 @@
       "name_fr": "Chant de la Sirène",
       "name_it": "Siren Song",
       "points": 30,
-      "type": "daemonic-gift-slaanesh"
+      "type": "daemonic-gift-slaanesh",
+      "nonExclusive": true
     },
     {
       "name_de": "Soporific Musk*",
@@ -4205,7 +4222,8 @@
       "name_it": "Soporific Musk*",
       "points": 30,
       "stackable": true,
-      "type": "daemonic-gift-slaanesh"
+      "type": "daemonic-gift-slaanesh",
+      "nonExclusive": true
     },
     {
       "name_de": "Enrapturing Gaze*",
@@ -4214,7 +4232,8 @@
       "name_it": "Enrapturing Gaze*",
       "points": 20,
       "stackable": true,
-      "type": "daemonic-gift-slaanesh"
+      "type": "daemonic-gift-slaanesh",
+      "nonExclusive": true
     }
   ],
   "daemonic-icons-slaanesh": [
@@ -4250,7 +4269,8 @@
       "name_fr": "Sceptre du Changement",
       "name_it": "Bastone Of Change",
       "points": 65,
-      "type": "daemonic-gift-tzeentch"
+      "type": "daemonic-gift-tzeentch",
+      "nonExclusive": true
     },
     {
       "name_de": "Will Of Tzeentch",
@@ -4258,7 +4278,8 @@
       "name_fr": "Volonté de Tzeentch",
       "name_it": "Will Of Tzeentch",
       "points": 55,
-      "type": "daemonic-gift-tzeentch"
+      "type": "daemonic-gift-tzeentch",
+      "nonExclusive": true
     },
     {
       "name_de": "Power Vortex",
@@ -4266,7 +4287,8 @@
       "name_fr": "Vortex de Pouvoir",
       "name_it": "Potere Vortex",
       "points": 35,
-      "type": "daemonic-gift-tzeentch"
+      "type": "daemonic-gift-tzeentch",
+      "nonExclusive": true
     },
     {
       "name_de": "Iridescent Corona*",
@@ -4275,7 +4297,8 @@
       "name_it": "Iridescent Corona*",
       "points": 30,
       "stackable": true,
-      "type": "daemonic-gift-tzeentch"
+      "type": "daemonic-gift-tzeentch",
+      "nonExclusive": true
     },
     {
       "name_de": "Twin Heads",
@@ -4283,7 +4306,8 @@
       "name_fr": "Têtes Jumelles",
       "name_it": "Twin Heads",
       "points": 20,
-      "type": "daemonic-gift-tzeentch"
+      "type": "daemonic-gift-tzeentch",
+      "nonExclusive": true
     }
   ],
   "daemonic-icons-tzeentch": [


### PR DESCRIPTION
all daemonic gifts are treated as common magic items with the exception that they can only be taken once per army unless specified