### PR TITLE
Engine of the Gods on the Stegadon Mount is exclusive with the other options

### DIFF
--- a/public/games/the-old-world/lizardmen.json
+++ b/public/games/the-old-world/lizardmen.json
@@ -450,6 +450,7 @@
             },
             {
               "name_en": "Engine of the Gods",
+              "exclusive": true,
               "points": 25,
               "name_fr": "Machine des Dieux"
             }


### PR DESCRIPTION
Quick fix for a bug that was brought up on the discord. On the mount version of the Ancient Stegadon, the 3 weapon options are exclusive to each other.
![image](https://github.com/user-attachments/assets/b08abd9b-a852-4671-91cc-1501019ced12)
