### PR TITLE
Only Vampires, Necromancers, or Ghoul Kings can be generals of a VC army

### DIFF
--- a/public/games/the-old-world/vampire-counts.json
+++ b/public/games/the-old-world/vampire-counts.json
@@ -674,15 +674,7 @@
       "name_fr": "Cairn Wraith",
       "id": "cairn-wraith",
       "points": 50,
-      "command": [
-        {
-          "name_en": "General",
-          "name_de": "General",
-          "name_fr": "Général",
-          "name_es": "General",
-          "points": 0
-        }
-      ],
+      "command": [],
       "equipment": [
         {
           "name_en": "Spectral scythe {cairn wraith}",
@@ -719,15 +711,7 @@
       "name_fr": "Wight King",
       "id": "wight-king",
       "points": 85,
-      "command": [
-        {
-          "name_en": "General",
-          "name_de": "General",
-          "name_fr": "Général",
-          "name_es": "General",
-          "points": 0
-        }
-      ],
+      "command": [],
       "equipment": [
         {
           "name_en": "Hand weapon",
@@ -842,13 +826,6 @@
       "id": "wight-lord",
       "points": 40,
       "command": [
-        {
-          "name_en": "General",
-          "name_de": "General",
-          "name_fr": "Général",
-          "name_es": "General",
-          "points": 0
-        },
         {
           "name_en": "Battle Standard Bearer",
           "name_de": "Battle Standard Bearer",
@@ -973,15 +950,7 @@
       "name_fr": "Tomb Banshee",
       "id": "tomb-banshee",
       "points": 90,
-      "command": [
-        {
-          "name_en": "General",
-          "name_de": "General",
-          "name_fr": "Général",
-          "name_es": "General",
-          "points": 0
-        }
-      ],
+      "command": [],
       "equipment": [
         {
           "name_en": "Hand weapon",


### PR DESCRIPTION
The general of a Vampire Count army has to be a wizard, so only Vampires, Necromancers, or Ghoul Kings can be the general.

There could be an argument that a Wight with the Wizarding Hat could be the general, but based on the wording in the VC pdf _("... the General of a Vampire Counts army must also be a Wizard (be they a Vampire, a Necromancer or a Strigoi Ghoul King).")_ and an FAQ about whether characters with the Wizarding Hat can wear armour _("The wearer of the Wizarding Hat is not actually a Wizard – their magical powers are granted by a haunted hat which is not affected by any armour the model may wear")_, I'm inclined to say they can't be the general, as awesome as a mad burrow king leading an army without a fancy pants vampire or nerdy necromancer in sight would be.

Wraiths and Banshees can't even take magic items, so that potential edge cases doesn't apply to them.