### PR TITLE
Avoid inserting page breaks inside units

### DIFF
--- a/src/pages/print/Print.css
+++ b/src/pages/print/Print.css
@@ -45,6 +45,7 @@
 
 .print li {
   margin-bottom: 1rem;
+  break-inside: avoid
 }
 
 .print__points {


### PR DESCRIPTION
When there is a page break inside of the block for a unit, makes it hard to read when printed. Add a CSS rule to avoid breaks inside single units.

I've tested the CSS by putting it in directly with the Inspector in Firefox, but I haven't done a proper build&deploy test.