### PR TITLE
Fix Nomadic Waaagh Black Orc Bosses requirements

### DIFF
--- a/src/utils/rules.js
+++ b/src/utils/rules.js
@@ -551,7 +551,7 @@ export const rules = {
           ids: ["black-orc-warboss", "black-orc-bigboss"],
           min: 0,
           max: 1,
-          requiresType: "rare",
+          requiresType: "all",
           requires: ["black-orc-boar-chariot"],
           perUnit: true,
         },


### PR DESCRIPTION
The Core Black Orc Boar Chariot wasn't counted for the purpose of requirements
![black-orc-boss-bug](https://github.com/user-attachments/assets/58a267dc-46af-4807-9186-a23ce108542f)
