### PR TITLE
Add Points per model to Unit Size input

### DIFF
--- a/src/pages/unit/Unit.css
+++ b/src/pages/unit/Unit.css
@@ -54,6 +54,15 @@
 
 .unit__strength {
   margin-top: 1rem;
+  margin-right: 0;
+  display: flex;
+  justify-content: space-between;
+}
+
+.unit__strength-points {
+  font-style: italic;
+  font-weight: normal;
+  text-align: right;
 }
 
 .unit__link .list__inner label {

--- a/src/pages/unit/Unit.js
+++ b/src/pages/unit/Unit.js
@@ -7,7 +7,7 @@ import classNames from "classnames";
 import { Helmet } from "react-helmet-async";
 
 import { fetcher } from "../../utils/fetcher";
-import { getUnitPoints, getUnitMagicPoints } from "../../utils/points";
+import { getPointsPerModel, getUnitPoints, getUnitMagicPoints } from "../../utils/points";
 import { ListItem } from "../../components/list";
 import { NumberInput } from "../../components/number-input";
 import { Icon } from "../../components/icon";
@@ -570,7 +570,8 @@ export const Unit = ({ isMobile, previewData = {} }) => {
         {unit.minimum ? (
           <>
             <label htmlFor="strength" className="unit__strength">
-              <FormattedMessage id="unit.unitSize" />
+              <span><FormattedMessage id="unit.unitSize" /></span>
+              <i className="unit__strength-points">{getPointsText({ points: getPointsPerModel(unit), perModel: true }) }</i>
             </label>
             <NumberInput
               id="strength"

--- a/src/utils/points.js
+++ b/src/utils/points.js
@@ -8,6 +8,14 @@ export const getPointsPerModel = (unit) => {
     unit.options.forEach((option) => {
       if (option.active && option.perModel) {
         modelPoints += option.points;
+      } else if (option.active && option.options && option.options.length > 0) {
+        option.options.forEach((subOption) => {
+          if (subOption.active) {
+            if (subOption.perModel) {
+              modelPoints += subOption.points;
+            }
+          }
+        });
       }
     });
   }

--- a/src/utils/points.js
+++ b/src/utils/points.js
@@ -1,5 +1,33 @@
 import { unitHasItem } from "./unit";
 
+// returns the points cost for adding a single model in a unit, given the
+// selected options and equipment
+export const getPointsPerModel = (unit) => {
+  let modelPoints = unit.points;
+  if (unit.options) {
+    unit.options.forEach((option) => {
+      if (option.active && option.perModel) {
+        modelPoints += option.points;
+      }
+    });
+  }
+  if (unit.equipment) {
+    unit.equipment.forEach((option) => {
+      if (option.active && option.perModel) {
+        modelPoints += option.points;
+      }
+    });
+  }
+  if (unit.armor) {
+    unit.armor.forEach((option) => {
+      if (option.active && option.perModel) {
+        modelPoints += option.points;
+      }
+    });
+  }
+  return modelPoints;
+}
+
 export const getUnitPoints = (unit, settings) => {
   const detachmentActive =
     unit?.options?.length > 0 &&


### PR DESCRIPTION
It would be helpful to indicate how many points each model in a unit is costing, given the selected equipment and options. I've added a right-aligned bit of text to the label for the Unit size input that shows this. Please let me know if I've missed anything.

![PointsPerModel2](https://github.com/user-attachments/assets/3c9c2263-7b27-4993-86fb-6bbac78cf2b0)
