### PR TITLE
Because Prince Apophas is a loner, he cannot be the general

### DIFF
--- a/public/games/the-old-world/tomb-kings-of-khemri.json
+++ b/public/games/the-old-world/tomb-kings-of-khemri.json
@@ -1079,16 +1079,7 @@
       "name_fr": "Prince Apophas",
       "id": "prince-apophas-the-cursed-scarab-lord",
       "points": 130,
-      "command": [
-        {
-          "name_en": "General",
-          "name_it": "Generale",
-          "name_de": "General",
-          "name_fr": "Général",
-          "name_es": "General",
-          "points": 0
-        }
-      ],
+      "command": [],
       "equipment": [
         {
           "name_en": "Hand weapon, Swarming Mass",

--- a/src/utils/rules.js
+++ b/src/utils/rules.js
@@ -310,7 +310,6 @@ export const rules = {
             "tomb-king",
             "tomb-prince",
             "settra-the-imperishable-the-great-king-of-nehekhara",
-            "prince-apophas-the-cursed-scarab-lord",
           ],
         },
       ],


### PR DESCRIPTION
Characters with the Loner rule cannot be generals, so Prince Apophas should not have that option. He should still fulfill the requirement to have a Tomb King or Prince in a Grand Army or Royal Host list, though.

Also, there's a weird instance with Night Goblin Bosses where if they hop on a Giant Cave Squig, they gain Loner and thus lose the ability to be the General. That doesn't seem easy to check for, though.