### PR TITLE
Removing unusable banner options from Pink Horrors

### DIFF
--- a/public/games/the-old-world/daemons-of-chaos.json
+++ b/public/games/the-old-world/daemons-of-chaos.json
@@ -1922,7 +1922,7 @@
           "name_pl": "Standard bearer",
           "points": 6,
           "magic": {
-            "types": ["daemonic-icon-common", "daemonic-icon-tzeentch"],
+            "types": ["daemonic-icon-tzeentch"],
             "maxPoints": 50
           }
         },


### PR DESCRIPTION
This PR removes the common daemonic banner options from the Pink Horrors because none of these options can be taken due to point limits on banners. This is in line with the other Daemons which were already corrected in a previous PR, but I missed this one.