### PR TITLE
Add black orc boar chariot to chaos dwarfs black orc boss mount options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ yarn-error.log*
 
 # Sentry Config File
 .sentryclirc
+
+# intellij metadata
+.idea

--- a/public/games/the-old-world/chaos-dwarfs.json
+++ b/public/games/the-old-world/chaos-dwarfs.json
@@ -927,6 +927,35 @@
           ]
         },
         {
+          "name_en": "Black Orc Boar Chariot",
+          "name_de": "Black Orc Boar Chariot",
+          "name_fr": "Char à Sangliers Orque Noir",
+          "points": 130,
+          "options": [
+            {
+              "name_en": "Hand weapon, Additional hand weapon",
+              "name_de": "Hand weapon, Additional hand weapon",
+              "points": 2,
+              "exclusive": true,
+              "active": true,
+              "name_fr": "Arme de base, Arme de base additionnelle"
+            },
+            {
+              "name_en": "Hand weapon, Great weapon",
+              "name_de": "Hand weapon, Great weapon",
+              "points": 4,
+              "exclusive": true,
+              "name_fr": "Arme de base, Arme lourde"
+            },
+            {
+              "name_en": "Standard bearer",
+              "name_de": "Standard bearer",
+              "points": 10,
+              "name_fr": "Porte-étendard"
+            }
+          ]
+        },
+        {
           "name_en": "Wyvern",
           "name_de": "Wyvern",
           "name_es": "Wyvern",
@@ -1079,6 +1108,35 @@
               "name_de": "Warpaint (if frenzied)",
               "name_fr": "Peintures de Guerre (si frénétique)",
               "points": 10
+            }
+          ]
+        },
+        {
+          "name_en": "Black Orc Boar Chariot",
+          "name_de": "Black Orc Boar Chariot",
+          "name_fr": "Char à Sangliers Orque Noir",
+          "points": 130,
+          "options": [
+            {
+              "name_en": "Hand weapon, Additional hand weapon",
+              "name_de": "Hand weapon, Additional hand weapon",
+              "points": 2,
+              "exclusive": true,
+              "active": true,
+              "name_fr": "Arme de base, Arme de base additionnelle"
+            },
+            {
+              "name_en": "Hand weapon, Great weapon",
+              "name_de": "Hand weapon, Great weapon",
+              "points": 4,
+              "exclusive": true,
+              "name_fr": "Arme de base, Arme lourde"
+            },
+            {
+              "name_en": "Standard bearer",
+              "name_de": "Standard bearer",
+              "points": 10,
+              "name_fr": "Porte-étendard"
             }
           ]
         }

--- a/public/games/the-old-world/orc-and-goblin-tribes.json
+++ b/public/games/the-old-world/orc-and-goblin-tribes.json
@@ -169,7 +169,6 @@
           "name_de": "Black Orc Boar Chariot",
           "name_fr": "Char à Sangliers Orque Noir",
           "points": 130,
-          "armyComposition": ["nomadic-waaagh"],
           "options": [
             {
               "name_en": "Hand weapon, Additional hand weapon",
@@ -398,7 +397,6 @@
           "name_de": "Black Orc Boar Chariot",
           "name_fr": "Char à Sangliers Orque Noir",
           "points": 130,
-          "armyComposition": ["nomadic-waaagh"],
           "options": [
             {
               "name_en": "Hand weapon, Additional hand weapon",


### PR DESCRIPTION
This pull request adds black orc boar chariot mount options for chaos dwarf black orc bosses. This is legal since O&G Arcane Journal adds black orc chariot mount option for black orc characters (irrespective if they are grand army or nomadic waaagh).

![black_orc_chariot](https://github.com/user-attachments/assets/4c46558e-490d-441d-af46-76075e54a4d0)
