### PR TITLE
Being BSB doesn't remove a character from General candidacy vis-a-vis leadership

### DIFF
--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -41,10 +41,6 @@ export const validateList = ({ list, language, intl }) => {
             command.name_en === "General" &&
             (!command.armyComposition ||
               equalsOrIncludes(command.armyComposition, list.armyComposition))
-        ) &&
-        !unit.command.find(
-          (command) =>
-            command.name_en.includes("Battle Standard Bearer") && command.active
         )
       ) {
         const unitName =


### PR DESCRIPTION
The recent FAQ clarified that a BSB cannot have higher leadership than the general. When I made the initial validation check this wasn't clear, and we elected to have the more permissive interpretation. Now that this has been clarified, I'm removing the BSB exception in the general's leadership validation.