### PR TITLE
Check for armyComposition option when validating General candidates

### DIFF
--- a/public/games/the-old-world/magic-items.json
+++ b/public/games/the-old-world/magic-items.json
@@ -1064,51 +1064,13 @@
       "name_pl": "Blade of Silvered Steel",
       "points": 30,
       "type": "weapon",
-      "armyComposition": "knightly-order-panther"
-    },
-    {
-      "name_de": "Blade of Silvered Steel",
-      "name_en": "Blade of Silvered Steel",
-      "name_cn": "镀银钢剑",
-      "name_fr": "Lame d'Acier Argenté",
-      "name_it": "Blade of Silvered Steel",
-      "name_pl": "Blade of Silvered Steel",
-      "points": 30,
-      "type": "weapon",
-      "armyComposition": "knightly-order-morr"
-    },
-    {
-      "name_de": "Blade of Silvered Steel",
-      "name_en": "Blade of Silvered Steel",
-      "name_cn": "镀银钢剑",
-      "name_fr": "Lame d'Acier Argenté",
-      "name_it": "Blade of Silvered Steel",
-      "name_pl": "Blade of Silvered Steel",
-      "points": 30,
-      "type": "weapon",
-      "armyComposition": "knightly-order-blazing-sun"
-    },
-    {
-      "name_de": "Blade of Silvered Steel",
-      "name_en": "Blade of Silvered Steel",
-      "name_cn": "镀银钢剑",
-      "name_fr": "Lame d'Acier Argenté",
-      "name_it": "Blade of Silvered Steel",
-      "name_pl": "Blade of Silvered Steel",
-      "points": 30,
-      "type": "weapon",
-      "armyComposition": "knightly-order-fiery-heart"
-    },
-    {
-      "name_de": "Blade of Silvered Steel",
-      "name_en": "Blade of Silvered Steel",
-      "name_cn": "镀银钢剑",
-      "name_fr": "Lame d'Acier Argenté",
-      "name_it": "Blade of Silvered Steel",
-      "name_pl": "Blade of Silvered Steel",
-      "points": 30,
-      "type": "weapon",
-      "armyComposition": "knightly-order-white-wolf"
+      "armyComposition": [
+        "knightly-order-panther",
+        "knightly-order-morr",
+        "knightly-order-blazing-sun",
+        "knightly-order-fiery-heart",
+        "knightly-order-white-wolf"
+      ]
     },
     {
       "name_de": "Dragon Bow",
@@ -1150,51 +1112,13 @@
       "name_pl": "Shield of the Gorgon",
       "points": 40,
       "type": "armor",
-      "armyComposition": "knightly-order-panther"
-    },
-    {
-      "name_de": "Shield of the Gorgon",
-      "name_en": "Shield of the Gorgon",
-      "name_cn": "戈尔贡之盾",
-      "name_fr": "Bouclier de la Gorgone",
-      "name_it": "Shield of the Gorgon",
-      "name_pl": "Shield of the Gorgon",
-      "points": 40,
-      "type": "armor",
-      "armyComposition": "knightly-order-morr"
-    },
-    {
-      "name_de": "Shield of the Gorgon",
-      "name_en": "Shield of the Gorgon",
-      "name_cn": "戈尔贡之盾",
-      "name_fr": "Bouclier de la Gorgone",
-      "name_it": "Shield of the Gorgon",
-      "name_pl": "Shield of the Gorgon",
-      "points": 40,
-      "type": "armor",
-      "armyComposition": "knightly-order-blazing-sun"
-    },
-    {
-      "name_de": "Shield of the Gorgon",
-      "name_en": "Shield of the Gorgon",
-      "name_cn": "戈尔贡之盾",
-      "name_fr": "Bouclier de la Gorgone",
-      "name_it": "Shield of the Gorgon",
-      "name_pl": "Shield of the Gorgon",
-      "points": 40,
-      "type": "armor",
-      "armyComposition": "knightly-order-fiery-heart"
-    },
-    {
-      "name_de": "Shield of the Gorgon",
-      "name_en": "Shield of the Gorgon",
-      "name_cn": "戈尔贡之盾",
-      "name_fr": "Bouclier de la Gorgone",
-      "name_it": "Shield of the Gorgon",
-      "name_pl": "Shield of the Gorgon",
-      "points": 40,
-      "type": "armor",
-      "armyComposition": "knightly-order-white-wolf"
+      "armyComposition": [
+        "knightly-order-panther",
+        "knightly-order-morr",
+        "knightly-order-blazing-sun",
+        "knightly-order-fiery-heart",
+        "knightly-order-white-wolf"
+      ]
     },
     {
       "name_de": "Armour of Tarnus",
@@ -3995,7 +3919,10 @@
       "points": 10,
       "type": "elven-honour",
       "name": "chracian-hunter",
-      "armyComposition": ["high-elf-realms", "the-chracian-warhost"]
+      "armyComposition": [
+        "high-elf-realms",
+        "the-chracian-warhost"
+      ]
     },
     {
       "name_de": "Wächter von Saphery",
@@ -4030,7 +3957,10 @@
       "points": 0,
       "type": "elven-honour",
       "name": "sea-guard",
-      "armyComposition": ["high-elf-realms", "sea-guard-garrison"]
+      "armyComposition": [
+        "high-elf-realms",
+        "sea-guard-garrison"
+      ]
     }
   ],
   "chaos-dwarfs": [

--- a/public/games/the-old-world/tomb-kings-of-khemri.json
+++ b/public/games/the-old-world/tomb-kings-of-khemri.json
@@ -15,7 +15,8 @@
           "name_de": "General",
           "name_fr": "Général",
           "name_es": "General",
-          "points": 0
+          "points": 0,
+          "armyComposition": ["tomb-kings-of-khemri", "nehekharan-royal-hosts"]
         }
       ],
       "equipment": [
@@ -240,7 +241,8 @@
           "name_de": "General",
           "name_fr": "Général",
           "name_es": "General",
-          "points": 0
+          "points": 0,
+          "armyComposition": ["tomb-kings-of-khemri", "nehekharan-royal-hosts"]
         }
       ],
       "equipment": [
@@ -431,7 +433,8 @@
           "name_de": "General",
           "name_fr": "Général",
           "name_es": "General",
-          "points": 0
+          "points": 0,
+          "armyComposition": ["tomb-kings-of-khemri"]
         },
         {
           "name_en": "Battle Standard Bearer",
@@ -596,7 +599,8 @@
           "name_de": "General",
           "name_fr": "Général",
           "name_es": "General",
-          "points": 0
+          "points": 0,
+          "armyComposition": ["tomb-kings-of-khemri", "mortuary-cults"]
         }
       ],
       "equipment": [
@@ -721,7 +725,8 @@
           "name_de": "General",
           "name_fr": "Général",
           "name_es": "General",
-          "points": 0
+          "points": 0,
+          "armyComposition": ["tomb-kings-of-khemri", "mortuary-cults"]
         },
         {
           "name_en": "Battle Standard Bearer",
@@ -839,16 +844,7 @@
       "name_fr": "Archi-Nécrotecte",
       "id": "arch-necrotect",
       "points": 90,
-      "command": [
-        {
-          "name_en": "General",
-          "name_it": "Generale",
-          "name_de": "General",
-          "name_fr": "Général",
-          "name_es": "General",
-          "points": 0
-        }
-      ],
+      "command": [],
       "equipment": [
         {
           "name_en": "Hand weapon",
@@ -922,7 +918,8 @@
           "name_de": "General",
           "name_fr": "Général",
           "name_es": "General",
-          "points": 0
+          "points": 0,
+          "armyComposition": ["tomb-kings-of-khemri"]
         }
       ],
       "equipment": [
@@ -1129,7 +1126,8 @@
           "name_de": "General",
           "name_fr": "Général",
           "name_es": "General",
-          "points": 0
+          "points": 0,
+          "armyComposition": ["tomb-kings-of-khemri"]
         }
       ],
       "equipment": [

--- a/src/pages/magic/Magic.js
+++ b/src/pages/magic/Magic.js
@@ -16,7 +16,7 @@ import { editUnit } from "../../state/lists";
 import { openRulesIndex } from "../../state/rules-index";
 import { useLanguage } from "../../utils/useLanguage";
 import { updateLocalList } from "../../utils/list";
-import { normalizeRuleName } from "../../utils/string";
+import { normalizeRuleName, equalsOrIncludes } from "../../utils/string";
 import gameSystems from "../../assets/armies.json";
 import {
   isMultipleAllowedItem,
@@ -493,13 +493,7 @@ export const Magic = ({ isMobile }) => {
           ).filter(
             (item) =>
               (!maxMagicPoints || item.points <= maxMagicPoints) &&
-              (item?.armyComposition === list?.armyComposition ||
-                !item.armyComposition ||
-                (item?.armyComposition &&
-                  item.armyComposition.length > 0 &&
-                  item.armyComposition.includes(
-                    list?.armyComposition || list?.army
-                  )))
+              (!item.armyComposition || equalsOrIncludes(item.armyComposition, list?.armyComposition))
           );
 
           if (itemGroupItems.length > 0) {

--- a/src/pages/magic/Magic.js
+++ b/src/pages/magic/Magic.js
@@ -493,7 +493,10 @@ export const Magic = ({ isMobile }) => {
           ).filter(
             (item) =>
               (!maxMagicPoints || item.points <= maxMagicPoints) &&
-              (!item.armyComposition || equalsOrIncludes(item.armyComposition, list?.armyComposition))
+              (
+                !item.armyComposition || 
+                equalsOrIncludes(item.armyComposition, list?.armyComposition || list?.army)
+              )
           );
 
           if (itemGroupItems.length > 0) {

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -12,3 +12,13 @@ export const normalizeRuleName = (string = "") => {
     .replace(/”/g, '"')
     .trim();
 };
+
+/**
+ * Given an object that is either a string or an array of strings
+ * and a target string, checks whether the target is equal to the
+ * string or is in the array. Useful for armyComposition checks.
+ */
+export const equalsOrIncludes = (strOrArray, x) => (
+  x === strOrArray ||
+  (Array.isArray(strOrArray) && strOrArray.includes(x))
+);

--- a/src/utils/string.test.js
+++ b/src/utils/string.test.js
@@ -1,0 +1,41 @@
+import { normalizeRuleName, equalsOrIncludes } from "./string";
+
+describe("normalizeRuleName", () => {
+  test("Lower cases rules names", () => {
+    expect(normalizeRuleName("Settra the Imperishable")).toBe("settra the imperishable");
+  });
+
+  test("Removes everything between parenthesis", () => {
+    expect(normalizeRuleName("Hatred (Anything + Everything)")).toBe("hatred");
+  });
+
+  test("Converts curly quotes to straight quotes", () => {
+    expect(normalizeRuleName("“Stand Back Chief”")).toBe("\"stand back chief\"");
+  });
+
+  test("Removes asterisks (*)", () => {
+    expect(normalizeRuleName("Sword of Striking*")).toBe("sword of striking");
+  });
+
+  test("Removes curly braces", () => {
+    expect(normalizeRuleName("Skeletal Steed {Tomb Kings}")).toBe("skeletal steed tomb kings");
+  });
+});
+
+describe("equalsOrIncludes", () => {
+    test("Returns true if object and target are equal", () => {
+      expect(equalsOrIncludes("tomb-kings", "tomb-kings")).toBe(true);
+    });
+
+    test("Returns false if object is string and target is just a subset of that string", () => {
+      expect(equalsOrIncludes("tomb-kings", "kings")).toBe(false);
+    });
+
+    test("Returns true if object is array and target included in it", () => {
+      expect(equalsOrIncludes(["tomb-kings", "mortuary-cults"], "mortuary-cults")).toBe(true);
+    });
+    
+    test("Returns false if object is array and target isn't in it", () => {
+        expect(equalsOrIncludes(["tomb-kings", "mortuary-cults"], "kings")).toBe(false);
+      });
+  });

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,5 +1,6 @@
 import { rules } from "./rules";
 import { uniq } from "./collection";
+import { equalsOrIncludes } from "./string";
 import { getUnitName, getUnitLeadership, getUnitRuleData } from "./unit";
 
 const filterByTroopType = (unit) => {
@@ -26,7 +27,11 @@ export const validateList = ({ list, language, intl }) => {
     list.characters.map((unit) => {
       if (
         unit.command &&
-        unit.command.find((command) => command.name_en === "General") &&
+        unit.command.find(
+          (command) => 
+            command.name_en === "General" &&
+            (!command.armyComposition || equalsOrIncludes(command.armyComposition, list.armyComposition))
+        ) &&
         !unit.command.find(
           (command) =>
             command.name_en.includes("Battle Standard Bearer") && command.active


### PR DESCRIPTION
Some army compositions require the general to be a particular type of character, so other characters ought to have the option to be toggled General turned off, and be excluded from the list of potential candidates for general during validation. I've added `armyCompostion` parameters to the Tomb Kings characters as the army I'm most familiar with, but I'm sure other armies of infamy have similar requirements.

Also, I ran into a bit of a block with `options.armyComposition` being allowed to be either a string or an array of strings. There's a lot of overlap between functions for strings and arrays, which could result in some bugs in the future; for example, both have `includes` and `length` properties/functions. I would suggest that `options.armyComposition` always be an array of strings.