### PR TITLE
Add links to spell rules in game view's spell selection

### DIFF
--- a/src/components/generated-spells/GeneratedSpells.css
+++ b/src/components/generated-spells/GeneratedSpells.css
@@ -54,3 +54,12 @@
 .generated-spells__spell-index::after {
   content: ".";
 }
+
+.generated-spells__rules-wrapper {
+  display: inline-flex;
+  align-items: center;
+}
+
+.generated-spells__rule-icon {
+  margin-left: 0.5rem;
+}

--- a/src/components/generated-spells/GeneratedSpells.js
+++ b/src/components/generated-spells/GeneratedSpells.js
@@ -3,7 +3,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import PropTypes from "prop-types";
 
 import { Button } from "../button";
-import { LocalizedRuleLink } from "../rules-index";
+import { LocalizedRuleLink, RuleWithIcon } from "../rules-index";
 
 import "./GeneratedSpells.css";
 
@@ -128,16 +128,23 @@ export const GeneratedSpells = ({
                             );
                           }}
                         />
-                        <span className="generated-spells__spell-index">
-                          {spell.index === "signature"
-                            ? intl.formatMessage({
-                                id: "misc.signatureAbbr",
-                              })
-                            : spell.index}
+                        <span className="generated-spells__rules-wrapper">
+                          <span className="generated-spells__spell-index">
+                            {spell.index === "signature"
+                              ? intl.formatMessage({
+                                  id: "misc.signatureAbbr",
+                                })
+                              : spell.index}
+                          </span>
+                          <FormattedMessage
+                            id={spellIdToFormattedMessageId(spellId)}
+                          />
+                          <RuleWithIcon
+                            name={spellId}
+                            isDark
+                            className="generated-spells__rule-icon"
+                          />
                         </span>
-                        <FormattedMessage
-                          id={spellIdToFormattedMessageId(spellId)}
-                        />
                       </label>
                     </li>
                   );

--- a/src/utils/string.test.js
+++ b/src/utils/string.test.js
@@ -23,19 +23,19 @@ describe("normalizeRuleName", () => {
 });
 
 describe("equalsOrIncludes", () => {
-    test("Returns true if object and target are equal", () => {
-      expect(equalsOrIncludes("tomb-kings", "tomb-kings")).toBe(true);
-    });
-
-    test("Returns false if object is string and target is just a subset of that string", () => {
-      expect(equalsOrIncludes("tomb-kings", "kings")).toBe(false);
-    });
-
-    test("Returns true if object is array and target included in it", () => {
-      expect(equalsOrIncludes(["tomb-kings", "mortuary-cults"], "mortuary-cults")).toBe(true);
-    });
-    
-    test("Returns false if object is array and target isn't in it", () => {
-        expect(equalsOrIncludes(["tomb-kings", "mortuary-cults"], "kings")).toBe(false);
-      });
+  test("Returns true if object and target are equal", () => {
+    expect(equalsOrIncludes("tomb-kings", "tomb-kings")).toBe(true);
   });
+
+  test("Returns false if object is string and target is just a subset of that string", () => {
+    expect(equalsOrIncludes("tomb-kings", "kings")).toBe(false);
+  });
+
+  test("Returns true if object is array and target included in it", () => {
+    expect(equalsOrIncludes(["tomb-kings", "mortuary-cults"], "mortuary-cults")).toBe(true);
+  });
+
+  test("Returns false if object is array and target isn't in it", () => {
+    expect(equalsOrIncludes(["tomb-kings", "mortuary-cults"], "kings")).toBe(false);
+  });
+});


### PR DESCRIPTION
In Game View, there isn't a way to view a spell's rules from the Generated Spells selection step, at least until after you've selected the spells and gone back to the compact view. I've added RulesWithIcon links to each spell so you can quickly bring up the rules during selection.

Also a small formatting fix for the tests I added in a previous PR.