### PR TITLE
Prioritize unit notes from army composition over general unit notes

### DIFF
--- a/src/pages/unit/Unit.js
+++ b/src/pages/unit/Unit.js
@@ -496,12 +496,10 @@ export const Unit = ({ isMobile, previewData = {} }) => {
       callback: () => handleRemove(unit.id),
     },
   ];
+
   const notes =
-    unit.notes ||
-    (
-      unit.armyComposition &&
-      unit.armyComposition[list.armyComposition || list.army]
-    )?.notes;
+    unit?.armyComposition?.[list.armyComposition || list.army]?.notes ||
+    unit.notes;
 
   return (
     <>


### PR DESCRIPTION
At the moment, if a unit has notes AND army compositions also including notes, the former will always show.

I think it would be better if notes from the army composition have priority.

The Doomseeker mercenary unit for example has general notes (required when included in non-dwarfen army) and notes for each dwarfen army composition. But only the general notes are shown everywhere.
```json
      "notes": {
        "name_en": "0-3 per army", <== THIS IS ALWAYS SHOWN
        "name_fr": "0-3 par armée"
      },
      "armyComposition": {
        "dwarfen-mountain-holds": {
          "category": "mercenaries",
          "notes": {
            "name_en": "0-3 per army",
            "name_fr": "0-3 par armée"
          }
        },
        "royal-clan": {
          "category": "mercenaries",
          "notes": {
            "name_en": "0-4 per army",
            "name_fr": "0-4 par armée"
          }
        },
        "expeditionary-force": {
          "category": "mercenaries",
          "notes": {
            "name_en": "0-2 per 1000 points",
            "name_fr": "0-2 par tranche de 1000 points"
          }
        }
      },
```