### PR TITLE
fix english name for empire war wagon

### DIFF
--- a/public/games/the-old-world/empire-of-man.json
+++ b/public/games/the-old-world/empire-of-man.json
@@ -2230,7 +2230,7 @@
           "active": true
         },
         {
-          "name_en": "War Wagon {empire}",
+          "name_en": "Empire War Wagon",
           "name_de": "War Wagon",
           "name_fr": "Chariot de Guerre",
           "name_es": "War Wagon",
@@ -5558,7 +5558,7 @@
       }
     },
     {
-      "name_en": "War Wagon {empire}",
+      "name_en": "Empire War Wagon",
       "name_de": "War Wagon",
       "name_fr": "Chariot de Guerre",
       "name_es": "War Wagon",


### PR DESCRIPTION
**Issue:**
The profile values for the Empire's War Wagon were not being displayed in the unit selection screen and the game overview.
<img width="250" alt="image" src="https://github.com/user-attachments/assets/d4d6e854-18bf-4489-93b2-bcd28290e88a" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/4cf8d010-d568-4bf0-b342-8323da909f65" />


**Fix:**
The issue was caused by an incorrect name being used for the War Wagon in the code. After applying the fix, the profile values are now correctly displayed in both the unit selection and game overview.
<img width="250" alt="image" src="https://github.com/user-attachments/assets/4c137ca3-82c8-4d2f-967c-33b2f9b0c80c" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/5b5b6224-c48d-482c-a1cb-042312b47304" />
