### PR TITLE
Add Monstrous Creatures to count towards minimum 3 units

### DIFF
--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -4,7 +4,7 @@ import { getUnitName, getUnitLeadership, getUnitRuleData } from "./unit";
 
 const filterByTroopType = (unit) => {
   const ruleData = getUnitRuleData(unit.name_en);
-  return ["MCa", "LCa", "HCa", "MI", "RI", "HI", "HCh", "LCh", "Be"].includes(
+  return ["MCa", "LCa", "HCa", "MI", "RI", "HI", "HCh", "LCh", "MCr", "Be"].includes(
     ruleData?.troopType
   );
 };


### PR DESCRIPTION
Monstrous Creatures should count towards the minimum 3 units requirements; only Characters, Swarms, War Beasts, and War Machines don't count towards this requirement.