### PR TITLE
New Feature: Notes for unit options

### DIFF
--- a/src/pages/unit/Unit.css
+++ b/src/pages/unit/Unit.css
@@ -210,3 +210,19 @@
   position: relative;
   margin-right: 0.5rem;
 }
+
+.unit__option-note {
+  margin: -0.8rem 0 0.8rem 1.4rem;
+  line-height: normal;
+  font-size: 0.9em;
+  font-style: italic;
+}
+
+.unit__option-note--stackable {
+  margin-left: 1rem;
+  margin-right: 2.2rem;
+}
+
+.unit__option-note--conditionnal {
+  margin-left: 1.8rem;
+}

--- a/src/pages/unit/Unit.js
+++ b/src/pages/unit/Unit.js
@@ -28,7 +28,7 @@ import { useLanguage } from "../../utils/useLanguage";
 import { updateLocalList } from "../../utils/list";
 import { updateIds, getRandomId } from "../../utils/id";
 import { normalizeRuleName } from "../../utils/string";
-import { getUnitName } from "../../utils/unit";
+import { getUnitName, showUnitOptionNotes } from "../../utils/unit";
 
 import "./Unit.css";
 
@@ -777,26 +777,41 @@ export const Unit = ({ isMobile, previewData = {} }) => {
               <FormattedMessage id="unit.equipment" />
             </h2>
             {unit.equipment.map(
-              ({ points, perModel, id, active = false, ...equipment }) => (
-                <div className="radio" key={id}>
-                  <input
-                    type="radio"
-                    id={`equipment-${id}`}
-                    name="equipment"
-                    value={id}
-                    onChange={() => handleEquipmentChange(id)}
-                    checked={active}
-                    className="radio__input"
-                  />
-                  <label htmlFor={`equipment-${id}`} className="radio__label">
-                    <span className="unit__label-text">
-                      <RulesWithIcon textObject={equipment} />
-                    </span>
-                    <i className="checkbox__points">
-                      {getPointsText({ points, perModel })}
-                    </i>
-                  </label>
-                </div>
+              ({
+                points,
+                perModel,
+                id,
+                active = false,
+                notes,
+                ...equipment
+              }) => (
+                <Fragment key={id}>
+                  <div className="radio">
+                    <input
+                      type="radio"
+                      id={`equipment-${id}`}
+                      name="equipment"
+                      value={id}
+                      onChange={() => handleEquipmentChange(id)}
+                      checked={active}
+                      className="radio__input"
+                    />
+                    <label htmlFor={`equipment-${id}`} className="radio__label">
+                      <span className="unit__label-text">
+                        <RulesWithIcon textObject={equipment} />
+                      </span>
+                      <i className="checkbox__points">
+                        {getPointsText({ points, perModel })}
+                      </i>
+                    </label>
+                  </div>
+                  {showUnitOptionNotes(
+                    notes,
+                    `equipment-${id}-note`,
+                    "unit__option-note",
+                    language
+                  )}
+                </Fragment>
               )
             )}
           </>
@@ -813,33 +828,42 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                 id,
                 activeDefault,
                 active = false,
+                notes,
                 ...equipment
               }) => {
                 const isRadio = unit.armor.length > 1 || activeDefault;
 
                 return (
-                  <div className={isRadio ? "radio" : "checkbox"} key={id}>
-                    <input
-                      type={isRadio ? "radio" : "checkbox"}
-                      id={`armor-${id}`}
-                      name="armor"
-                      value={id}
-                      onChange={() => handleArmorChange(id)}
-                      checked={active}
-                      className={isRadio ? "radio__input" : "checkbox__input"}
-                    />
-                    <label
-                      htmlFor={`armor-${id}`}
-                      className={isRadio ? "radio__label" : "checkbox__label"}
-                    >
-                      <span className="unit__label-text">
-                        <RulesWithIcon textObject={equipment} />
-                      </span>
-                      <i className="checkbox__points">
-                        {getPointsText({ points, perModel })}
-                      </i>
-                    </label>
-                  </div>
+                  <Fragment key={id}>
+                    <div className={isRadio ? "radio" : "checkbox"}>
+                      <input
+                        type={isRadio ? "radio" : "checkbox"}
+                        id={`armor-${id}`}
+                        name="armor"
+                        value={id}
+                        onChange={() => handleArmorChange(id)}
+                        checked={active}
+                        className={isRadio ? "radio__input" : "checkbox__input"}
+                      />
+                      <label
+                        htmlFor={`armor-${id}`}
+                        className={isRadio ? "radio__label" : "checkbox__label"}
+                      >
+                        <span className="unit__label-text">
+                          <RulesWithIcon textObject={equipment} />
+                        </span>
+                        <i className="checkbox__points">
+                          {getPointsText({ points, perModel })}
+                        </i>
+                      </label>
+                    </div>
+                    {showUnitOptionNotes(
+                      notes,
+                      `armor-${id}-note`,
+                      "unit__option-note",
+                      language
+                    )}
+                  </Fragment>
                 );
               }
             )}
@@ -861,6 +885,7 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                   points,
                   perModel,
                   id,
+                  notes,
                   stackable,
                   maximum,
                   minimum = 0,
@@ -902,6 +927,12 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                             </i>
                           </label>
                         </div>
+                        {showUnitOptionNotes(
+                          notes,
+                          `options-${id}-note`,
+                          "unit__option-note",
+                          language
+                        )}
                         {options?.length > 0 && active && (
                           <>
                             {options
@@ -988,6 +1019,12 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                           })
                         }
                       />
+                      {showUnitOptionNotes(
+                        notes,
+                        `options-${id}-note`,
+                        "unit__option-note unit__option-note--stackable",
+                        language
+                      )}
                     </Fragment>
                   );
                 }
@@ -1230,85 +1267,99 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                   !armyComposition ||
                   armyComposition.includes(list.armyComposition)
               )
-              .map(({ points, id, active = false, options, ...mount }) => (
-                <Fragment key={id}>
-                  <div className="radio">
-                    <input
-                      type="radio"
-                      id={`mounts-${id}`}
-                      name="mounts"
-                      value={id}
-                      onChange={() => handleMountsChange(id)}
-                      checked={active}
-                      className="radio__input"
-                    />
-                    <label htmlFor={`mounts-${id}`} className="radio__label">
-                      <span className="unit__label-text">
-                        <RulesWithIcon textObject={mount} />
-                      </span>
-                      <i className="checkbox__points">
-                        {getPointsText({ points })}
-                      </i>
-                    </label>
-                  </div>
-                  {options?.length > 0 && active && (
-                    <>
-                      {options
-                        .filter(
-                          (option) =>
-                            !option.armyComposition ||
-                            option.armyComposition.includes(
-                              list.armyComposition
-                            )
-                        )
-                        .map((option, optionIndex) => {
-                          const exclusiveCheckedOption = options.find(
-                            (exclusiveOption) =>
-                              exclusiveOption.exclusive &&
-                              exclusiveOption.active
-                          );
+              .map(
+                ({ points, id, active = false, options, notes, ...mount }) => (
+                  <Fragment key={id}>
+                    <div className="radio">
+                      <input
+                        type="radio"
+                        id={`mounts-${id}`}
+                        name="mounts"
+                        value={id}
+                        onChange={() => handleMountsChange(id)}
+                        checked={active}
+                        className="radio__input"
+                      />
+                      <label htmlFor={`mounts-${id}`} className="radio__label">
+                        <span className="unit__label-text">
+                          <RulesWithIcon textObject={mount} />
+                        </span>
+                        <i className="checkbox__points">
+                          {getPointsText({ points })}
+                        </i>
+                      </label>
+                    </div>
+                    {showUnitOptionNotes(
+                      notes,
+                      `mounts-${id}-note`,
+                      "unit__option-note",
+                      language
+                    )}
+                    {options?.length > 0 && active && (
+                      <>
+                        {options
+                          .filter(
+                            (option) =>
+                              !option.armyComposition ||
+                              option.armyComposition.includes(
+                                list.armyComposition
+                              )
+                          )
+                          .map((option, optionIndex) => {
+                            const exclusiveCheckedOption = options.find(
+                              (exclusiveOption) =>
+                                exclusiveOption.exclusive &&
+                                exclusiveOption.active
+                            );
 
-                          return (
-                            <Fragment key={option.name_en}>
-                              <div className="checkbox checkbox--conditional">
-                                <input
-                                  type="checkbox"
-                                  id={`mount-${id}-option-${optionIndex}`}
-                                  value={`${id}-${optionIndex}`}
-                                  onChange={() =>
-                                    handleMountsChange(id, optionIndex)
-                                  }
-                                  checked={Boolean(option.active)}
-                                  className="checkbox__input"
-                                  disabled={
-                                    (exclusiveCheckedOption &&
-                                      option.exclusive &&
-                                      !option.active) ||
-                                    detachmentActive
-                                  }
-                                />
-                                <label
-                                  htmlFor={`mount-${id}-option-${optionIndex}`}
-                                  className="checkbox__label"
-                                >
-                                  <span className="unit__label-text">
-                                    <RulesWithIcon textObject={option} />
-                                  </span>
-                                  <i className="checkbox__points">
-                                    {getPointsText({ points: option.points })}
-                                  </i>
-                                </label>
-                              </div>
-                              {optionIndex === options.length - 1 && (
-                                <hr className="unit__command-option-hr" />
-                              )}
-                            </Fragment>
-                          );
-                        })}
-                    </>
-                  )}
-                </Fragment>
-              ))}
+                            return (
+                              <Fragment key={option.name_en}>
+                                <div className="checkbox checkbox--conditional">
+                                  <input
+                                    type="checkbox"
+                                    id={`mount-${id}-option-${optionIndex}`}
+                                    value={`${id}-${optionIndex}`}
+                                    onChange={() =>
+                                      handleMountsChange(id, optionIndex)
+                                    }
+                                    checked={Boolean(option.active)}
+                                    className="checkbox__input"
+                                    disabled={
+                                      (exclusiveCheckedOption &&
+                                        option.exclusive &&
+                                        !option.active) ||
+                                      detachmentActive
+                                    }
+                                  />
+                                  <label
+                                    htmlFor={`mount-${id}-option-${optionIndex}`}
+                                    className="checkbox__label"
+                                  >
+                                    <span className="unit__label-text">
+                                      <RulesWithIcon textObject={option} />
+                                    </span>
+                                    <i className="checkbox__points">
+                                      {getPointsText({ points: option.points })}
+                                    </i>
+                                  </label>
+                                </div>
+                                {showUnitOptionNotes(
+                                  option.notes,
+                                  `mount-${id}-option-${optionIndex}`,
+                                  "unit__option-note unit__option-note--conditionnal",
+                                  language
+                                )}
+                                {optionIndex === options.length - 1 && (
+                                  <hr className="unit__command-option-hr" />
+                                )}
+                              </Fragment>
+                            );
+                          })}
+                      </>
+                    )}
+                  </Fragment>
+                )
+              )}
           </>
         )}
         {unit.lores && unit.lores.length ? (

--- a/src/utils/unit.js
+++ b/src/utils/unit.js
@@ -262,3 +262,13 @@ export const getUnitName = ({ unit, language }) => {
     ""
   );
 };
+
+export const showUnitOptionNotes = (notes, keyPrefix, className, language) => {
+  return (Array.isArray(notes) ? [...notes] : notes ? [notes] : []).map(
+    (note, index) => (
+      <p className={className} key={`${keyPrefix}-${index}`}>
+        {note[`name_${language}`] || note["name_en"]}
+      </p>
+    )
+  );
+};


### PR DESCRIPTION
### What
This PR adds a new feature to make visible text notes under unit options (equipment, armour and options).

It also comes with a thorough check, french translation and port to the new options notes of the Orc & Goblin Tribes and Dwarfen Mountain Holds.

Since it adds new data in army JSON files, it shouldn't be conflicting with anything.

### Why
This is useful to give additional information, like `0-1 per army` for an option or `Scaly skin` for an armour.

At the moment, some options have additional text directly in their name, but then it also appears in the unit profile, which is not ideal.

Example:
![option-with-info-in-name](https://github.com/user-attachments/assets/4122a09d-f0cc-4fa2-ad31-607e0788e837)

Also, we can make it visually more pleasing 😅

### How
By adding a `"notes"` object or array of object in a unit equipment, armor or option (in army JSON files).
For example, for the Orc Boar Chariot options, it looks like this: 
```javascript
"options": [
  {
    "name_en": "Third Orc crew member",
    "name_de": "Third Orc crew member",
    "name_fr": "Troisième Aurige Orque",
    "points": 5
  },
  {
    "name_en": "Frenzy",
    "name_de": "Frenzy",
    "name_fr": "Frénésie",
    "points": 4,
    "notes": [    // <---- HERE
      {
        "name_en": "If 2 crew members",
        "name_fr": "Si 2 auriges"
      },
      {
        "name_en": "0-1 per 1000 points",
        "name_fr": "0-1 par tranche de 1000 points"
      }
    ]
  },
  {
    "name_en": "Frenzy",
    "name_de": "Frenzy",
    "name_fr": "Frénésie",
    "points": 6,
    "notes": [    // <---- HERE
      {
        "name_en": "If 3 crew members",
        "name_fr": "Si 3 auriges"
      },
      {
        "name_en": "0-1 per 1000 points",
        "name_fr": "0-1 par tranche de 1000 points"
      }
    ]
  },
  {
    "name_en": "Warpaint",
    "name_de": "Warpaint",
    "name_fr": "Peintures de Guerre",
    "points": 10,
    "notes": {    // <---- HERE
      "name_en": "If frenzied",
      "name_fr": "Si frénétique"
    }
  }
],
```
And the result:
![option-with-new-notes](https://github.com/user-attachments/assets/df969e9e-484e-4cbf-bc10-1b1f6eee2d36)