### PR TITLE
Correctly fetch leadership stats during validation for units with Renegade changes

### DIFF
--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -24,12 +24,12 @@ export const validateList = ({ list, language, intl }) => {
   const generals = !list?.characters?.length
     ? []
     : list.characters.filter(
-        (unit) =>
-          unit.command &&
-          unit.command.find(
-            (command) => command.active && command.name_en === "General"
-          )
-      );
+      (unit) =>
+        unit.command &&
+        unit.command.find(
+          (command) => command.active && command.name_en === "General"
+        )
+    );
   // The general must be one of the characters with the highest leadership
   let highestLeadership = 0;
   if (list?.characters?.length) {
@@ -47,7 +47,11 @@ export const validateList = ({ list, language, intl }) => {
             command.name_en.includes("Battle Standard Bearer") && command.active
         )
       ) {
-        const leadership = getUnitLeadership(unit.name_en);
+        const unitName =
+          unit.name_en.includes("renegade") && list.armyComposition?.includes("renegade")
+            ? unit.name_en
+            : unit.name_en.replace(" {renegade}", "");
+        const leadership = getUnitLeadership(unitName);
         if (leadership > highestLeadership) {
           highestLeadership = leadership;
         }
@@ -58,14 +62,14 @@ export const validateList = ({ list, language, intl }) => {
   const BSBs = !list.characters?.length
     ? []
     : list.characters.filter(
-        (unit) =>
-          unit.command &&
-          unit.command.find(
-            (command) =>
-              command.active &&
-              command.name_en.includes("Battle Standard Bearer")
-          )
-      );
+      (unit) =>
+        unit.command &&
+        unit.command.find(
+          (command) =>
+            command.active &&
+            command.name_en.includes("Battle Standard Bearer")
+        )
+    );
 
   const coreUnits = list?.core?.length
     ? list.core.filter(filterByTroopType).length


### PR DESCRIPTION
Units with changes in the Renegades lists apparently need their name adjusted during stat look up, which was messing up validation checks for the General's leadership. I've adjusted it to match the pattern elsewhere.