### PR TITLE
Update high-elf-realms for arcane journal new units

### DIFF
--- a/public/games/the-old-world/high-elf-realms.json
+++ b/public/games/the-old-world/high-elf-realms.json
@@ -3884,6 +3884,12 @@
       "id": "war-lions",
       "points": 18,
       "armyComposition": {
+        "high-elf-realms": {
+          "category": "rare",
+          "notes": {
+            "name_en": "0-1 Rare choice if you include one or more White Lions of Chrace unit"
+          }
+        },
         "the-chracian-warhost": {
           "category": "special",
           "notes": {
@@ -4355,6 +4361,12 @@
       "id": "merwyrms",
       "points": 225,
       "armyComposition": {
+        "high-elf-realms": {
+          "category": "rare",
+          "notes": {
+            "name_en": "0-1 Rare choice if you include one or more Lothern Sea Guard unit"
+          }
+        },
         "sea-guard-garrison": {
           "category": "rare"
         }


### PR DESCRIPTION
*PR not tested, especially to make the note work. But I have tried to mimic that of Sisters of Averlorn

Missing War Lions options from High Elf Grand Army list, it is conditional to have at least a unit of White Lions. Please see photo.
The Merwyrm option at the moment it is enabled to all Grand Army, but it should be only if there is a unit of Lothern Sea Guard. Please photo too.

![image0 (1)](https://github.com/user-attachments/assets/35c60e71-3cb4-4604-9821-06c0d9c854fa)
![image0 (2)](https://github.com/user-attachments/assets/d71b2b85-809c-4b01-b815-39bdd94ec197)
