### PR TITLE
Add Ulther's Dragon Company as a mercenary option for Nuln list

### DIFF
--- a/public/games/the-old-world/dwarfen-mountain-holds.json
+++ b/public/games/the-old-world/dwarfen-mountain-holds.json
@@ -3902,7 +3902,7 @@
       "name_it": "Prince Ulther's Dragon Company",
       "name_pl": "Prince Ulther's Dragon Company",
       "id": "prince-ulther's-dragon-company",
-      "points": 0,
+      "points": 115,
       "command": [
         {
           "name_en": "Prince Ulther",

--- a/public/games/the-old-world/dwarfen-mountain-holds.json
+++ b/public/games/the-old-world/dwarfen-mountain-holds.json
@@ -3911,7 +3911,7 @@
           "name_fr": "Prince Ulther",
           "name_it": "Prince Ulther",
           "name_pl": "Prince Ulther",
-          "points": 115,
+          "points": 0,
           "active": true
         },
         {

--- a/src/assets/armies.json
+++ b/src/assets/armies.json
@@ -67,7 +67,11 @@
           "city-state-of-nuln": [
             {
               "army": "dwarfen-mountain-holds",
-              "units": ["doomseeker-merc", "imperial-dwarf-mercenaries"]
+              "units": [
+                "doomseeker-merc",
+                "imperial-dwarf-mercenaries",
+                "prince-ulther's-dragon-company"
+              ]
             },
             {
               "army": "empire-of-man",


### PR DESCRIPTION
Prince Ulther's Dragon Company can be used in any Empire list that can use mercenaries, so it should be an option for the Nuln City State army of infamy. 

I also updated the base value of the unit so it shows up in the "Select a unit" list correctly. This is a weird unit, so I'm happy to pull this change out.