### PR TITLE
Use armyComposition for various options limited to specific army lists

### DIFF
--- a/public/games/the-old-world/dwarfen-mountain-holds.json
+++ b/public/games/the-old-world/dwarfen-mountain-holds.json
@@ -512,16 +512,15 @@
         },
         {
           "name_en": "Battle Standard Bearer",
+          "name_it": "Stendardo da Battaglia",
+          "name_de": "Armeestandartenträger",
+          "name_fr": "Porteur de la Grande Bannière",
           "points": 25,
           "magic": {
             "types": ["banner-runes"],
             "maxPoints": 0
           },
-          "name_fr": "Porteur de la Grande Bannière",
-          "notes": {
-            "name_en": "Royal Clan only",
-            "name_fr": "Clans Royaux uniquement"
-          }
+          "armyComposition": "royal-clan"
         }
       ],
       "equipment": [
@@ -808,19 +807,16 @@
           "points": 0
         },
         {
-          "name_de": "Armeestandartenträger",
           "name_en": "Battle Standard Bearer",
+          "name_it": "Stendardo da Battaglia",
+          "name_de": "Armeestandartenträger",
           "name_fr": "Porteur de la Grande Bannière",
           "points": 25,
           "magic": {
             "types": ["banner-runes"],
             "maxPoints": 0
           },
-          "notes": {
-            "name_de": "Nur Expeditionsstreitmacht",
-            "name_en": "Expeditionary Force only",
-            "name_fr": "Corps Expéditionnaires uniquement"
-          }
+          "armyComposition": "expeditionary-force"
         }
       ],
       "equipment": [
@@ -879,11 +875,7 @@
           "name_de": "Expeditionsschützen",
           "name_fr": "Tireur d'Élite Expéditionnaire",
           "points": 10,
-          "notes": {
-            "name_de": "Nur Expeditionsstreitmacht",
-            "name_en": "Expeditionary Force only",
-            "name_fr": "Corps Expéditionnaires uniquement"
-          }
+          "armyComposition": "expeditionary-force"
         }
       ],
       "mounts": [],
@@ -1791,10 +1783,11 @@
           "name_fr": "Tireurs d'Élite Expéditionnaires",
           "points": 1,
           "perModel": true,
+          "armyComposition": "expeditionary-force",
           "notes": {
-            "name_de": "0-1 Einheit Musketenschützen pro 1.000 Punkte, nur Expeditionsstreitmacht",
-            "name_en": "0-1 unit per 1000 points, Expeditionary Force only",
-            "name_fr": "0-1 unité par tranche de 1000 points, Corps Expéditionnaires uniquement"
+            "name_de": "0-1 Einheit Musketenschützen pro 1.000 Punkte",
+            "name_en": "0-1 unit per 1000 points",
+            "name_fr": "0-1 unité par tranche de 1000 points"
           }
         }
       ],

--- a/public/games/the-old-world/tomb-kings-of-khemri.json
+++ b/public/games/the-old-world/tomb-kings-of-khemri.json
@@ -733,12 +733,7 @@
             "types": ["banner"],
             "maxPoints": 0
           },
-          "notes": {
-            "name_en": "Mortuary Cult only",
-            "name_it": "Solo Culto Mortuario",
-            "name_de": "Nur Totenkult",
-            "name_fr": "Culte Mortuaire uniquement"
-          }
+          "armyComposition": "mortuary-cults"
         }
       ],
       "equipment": [

--- a/public/games/the-old-world/warriors-of-chaos.json
+++ b/public/games/the-old-world/warriors-of-chaos.json
@@ -1728,10 +1728,11 @@
           "name_es": "Ambushers",
           "name_fr": "Embusqueurs",
           "points": 10,
+          "armyComposition": "wolves-of-the-sea",
           "notes": {
-            "name_en": "Wolves of the Sea army only, infantry or cavalry only",
-            "name_de": "Wolves of the Sea army only, infantry or cavalry only",
-            "name_fr": "Armée de Loups des Mers uniquement, infanterie ou cavalerie uniquement"
+            "name_en": "Infantry or cavalry only",
+            "name_de": "Infantry or cavalry only",
+            "name_fr": "Infanterie ou cavalerie uniquement"
           }
         }
       ],
@@ -2815,11 +2816,7 @@
           "name_fr": "Embusqueurs",
           "points": 1,
           "perModel": true,
-          "notes": {
-            "name_en": "Wolves of the Sea army only",
-            "name_de": "Wolves of the Sea army only",
-            "name_fr": "Armée de Loups des Mers uniquement"
-          }
+          "armyComposition": "wolves-of-the-sea"
         }
       ],
       "mounts": [],
@@ -3016,11 +3013,7 @@
           "name_fr": "Embusqueurs",
           "points": 1,
           "perModel": true,
-          "notes": {
-            "name_en": "Wolves of the Sea army only",
-            "name_de": "Wolves of the Sea army only",
-            "name_fr": "Armée de Loups des Mers uniquement"
-          }
+          "armyComposition": "wolves-of-the-sea"
         }
       ],
       "mounts": [],


### PR DESCRIPTION
I found a couple instances where a unit option ought to be limited by the army composition, but only had a note warning instead of using the armyComposition property.

I also took the opportunity to standardize the alternative localizations for the Dwarven Battle Standard Bearer.