### PR TITLE
Add missing default equipment options and consolidate lists of equipment

### DIFF
--- a/public/games/the-old-world/beastmen-brayherds.json
+++ b/public/games/the-old-world/beastmen-brayherds.json
@@ -1721,6 +1721,17 @@
           "name_fr": "Musicien"
         }
       ],
+      "equipment": [
+        {
+          "name_en": "Hand weapons, Great weapons",
+          "name_cn": "单手武器, 重型武器",
+          "name_de": "Hand weapons, Great weapons",
+          "points": 0,
+          "perModel": true,
+          "active": true,
+          "name_fr": "Armes de base, Armes lourdes"
+        }
+      ],
       "armor": [
         {
           "name_en": "Heavy armour",
@@ -1846,29 +1857,18 @@
       ],
       "equipment": [
         {
-          "name_en": "Hand weapons",
-          "name_cn": "单手武器",
-          "name_de": "Hand weapons",
-          "points": 0,
-          "perModel": true,
-          "active": true,
-          "equippedDefault": true,
-          "name_es": "Hand weapons",
-          "name_fr": "Armes de base"
-        },
-        {
-          "name_en": "Additional hand weapons",
-          "name_cn": "额外单手武器",
-          "name_de": "Additional hand weapons",
+          "name_en": "Hand weapons, Additional hand weapons",
+          "name_cn": "单手武器, 额外单手武器",
+          "name_de": "Hand weapons, Additional hand weapons",
           "points": 0,
           "perModel": true,
           "name_es": "Arma de mano adicional",
           "name_fr": "Armes de base additionnelles"
         },
         {
-          "name_en": "Shields",
-          "name_cn": "盾牌",
-          "name_de": "Shields",
+          "name_en": "Hand weapons, Shields",
+          "name_cn": "单手武器, 盾牌",
+          "name_de": "Hand weapons, Shields",
           "points": 0,
           "perModel": true,
           "name_es": "Escudos",
@@ -4080,13 +4080,13 @@
       "command": [],
       "equipment": [
         {
-          "name_en": "Hand weapons",
-          "name_cn": "单手武器",
-          "name_de": "Hand weapons",
+          "name_en": "Hand weapons, Troll vomit",
+          "name_cn": "单手武器, 巨魔呕吐",
+          "name_de": "Handwaffen, Trollkotze",
+          "name_fr": "Armes de base, Vomi de troll",
           "points": 0,
           "perModel": true,
-          "active": true,
-          "name_fr": "Armes de base"
+          "active": true
         }
       ],
       "armor": [
@@ -4094,10 +4094,10 @@
           "name_en": "Light armour (calloused hide)",
           "name_cn": "轻甲(坚硬皮肤)",
           "name_de": "Light armour (calloused hide)",
+          "name_fr": "Armure légère (peau calleuse)",
           "points": 0,
           "perModel": true,
-          "active": true,
-          "name_fr": "Armure légère (peau calleuse)"
+          "active": true
         }
       ],
       "options": [

--- a/public/games/the-old-world/empire-of-man.json
+++ b/public/games/the-old-world/empire-of-man.json
@@ -4829,11 +4829,11 @@
       ],
       "armor": [
         {
-          "name_en": "Heavy armour",
-          "name_cn": "重甲",
-          "name_de": "Schwere Rüstung",
-          "name_fr": "Armure lourde",
-          "name_es": "Armadura pesada",
+          "name_en": "Heavy armour, Barding",
+          "name_cn": "重甲, 马铠",
+          "name_de": "Schwere Rüstung, Rossharnische",
+          "name_fr": "Armure lourde, Caparaçon",
+          "name_es": "Armadura pesada, Barding",
           "points": 0,
           "perModel": true,
           "active": true
@@ -5010,11 +5010,11 @@
       ],
       "armor": [
         {
-          "name_en": "Heavy armour",
-          "name_cn": "重甲",
-          "name_de": "Schwere Rüstung",
-          "name_fr": "Armure lourde",
-          "name_es": "Armadura pesada",
+          "name_en": "Heavy armour, Barding",
+          "name_cn": "重甲, 马铠",
+          "name_de": "Schwere Rüstung, Rossharnische",
+          "name_fr": "Armure lourde, Caparaçon",
+          "name_es": "Armadura pesada, Barding",
           "points": 0,
           "perModel": true,
           "active": true
@@ -5173,11 +5173,11 @@
       ],
       "armor": [
         {
-          "name_en": "Heavy armour",
-          "name_cn": "重甲",
-          "name_de": "Schwere Rüstung",
-          "name_fr": "Armure lourde",
-          "name_es": "Armadura pesada",
+          "name_en": "Heavy armour, Barding",
+          "name_cn": "重甲, 马铠",
+          "name_de": "Schwere Rüstung, Rossharnische",
+          "name_fr": "Armure lourde, Caparaçon",
+          "name_es": "Armadura pesada, Barding",
           "points": 0,
           "perModel": true,
           "active": true
@@ -5336,11 +5336,11 @@
       ],
       "armor": [
         {
-          "name_en": "Heavy armour",
-          "name_cn": "重甲",
-          "name_de": "Schwere Rüstung",
-          "name_fr": "Armure lourde",
-          "name_es": "Armadura pesada",
+          "name_en": "Heavy armour, Barding",
+          "name_cn": "重甲, 马铠",
+          "name_de": "Schwere Rüstung, Rossharnische",
+          "name_fr": "Armure lourde, Caparaçon",
+          "name_es": "Armadura pesada, Barding",
           "points": 0,
           "perModel": true,
           "active": true
@@ -5499,11 +5499,11 @@
       ],
       "armor": [
         {
-          "name_en": "Heavy armour",
-          "name_cn": "重甲",
-          "name_de": "Schwere Rüstung",
-          "name_fr": "Armure lourde",
-          "name_es": "Armadura pesada",
+          "name_en": "Heavy armour, Barding",
+          "name_cn": "重甲, 马铠",
+          "name_de": "Schwere Rüstung, Rossharnische",
+          "name_fr": "Armure lourde, Caparaçon",
+          "name_es": "Armadura pesada, Barding",
           "points": 0,
           "perModel": true,
           "active": true
@@ -5623,11 +5623,11 @@
       ],
       "equipment": [
         {
-          "name_en": "Great weapons",
-          "name_cn": "重型武器",
-          "name_de": "Zweihandwaffen",
-          "name_fr": "Armes lourdes",
-          "name_es": "Armas a dos manos",
+          "name_en": "Hand weapons, Great weapons",
+          "name_cn": "单手武器, 重型武器",
+          "name_de": "Handwaffen, Zweihandwaffen",
+          "name_fr": "Armes de base, Armes lourdes",
+          "name_es": "Armas de mano, Armas a dos manos",
           "points": 0,
           "perModel": true,
           "active": true
@@ -8113,7 +8113,17 @@
         }
       },
       "command": [],
-      "equipment": [],
+      "equipment": [
+        {
+          "name_en": "Helblaster Volley Gun, Hand weapons",
+          "name_cn": "地狱喷射连环炮, 单手武器",
+          "name_de": "Höllenfeuer-Salvenkanone, Handwaffen",
+          "name_fr": "Canon à Répétition Feu d'Enfer, Armes de base",
+          "name_es": "Cañón de Salvas Helblaster, Armas de mano",
+          "points": 0,
+          "active": true
+        }
+      ],
       "armor": [],
       "options": [
         {
@@ -8173,7 +8183,15 @@
         }
       },
       "command": [],
-      "equipment": [],
+      "equipment": [{
+          "name_en": "Helstorm Rocket Battery, Hand weapons",
+          "name_cn": "地狱风暴火箭炮, 单手武器",
+          "name_de": "Höllensturm-Raketenlafette, Handwaffen",
+          "name_fr": "Batterie Tonnerre de Feu, Armes de base",
+          "name_es": "Batería de Cohetes HelStorm, Armas de mano",
+          "points": 0,
+          "active": true
+        }],
       "armor": [],
       "options": [
         {

--- a/public/games/the-old-world/kingdom-of-bretonnia.json
+++ b/public/games/the-old-world/kingdom-of-bretonnia.json
@@ -1639,10 +1639,11 @@
       ],
       "armor": [
         {
-          "name_en": "Heavy armour",
-          "name_cn": "重甲",
-          "name_de": "Schwere Rüstung",
-          "name_fr": "Armure lourde",
+          "name_en": "Heavy armour, Barding",
+          "name_cn": "重甲, 马铠",
+          "name_de": "Schwere Rüstung, Rossharnische",
+          "name_fr": "Armure lourde, Caparaçon",
+          "name_es": "Armadura pesada, Barding",
           "points": 0,
           "perModel": true,
           "active": true
@@ -1755,10 +1756,11 @@
       ],
       "armor": [
         {
-          "name_en": "Heavy armour",
-          "name_cn": "重甲",
-          "name_de": "Schwere Rüstung",
-          "name_fr": "Armure lourde",
+          "name_en": "Heavy armour, Barding",
+          "name_cn": "重甲, 马铠",
+          "name_de": "Schwere Rüstung, Rossharnische",
+          "name_fr": "Armure lourde, Caparaçon",
+          "name_es": "Armadura pesada, Barding",
           "points": 0,
           "perModel": true,
           "active": true
@@ -2030,10 +2032,11 @@
       ],
       "armor": [
         {
-          "name_en": "Heavy armour",
-          "name_cn": "重甲",
-          "name_de": "Schwere Rüstung",
-          "name_fr": "Armure lourde",
+          "name_en": "Heavy armour, Barding",
+          "name_cn": "重甲, 马铠",
+          "name_de": "Schwere Rüstung, Rossharnische",
+          "name_fr": "Armure lourde, Caparaçon",
+          "name_es": "Armadura pesada, Barding",
           "points": 0,
           "perModel": true,
           "active": true
@@ -2119,10 +2122,11 @@
       ],
       "armor": [
         {
-          "name_en": "Heavy armour",
-          "name_cn": "重甲",
-          "name_de": "Schwere Rüstung",
-          "name_fr": "Armure lourde",
+          "name_en": "Heavy armour, Barding",
+          "name_cn": "重甲, 马铠",
+          "name_de": "Schwere Rüstung, Rossharnische",
+          "name_fr": "Armure lourde, Caparaçon",
+          "name_es": "Armadura pesada, Barding",
           "points": 0,
           "perModel": true,
           "active": true
@@ -2463,10 +2467,11 @@
       ],
       "armor": [
         {
-          "name_en": "Heavy armour",
-          "name_cn": "重甲",
-          "name_de": "Schwere Rüstung",
-          "name_fr": "Armure lourde",
+          "name_en": "Heavy armour, Barding",
+          "name_cn": "重甲, 马铠",
+          "name_de": "Schwere Rüstung, Rossharnische",
+          "name_fr": "Armure lourde, Caparaçon",
+          "name_es": "Armadura pesada, Barding",
           "points": 0,
           "perModel": true,
           "active": true
@@ -2732,11 +2737,11 @@
       "command": [],
       "equipment": [
         {
-          "name_en": "Hand weapons",
-          "name_cn": "单手武器",
-          "name_de": "Handwaffen",
-          "name_es": "Hand weapons",
-          "name_fr": "Armes de base",
+          "name_en": "Bombard, Hand weapons",
+          "name_cn": "Bombard, 单手武器",
+          "name_de": "Bombarde, Handwaffen",
+          "name_es": "Bombarda, Armas de mano",
+          "name_fr": "Bombarde, Armes de base",
           "points": 0,
           "perModel": true,
           "active": true

--- a/public/games/the-old-world/tomb-kings-of-khemri.json
+++ b/public/games/the-old-world/tomb-kings-of-khemri.json
@@ -1011,12 +1011,11 @@
       "command": [],
       "equipment": [
         {
-          "name_en": "Hand weapon",
-          "name_cn": "单手武器",
-          "name_it": "Arma Bianca",
-          "name_de": "Handwaffe",
-          "name_es": "Hand weapon",
-          "name_fr": "Arme de base",
+          "name_en": "Hand weapon, Whip",
+          "name_cn": "单手武器, 长鞭",
+          "name_it": "Arma Bianca, Frusta",
+          "name_de": "Handwaffe, Peitsche",
+          "name_fr": "Arme de base, Fouet",
           "points": 0,
           "perModel": true,
           "active": true
@@ -1095,21 +1094,11 @@
       ],
       "equipment": [
         {
-          "name_en": "Hand weapon",
-          "name_cn": "单手武器",
-          "name_it": "Arma Bianca",
-          "name_de": "Handwaffe",
-          "name_fr": "Arme de base",
-          "points": 0,
-          "perModel": true,
-          "active": true
-        },
-        {
-          "name_en": "Whip",
-          "name_cn": "长鞭",
-          "name_it": "Frusta",
-          "name_de": "Peitsche",
-          "name_fr": "Fouet",
+          "name_en": "Hand weapon, Whip",
+          "name_cn": "单手武器, 长鞭",
+          "name_it": "Arma Bianca, Frusta",
+          "name_de": "Handwaffe, Peitsche",
+          "name_fr": "Arme de base, Fouet",
           "points": 0,
           "perModel": true,
           "active": true
@@ -1766,41 +1755,11 @@
       "command": [],
       "equipment": [
         {
-          "name_en": "Hand weapons",
-          "name_cn": "单手武器",
-          "name_it": "Arma Bianca",
-          "name_de": "Handwaffen",
-          "name_fr": "Armes de base",
-          "points": 0,
-          "perModel": true,
-          "active": true
-        },
-        {
-          "name_en": "Halberds",
-          "name_cn": "长戟",
-          "name_it": "Alabarde",
-          "name_de": "Hellebarden",
-          "name_fr": "Hallebardes",
-          "points": 0,
-          "perModel": true,
-          "active": true
-        },
-        {
-          "name_en": "Writhing tail",
-          "name_cn": "摇摆蛇尾",
-          "name_it": "Code Contorte",
-          "name_de": "Windende Schwänze",
-          "name_fr": "Queue sinueuse",
-          "points": 0,
-          "perModel": true,
-          "active": true
-        },
-        {
-          "name_en": "Petrifying gaze",
-          "name_cn": "石化凝视",
-          "name_it": "Sguardo Pietrificante",
-          "name_de": "Versteinender Blick",
-          "name_fr": "Regard pétrificateur",
+          "name_en": "Hand weapons, Halberds, Writhing tail, Petrifying gaze",
+          "name_cn": "单手武器, 长戟, 尾刺, 石化凝视",
+          "name_it": "Arma Bianca, Alabarde, Code Contorte, Sguardo Pietrificante",
+          "name_de": "Handwaffen, Hellebarden, Peitschende Schwänze, Versteinender Blick",
+          "name_fr": "Armes de base, Hallebardes, Queues sinueuses, Regard pétrificateur",
           "points": 0,
           "perModel": true,
           "active": true
@@ -3184,30 +3143,11 @@
       ],
       "equipment": [
         {
-          "name_en": "Hand weapons",
-          "name_cn": "单手武器",
-          "name_it": "Arma Bianca",
-          "name_de": "Handwaffen",
-          "name_fr": "Armes de base",
-          "points": 0,
-          "perModel": true,
-          "active": true
-        },
-        {
-          "name_en": "Cavalry spears",
-          "name_cn": "骑兵长矛",
-          "name_it": "Lance Leggere",
-          "name_de": "Kavalleriespeere",
-          "name_fr": "Lances de cavalerie",
-          "points": 0,
-          "perModel": true
-        },
-        {
-          "name_en": "Hand weapons (Lashing tails)",
-          "name_cn": "单手武器(Lashing tails)",
-          "name_it": "Code sferzanti (conta come Arma Bianca)",
-          "name_de": "Handwaffen (Peitschenschwänze)",
-          "name_fr": "Armes de base (Queues fouettardes)",
+          "name_en": "Hand weapons, Cavalry spears, Hand weapons (Lashing tails)",
+          "name_cn": "单手武器, 骑兵长矛, 单手武器(Lashing tails)",
+          "name_it": "Arma Bianca, Lance Leggere, Code sferzanti (conta come Arma Bianca)",
+          "name_de": "Handwaffen, Kavalleriespeere, Handwaffen (Peitschenschwänze)",
+          "name_fr": "Armes de base, Lances de cavalerie, Armes de base (Queues fouettardes)",
           "points": 0,
           "perModel": true,
           "active": true
@@ -3476,41 +3416,11 @@
       "command": [],
       "equipment": [
         {
-          "name_en": "Hand weapons",
-          "name_cn": "单手武器",
-          "name_it": "Arma Bianca",
-          "name_de": "Handwaffen",
-          "name_fr": "Armes de base",
-          "points": 0,
-          "perModel": true,
-          "active": true
-        },
-        {
-          "name_en": "Halberds",
-          "name_cn": "长戟",
-          "name_it": "Alabarde",
-          "name_de": "Hellebarden",
-          "name_fr": "Hallebardes",
-          "points": 0,
-          "perModel": true,
-          "active": true
-        },
-        {
-          "name_en": "Writhing tails",
-          "name_cn": "尾刺",
-          "name_it": "Code Contorte",
-          "name_de": "Peitschende Schwänze",
-          "name_fr": "Queues sinueuses",
-          "points": 0,
-          "perModel": true,
-          "active": true
-        },
-        {
-          "name_en": "Petrifying gaze",
-          "name_cn": "石化凝视",
-          "name_it": "Sguardo Pietrificante",
-          "name_de": "Versteinender Blick",
-          "name_fr": "Regard pétrificateur",
+          "name_en": "Hand weapons, Halberds, Writhing tail, Petrifying gaze",
+          "name_cn": "单手武器, 长戟, 尾刺, 石化凝视",
+          "name_it": "Arma Bianca, Alabarde, Code Contorte, Sguardo Pietrificante",
+          "name_de": "Handwaffen, Hellebarden, Peitschende Schwänze, Versteinender Blick",
+          "name_fr": "Armes de base, Hallebardes, Queues sinueuses, Regard pétrificateur",
           "points": 0,
           "perModel": true,
           "active": true
@@ -4024,21 +3934,11 @@
       "command": [],
       "equipment": [
         {
-          "name_en": "Screaming Skull Catapult",
-          "name_cn": "尖啸颅骨投石机",
-          "name_it": "Gettateschi Urlanti",
-          "name_de": "Schädelkatapult",
-          "name_fr": "Catapulte à Crânes Hurlants",
-          "points": 0,
-          "perModel": true,
-          "active": true
-        },
-        {
-          "name_en": "Hand weapons",
-          "name_cn": "单手武器",
-          "name_it": "Arma Bianca",
-          "name_de": "Handwaffen",
-          "name_fr": "Armes de base",
+          "name_en": "Screaming skull catapult, Hand weapons",
+          "name_cn": "尖啸颅骨投石机, 单手武器",
+          "name_it": "Gettateschi Urlanti, Arma Bianca",
+          "name_de": "Schädelkatapult, Handwaffen",
+          "name_fr": "Catapulte à Crânes Hurlants, Armes de base",
           "points": 0,
           "perModel": true,
           "active": true
@@ -4099,21 +3999,11 @@
       "command": [],
       "equipment": [
         {
-          "name_en": "Hand weapons",
-          "name_cn": "单手武器",
-          "name_it": "Arma Bianca",
-          "name_de": "Handwaffen",
-          "name_fr": "Armes de base",
-          "points": 0,
-          "perModel": true,
-          "active": true
-        },
-        {
-          "name_en": "Great weapons",
-          "name_cn": "重型武器",
-          "name_it": "Grandi Armi",
-          "name_de": "Zweihandwaffen",
-          "name_fr": "Armes lourdes",
+          "name_en": "Hand weapons, Great weapons",
+          "name_cn": "单手武器, 重型武器",
+          "name_it": "Arma Bianca, Grandi Armi",
+          "name_de": "Handwaffen, Zweihandwaffen",
+          "name_fr": "Armes de base, Armes lourdes",
           "points": 0,
           "perModel": true,
           "active": true

--- a/public/games/the-old-world/warriors-of-chaos.json
+++ b/public/games/the-old-world/warriors-of-chaos.json
@@ -4680,11 +4680,10 @@
       "command": [],
       "equipment": [
         {
-          "name_en": "Hand weapons",
-          "name_cn": "单手武器",
-          "name_de": "Hand weapons",
-          "name_es": "Hand weapons",
-          "name_fr": "Armes de base",
+          "name_en": "Hand weapons, Troll vomit",
+          "name_cn": "单手武器, 巨魔呕吐",
+          "name_de": "Handwaffen, Trollkotze",
+          "name_fr": "Armes de base, Vomi de troll",
           "points": 0,
           "perModel": true,
           "active": true

--- a/public/games/the-old-world/wood-elf-realms.json
+++ b/public/games/the-old-world/wood-elf-realms.json
@@ -1074,8 +1074,28 @@
           "points": 0
         }
       ],
-      "equipment": [],
-      "armor": [],
+      "equipment": [
+        {
+          "name_en": "Oaken fists, Strangleroots",
+          "name_cn": "Oaken fists, Strangleroots",
+          "name_de": "Oaken fists, Strangleroots",
+          "name_es": "Oaken fists, Strangleroots",
+          "name_fr": "Oaken fists, Strangleroots",
+          "points": 0,
+          "active": true
+        }
+      ],
+      "armor": [
+        {
+          "name_en": "Full plate armour (Arboreal armour)",
+          "name_cn": "全身甲",
+          "name_de": "Plattenrüstung",
+          "name_fr": "Armure de plate complète",
+          "name_es": "Armadura completa",
+          "points": 0,
+          "active": true
+        }
+      ],
       "options": [
         {
           "name_en": "Level 3 Wizard",
@@ -1163,6 +1183,16 @@
       ],
       "equipment": [
         {
+          "name_en": "Hand weapon",
+          "name_cn": "单手武器",
+          "name_de": "Handwaffe",
+          "name_fr": "Arme de base",
+          "name_pl": "Broń ręczna",
+          "points": 0,
+          "perModel": true,
+          "active": true
+        },
+        {
           "name_en": "Additional hand weapon",
           "name_cn": "额外单手武器",
           "name_de": "Zusätzliche Handwaffe",
@@ -1179,25 +1209,15 @@
           "name_pl": "Broń ciężka",
           "points": 4,
           "perModel": true
-        },
-        {
-          "name_en": "Hand weapon",
-          "name_cn": "单手武器",
-          "name_de": "Handwaffe",
-          "name_fr": "Arme de base",
-          "name_pl": "Broń ręczna",
-          "points": 0,
-          "perModel": true,
-          "active": true
         }
       ],
       "armor": [
         {
-          "name_en": "Light armour",
-          "name_cn": "轻甲",
-          "name_de": "Leichte Rüstung",
-          "name_fr": "Armure légère",
-          "name_pl": "Lekka zbroja",
+          "name_en": "Light armour (Sapwood flesh)",
+          "name_cn": "轻甲(Sapwood flesh)",
+          "name_de": "Leichte Rüstung (Splintholzhaut)",
+          "name_fr": "Armure légère (Chair d'aubier)",
+          "name_pl": "Lekka zbroja z bielu",
           "points": 0,
           "perModel": true,
           "active": true
@@ -2757,11 +2777,11 @@
       ],
       "equipment": [
         {
-          "name_en": "Hand weapon, Cavalry spear, Asrai longbow",
-          "name_cn": "单手武器, 骑兵长矛, 阿斯莱长弓",
-          "name_de": "Handwaffe, Kavalleriespeer, Asrai-Langbogen",
-          "name_fr": "Arme de base, Lance de cavalerie, Arc long Asrai",
-          "name_pl": "Broń ręczna, Lanca, Długi łuk Asrai",
+          "name_en": "Hand weapon, Cavalry spear, Asrai longbow, Wicked claws (Warhawk)",
+          "name_cn": "单手武器, 骑兵长矛, 阿斯莱长弓, 恶毒之爪",
+          "name_de": "Handwaffe, Kavalleriespeer, Asrai-Langbogen, Scheußliche Krallen",
+          "name_fr": "Arme de base, Lance de cavalerie, Arc long Asrai, Griffes mortelles",
+          "name_pl": "Broń ręczna, Lanca, Długi łuk Asrai, Wicked claws",
           "points": 0,
           "perModel": true,
           "active": true
@@ -3167,7 +3187,16 @@
       "id": "giant-eagle",
       "points": 60,
       "command": [],
-      "equipment": [],
+      "equipment": [{
+          "name_en": "Wicked claws, Serrated maw",
+          "name_cn": "恶毒之爪, 锯齿巨口",
+          "name_de": "Wicked claws, Serrated maw",
+          "name_es": "Garras crueles, Dientes serrados",
+          "name_fr": "Griffes mortelles, Gueules dentelées",
+          "points": 0,
+          "perModel": true,
+          "active": true
+        }],
       "armor": [],
       "options": [],
       "mounts": [],
@@ -3197,8 +3226,28 @@
         }
       },
       "command": [],
-      "equipment": [],
-      "armor": [],
+      "equipment": [
+        {
+          "name_en": "Oaken fists, Strangleroots",
+          "name_cn": "Oaken fists, Strangleroots",
+          "name_de": "Oaken fists, Strangleroots",
+          "name_es": "Oaken fists, Strangleroots",
+          "name_fr": "Oaken fists, Strangleroots",
+          "points": 0,
+          "active": true
+        }
+      ],
+      "armor": [
+        {
+          "name_en": "Full plate armour (Arboreal armour)",
+          "name_cn": "全身甲",
+          "name_de": "Plattenrüstung",
+          "name_fr": "Armure de plate complète",
+          "name_es": "Armadura completa",
+          "points": 0,
+          "active": true
+        }
+      ],
       "options": [
         {
           "name_en": "Ambushers",


### PR DESCRIPTION
I've done a pass through the various army lists for looking for default equipment and armour that was missing or poorly formatted and added a bunch back in. There were a lot of Barding that was missing from knights, and a few monsters that didn't have their weapon rules easily accessible. I may have missed a few but it's progress.

Is there a way for the rules links to find the right source in whfb.app if the weapon rule is the same as the unit, like the [Screaming Skull Catapult](https://tow.whfb.app/unit/screaming-skull-catapult) and its weapon profile the [Screaming Skull Catapult](https://tow.whfb.app/weapons-of-war/screaming-skull-catapult)? A lot of war machines have this problem, and it'd be a little nice to save a click and link to the right place.