### PR TITLE
Added "None" option to the Lores for Flamers

### DIFF
--- a/public/games/the-old-world/daemons-of-chaos.json
+++ b/public/games/the-old-world/daemons-of-chaos.json
@@ -3834,7 +3834,13 @@
       "options": [],
       "mounts": [],
       "items": [],
-      "lores": ["daemonology", "dark-magic", "elementalism", "illusion"],
+      "lores": [
+        "none",
+        "daemonology",
+        "dark-magic",
+        "elementalism",
+        "illusion"
+      ],
       "specialRules": {
         "name_en": "Daemonic, Daemons of Tzeentch, Flaming Attacks, Infernal Favour (1 - Exalted Flamer only), Lore of Daemons (Exalted Flamer only), Move Through Cover, Skirmishers",
         "name_de": "Daemonic, Daemons of Tzeentch, Flaming Attacks, Infernal Favour (1 - Exalted Flamer only), Lore of Daemons (Exalted Flamer only), Move Through Cover, Skirmishers",


### PR DESCRIPTION
Flamers in the DoC list only get a Lore if they take the upgrade for an Exalted Flamer, so none should be the default option here.