### PR TITLE
Item uniqueness validation

### DIFF
--- a/public/games/the-old-world/magic-items.json
+++ b/public/games/the-old-world/magic-items.json
@@ -8,7 +8,8 @@
       "name_it": "Spada dell'Ogre",
       "name_pl": "Ogrowe Ostrze",
       "points": 75,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_cn": "战争之剑",
@@ -18,7 +19,8 @@
       "name_it": "Spada della Battaglia",
       "name_pl": "Miecz Bitewny",
       "points": 60,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_cn": "决斗者之刃",
@@ -28,7 +30,8 @@
       "name_it": "Lame del Duellante",
       "name_pl": "Ostrza Pojedynkowicza",
       "points": 55,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_cn": "屠龙剑",
@@ -38,7 +41,8 @@
       "name_it": "Spada Ammazzadraghi",
       "name_pl": "Smokobójca",
       "points": 50,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_cn": "刽子手巨斧",
@@ -48,7 +52,8 @@
       "name_it": "Ascia del Boia",
       "name_pl": "Topór Katowski",
       "points": 45,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_cn": "食法斧",
@@ -58,7 +63,8 @@
       "name_it": "Ascia di Dispersione",
       "name_pl": "Czarożerca",
       "points": 35,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_cn": "巨剑",
@@ -68,7 +74,8 @@
       "name_it": "Lama Gigante",
       "name_pl": "Ostrze Gigantów",
       "points": 30,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_cn": "迅捷之剑",
@@ -78,7 +85,8 @@
       "name_it": "Spada della Rapidità",
       "name_pl": "Miecz Szybkości",
       "points": 25,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_cn": "狂战士之刃",
@@ -88,7 +96,8 @@
       "name_it": "Lama del Berserker",
       "name_pl": "Ostrze Berserkera",
       "points": 20,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_cn": "力量之剑",
@@ -99,7 +108,8 @@
       "name_pl": "Miecz Mocy*",
       "points": 20,
       "stackable": true,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": false
     },
     {
       "name_cn": "刺叮之刃",
@@ -109,7 +119,8 @@
       "name_it": "Lama Lacerante",
       "name_pl": "Gryzące Ostrze",
       "points": 15,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_cn": "打击之剑",
@@ -120,7 +131,8 @@
       "name_pl": "Miecz Trafiania*",
       "points": 15,
       "stackable": true,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": false
     },
     {
       "name_cn": "烈焰之刃",
@@ -131,7 +143,8 @@
       "name_pl": "Płonące Ostrze*",
       "points": 5,
       "stackable": true,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": false
     },
     {
       "name_cn": "天命护甲",
@@ -141,7 +154,8 @@
       "name_it": "Armatura Del Destino",
       "name_pl": "Zbroja Przeznaczenia",
       "points": 70,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_cn": "炫目头盔",
@@ -151,7 +165,8 @@
       "name_it": "Elmo Scintillante",
       "name_pl": "Olśniewający hełm",
       "points": 60,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_cn": "银钢甲",
@@ -161,7 +176,8 @@
       "name_it": "Armatura D'Acciaio Argentato",
       "name_pl": "Zbroja z Posrebrzanej Stali",
       "points": 40,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_cn": "闪耀鳞甲",
@@ -171,7 +187,8 @@
       "name_it": "Scaglie Luccicanti",
       "name_pl": "Błyszczące łuski",
       "points": 35,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_cn": "真正勇士之盾",
@@ -181,7 +198,8 @@
       "name_it": "Lo Scudo del Vero Guerriero",
       "name_pl": "Tarcza Prawdziwego Wojownika",
       "points": 30,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_cn": "法术盾",
@@ -193,7 +211,8 @@
       "points": 25,
       "stackable": true,
       "maximum": 1,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": false
     },
     {
       "name_cn": "陨铁甲",
@@ -203,7 +222,8 @@
       "name_it": "Armatura Di Ferro Meteoritico",
       "name_pl": "Pancerz z Meteorytowego Żelaza",
       "points": 20,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_cn": "附魔盾牌",
@@ -215,7 +235,8 @@
       "points": 10,
       "stackable": true,
       "maximum": 1,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": false
     },
     {
       "name_cn": "庇佑之盾",
@@ -227,7 +248,8 @@
       "points": 5,
       "stackable": true,
       "maximum": 1,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": false
     },
     {
       "name_cn": "黎明石",
@@ -237,7 +259,8 @@
       "name_it": "Pietra Dell'Alba",
       "name_pl": "Kamień Świtu",
       "points": 35,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_cn": "保护护符",
@@ -247,7 +270,8 @@
       "name_it": "Talismano Di Protezione",
       "name_pl": "Talizman Ochrony",
       "points": 30,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_cn": "军需官的硬币",
@@ -258,7 +282,8 @@
       "name_pl": "Moneta Skarbnika*",
       "points": 25,
       "stackable": true,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": false
     },
     {
       "name_cn": "黑曜石磁石",
@@ -269,7 +294,8 @@
       "name_pl": "Obsydianowy Magnetyt*",
       "points": 20,
       "stackable": true,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": false
     },
     {
       "name_cn": "幸运石",
@@ -280,7 +306,8 @@
       "name_pl": "Szczęśliwy kamień*",
       "points": 15,
       "stackable": true,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": false
     },
     {
       "name_cn": "铁纪旗",
@@ -290,7 +317,8 @@
       "name_it": "Stendardo Della Volontà Di Ferro",
       "name_pl": "Sztandar Żelaznej Determinacji",
       "points": 50,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_cn": "剃刀战旗",
@@ -300,7 +328,8 @@
       "name_it": "Stendardo Affilato",
       "name_pl": "Sztandar Brzytew",
       "points": 40,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_cn": "狂暴战旗",
@@ -310,7 +339,8 @@
       "name_it": "Stendardo Furioso",
       "name_pl": "Sztandar Szału",
       "points": 30,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_cn": "火焰旗",
@@ -320,7 +350,8 @@
       "name_it": "Stendardo Fiammeggiante",
       "name_pl": "Płonący Sztandar",
       "points": 25,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_cn": "战旗",
@@ -330,7 +361,8 @@
       "name_it": "Stendardo da Guerra",
       "name_pl": "Sztandar wojenny",
       "points": 25,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_cn": "巫师帽",
@@ -340,7 +372,8 @@
       "name_it": "Cappello Magico",
       "name_pl": "Kapelusz Czarownika",
       "points": 45,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_cn": "飞毯",
@@ -350,7 +383,8 @@
       "name_it": "Tappeto Volante",
       "name_pl": "Latający Dywan",
       "points": 40,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_cn": "治疗药剂",
@@ -361,7 +395,8 @@
       "name_pl": "Mikstura Lecząca*",
       "points": 35,
       "stackable": true,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": false
     },
     {
       "name_cn": "毁灭红宝石之戒",
@@ -371,7 +406,8 @@
       "name_it": "Anello Di Rubino Della Rovina",
       "name_pl": "Rubinowy Pierścień Zguby",
       "points": 35,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_cn": "力量药剂",
@@ -382,7 +418,8 @@
       "name_pl": "Mikstura Siły*",
       "points": 25,
       "stackable": true,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": false
     },
     {
       "name_cn": "坚韧药剂",
@@ -393,7 +430,8 @@
       "name_pl": "Mikstura Wytrzymałości*",
       "points": 20,
       "stackable": true,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": false
     },
     {
       "name_cn": "速度药剂",
@@ -404,7 +442,8 @@
       "name_pl": "Mikstura Szybkości*",
       "points": 10,
       "stackable": true,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": false
     },
     {
       "name_cn": "鲁莽药剂",
@@ -415,7 +454,8 @@
       "name_pl": "Mikstura Pochopności*",
       "points": 5,
       "stackable": true,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": false
     },
     {
       "name_cn": "反馈卷轴",
@@ -425,7 +465,8 @@
       "name_it": "Pergamena del Contraccolpo",
       "name_pl": "Zwój Odbicia*",
       "points": 60,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_cn": "变形卷轴",
@@ -436,7 +477,8 @@
       "name_pl": "Zwój Transmogryfikacji*",
       "points": 50,
       "stackable": true,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     },
     {
       "name_cn": "翡翠魔杖",
@@ -446,7 +488,8 @@
       "name_it": "Bacchetta di Giada",
       "name_pl": "Różdżka Sadzy",
       "points": 45,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_cn": "法系仆从",
@@ -456,7 +499,8 @@
       "name_it": "Famiglio del Sapere",
       "name_pl": "Chowaniec Wiedzy",
       "points": 30,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_cn": "能量卷轴",
@@ -467,7 +511,8 @@
       "name_pl": "Zwój Mocy*",
       "points": 20,
       "stackable": true,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     },
     {
       "name_cn": "破法卷轴",
@@ -478,7 +523,8 @@
       "name_pl": "Zwój Rozproszenia*",
       "points": 20,
       "stackable": true,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     },
     {
       "name_cn": "神秘仆从",
@@ -488,7 +534,8 @@
       "name_it": "Famiglio Arcano",
       "name_pl": "Magiczny chowaniec",
       "points": 15,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_cn": "接地杖",
@@ -498,7 +545,8 @@
       "name_it": "Asta della Messa a Terra",
       "name_pl": "Odgramiacz",
       "points": 5,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     }
   ],
   "kingdom-of-bretonnia": [
@@ -510,7 +558,8 @@
       "name_it": "Spada of the Quest",
       "name_pl": "Miecz Wyprawy",
       "points": 70,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Heldenschwert",
@@ -520,7 +569,8 @@
       "name_it": "Spada of Heroes",
       "name_pl": "Miecz Bohaterów",
       "points": 60,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Kernholzlanze",
@@ -530,7 +580,8 @@
       "name_it": "Heartwood Lance",
       "name_pl": "Lanca z Twardziela",
       "points": 50,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Morgenstern von Fracasse",
@@ -540,7 +591,8 @@
       "name_it": "Morning Star of Fracasse",
       "name_pl": "Jutrzenka z Fracasse",
       "points": 40,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "armyComposition": "errantry-crusades",
@@ -551,7 +603,8 @@
       "name_it": "Crusader's Lance",
       "name_pl": "Lanca Krzyżowca",
       "points": 60,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "armyComposition": "bretonnian-exiles",
@@ -562,7 +615,8 @@
       "name_it": "Frontier Axe",
       "name_pl": "Topór Pogranicza",
       "points": 30,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Schwert des tapferen Herzens",
@@ -572,7 +626,8 @@
       "name_it": "Spada of the Stout Hearted",
       "name_pl": "Miecz Niezłomnego",
       "points": 25,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Feindbrecher",
@@ -582,7 +637,8 @@
       "name_it": "Foebreaker",
       "name_pl": "Pogromca Wrogów",
       "points": 20,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Güldener Kürass",
@@ -592,7 +648,8 @@
       "name_it": "Gilded Cuirass",
       "name_pl": "Pozłacany Kirys",
       "points": 60,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Gromril-Vollhelm",
@@ -602,7 +659,8 @@
       "name_it": "Gromril Great Helm",
       "name_pl": "Wielki Hełm z Gromrilu",
       "points": 40,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Gesalbte Rüstung",
@@ -612,7 +670,8 @@
       "name_it": "Anointed Armour",
       "name_pl": "Namaszczona Zbroja",
       "points": 45,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "armyComposition": "bretonnian-exiles",
@@ -623,7 +682,8 @@
       "name_it": "Ironspike Scudo",
       "name_pl": "Tarcza żelaznych kolcy",
       "points": 20,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Mantel der Elena",
@@ -633,7 +693,8 @@
       "name_it": "Mantle of the Damsel Elena",
       "name_pl": "Płaszcz Pani Eleny ",
       "points": 25,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Siriennes Medaillon",
@@ -643,7 +704,8 @@
       "name_it": "Sirienne's Locket",
       "name_pl": "Medalion Sirienne",
       "points": 25,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Gralsanhänger",
@@ -653,7 +715,8 @@
       "name_it": "Grail Pendant",
       "name_pl": "Wisior Graala",
       "points": 40,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "armyComposition": "bretonnian-exiles",
@@ -665,7 +728,8 @@
       "name_pl": "Szczęśliwa pamiątka*",
       "points": 25,
       "stackable": true,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": false
     },
     {
       "name_de": "Standarte des Heldenmuts",
@@ -675,7 +739,8 @@
       "name_it": "Valorous Standard",
       "name_pl": "Sztandar Walecznych",
       "points": 60,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Gobelin der Heldentaten",
@@ -685,7 +750,8 @@
       "name_it": "Conqueror's Tapestry",
       "name_pl": "Gobelin Zdobywcy",
       "points": 40,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner der Fahrenden Ritter",
@@ -695,7 +761,8 @@
       "name_it": "Errantry Banner",
       "name_pl": "Sztandar Błądzących",
       "points": 30,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner von Chálons",
@@ -705,7 +772,8 @@
       "name_it": "Banner of Châlons",
       "name_pl": "Sztandar Châlons",
       "points": 20,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner der Anmut der Herrin",
@@ -715,7 +783,8 @@
       "name_it": "Banner of the Lady's Grace",
       "name_pl": "Sztandar Łaski Pani",
       "points": 75,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "armyComposition": "errantry-crusades",
@@ -726,7 +795,8 @@
       "name_it": "Crusader's Tapestry",
       "name_pl": "Gobelin Krzyżowca",
       "points": 40,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "armyComposition": "bretonnian-exiles",
@@ -737,7 +807,8 @@
       "name_it": "Banner of the Zealous Cavaliere",
       "name_pl": "Sztandar Gorliwego Rycerza",
       "points": 25,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner der ehrenhaften Kriegsführung",
@@ -747,7 +818,8 @@
       "name_it": "Banner of Honourable Warfare",
       "name_pl": "Sztandar Honorowej Wojny",
       "points": 25,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Falkenhorn des Fredemund",
@@ -757,7 +829,8 @@
       "name_it": "Falcon-horn of Fredemund",
       "name_pl": "Sokoli Róg Fredemunda",
       "points": 40,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Trophaen der Großen Jagd",
@@ -767,7 +840,8 @@
       "name_it": "Antlers of the Great Hunt",
       "name_pl": "Poroże Wielkich Łowów",
       "points": 25,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Fehdehandschuh*",
@@ -778,7 +852,8 @@
       "name_pl": "Rękawica pojedynkowe*",
       "points": 5,
       "stackable": true,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Das Siegel von Parravon",
@@ -788,7 +863,8 @@
       "name_it": "The Seal of Parravon",
       "name_pl": "Pieczęć Parravonu",
       "points": 35,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "armyComposition": "errantry-crusades",
@@ -799,7 +875,8 @@
       "name_it": "Crusader's Clarion",
       "name_pl": "Trąbka Krzyżowca",
       "points": 25,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "armyComposition": "bretonnian-exiles",
@@ -810,7 +887,8 @@
       "name_it": "Wyrmbreath Vial",
       "name_pl": "Fiolka Żmijodechu",
       "points": 20,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Silberspigel",
@@ -820,7 +898,8 @@
       "name_it": "Argento Mirror",
       "name_pl": "Srebrne Zwierciadło",
       "points": 35,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Hostie der Herrin des Sees*",
@@ -831,7 +910,8 @@
       "name_pl": "Sakrament Pani*",
       "points": 30,
       "stackable": true,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Gebetsikone der Quenelles",
@@ -841,7 +921,8 @@
       "name_it": "Prayer Icon of Quenelles",
       "name_pl": "Ikona z Quenelles",
       "points": 25,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Herz der Wildnis",
@@ -851,7 +932,8 @@
       "name_it": "Cuore of the Wilds",
       "name_pl": "Serce Ostępów",
       "points": 40,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "armyComposition": "errantry-crusades",
@@ -862,7 +944,8 @@
       "name_it": "Diadem of Potere",
       "name_pl": "Diadem Mocy",
       "points": 35,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "armyComposition": "bretonnian-exiles",
@@ -873,7 +956,8 @@
       "name_it": "Flamestrike Bacchetta",
       "name_pl": "Różdżka Ognistego Uderzenia",
       "points": 15,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     }
   ],
   "knightly-virtues": [
@@ -884,7 +968,8 @@
       "name_fr": "Vertu du Tempérament Chevaleresque",
       "name_it": "Virtue of Knightly Temper",
       "points": 70,
-      "type": "knightly-virtue"
+      "type": "knightly-virtue",
+      "onePerArmy": true
     },
     {
       "name_de": "Tugend der Tapferkeit",
@@ -893,7 +978,8 @@
       "name_fr": "Vertu d'Héroïsme",
       "name_it": "Virtue of Heroism",
       "points": 60,
-      "type": "knightly-virtue"
+      "type": "knightly-virtue",
+      "onePerArmy": true
     },
     {
       "name_de": "Tugend der Sturheit",
@@ -902,7 +988,8 @@
       "name_fr": "Vertu de Stoïcisme",
       "name_it": "Virtue of Stoicism",
       "points": 55,
-      "type": "knightly-virtue"
+      "type": "knightly-virtue",
+      "onePerArmy": true
     },
     {
       "name_de": "Tugend der Entsagung",
@@ -911,7 +998,8 @@
       "name_fr": "Vertu du Pénitent",
       "name_it": "Virtue of the Penitent",
       "points": 50,
-      "type": "knightly-virtue"
+      "type": "knightly-virtue",
+      "onePerArmy": true
     },
     {
       "name_de": "Tugend des ritterlichen Ideals",
@@ -920,7 +1008,8 @@
       "name_fr": "Vertu de l'Idéal",
       "name_it": "Virtue of the Ideal",
       "points": 45,
-      "type": "knightly-virtue"
+      "type": "knightly-virtue",
+      "onePerArmy": true
     },
     {
       "name_de": "Tugend des ungestümen Ritters",
@@ -929,7 +1018,8 @@
       "name_fr": "Vertu du Chevalier Impétueux",
       "name_it": "Virtue of the Impetuous Cavaliere",
       "points": 40,
-      "type": "knightly-virtue"
+      "type": "knightly-virtue",
+      "onePerArmy": true
     },
     {
       "name_de": "Tugend des Heldenmuts",
@@ -938,7 +1028,8 @@
       "name_fr": "Vertu de Témérité",
       "name_it": "Virtue of Audacity",
       "points": 35,
-      "type": "knightly-virtue"
+      "type": "knightly-virtue",
+      "onePerArmy": true
     },
     {
       "name_de": "Tugend der Reinheit",
@@ -947,7 +1038,8 @@
       "name_fr": "Vertu de Pureté",
       "name_it": "Virtue of Purity",
       "points": 30,
-      "type": "knightly-virtue"
+      "type": "knightly-virtue",
+      "onePerArmy": true
     },
     {
       "name_de": "Tugend der Pflicht",
@@ -956,7 +1048,8 @@
       "name_fr": "Vertu du Devoir",
       "name_it": "Virtue of Duty",
       "points": 25,
-      "type": "knightly-virtue"
+      "type": "knightly-virtue",
+      "onePerArmy": true
     },
     {
       "name_de": "Tugend der Tjoste",
@@ -965,7 +1058,8 @@
       "name_fr": "Vertu de la Joute",
       "name_it": "Virtue of the Joust",
       "points": 20,
-      "type": "knightly-virtue"
+      "type": "knightly-virtue",
+      "onePerArmy": true
     },
     {
       "name_de": "Tugend des Selbstvertrauens",
@@ -974,7 +1068,8 @@
       "name_fr": "Vertu de Confiance",
       "name_it": "Virtue of Confidence",
       "points": 15,
-      "type": "knightly-virtue"
+      "type": "knightly-virtue",
+      "onePerArmy": true
     },
     {
       "name_de": "Tugend der ritterlichen Verachtungn",
@@ -983,7 +1078,8 @@
       "name_fr": "Vertu de Noble Dédain",
       "name_it": "Virtue of Noble Disdain",
       "points": 10,
-      "type": "knightly-virtue"
+      "type": "knightly-virtue",
+      "onePerArmy": true
     },
     {
       "name_de": "Tugend der Barmherzigkeit",
@@ -992,7 +1088,8 @@
       "name_fr": "Vertu de Sollicitude",
       "name_it": "Virtue of Empathy",
       "points": 5,
-      "type": "knightly-virtue"
+      "type": "knightly-virtue",
+      "onePerArmy": true
     },
     {
       "name_de": "Tugend der Disziplin",
@@ -1001,7 +1098,8 @@
       "name_fr": "Vertu de Discipline",
       "name_it": "Virtue of Discipline",
       "points": 5,
-      "type": "knightly-virtue"
+      "type": "knightly-virtue",
+      "onePerArmy": true
     }
   ],
   "empire-of-man": [
@@ -1013,7 +1111,8 @@
       "name_it": "Runefang",
       "name_pl": "Runiczny Kieł",
       "points": 100,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Helsturms Streitkolben",
@@ -1023,7 +1122,8 @@
       "name_it": "Mace of Helsturm",
       "name_pl": "Buzdygan Helsturma",
       "points": 65,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Richtschwert",
@@ -1033,7 +1133,8 @@
       "name_it": "Spada of Justice",
       "name_pl": "Miecz Sprawiedliwości",
       "points": 50,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Hammer der Rechtschaffenheit",
@@ -1043,7 +1144,8 @@
       "name_it": "Hammer of Righteousness",
       "name_pl": "Hammer of Righteousness",
       "points": 50,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Perlmuttdolche",
@@ -1053,7 +1155,8 @@
       "name_it": "Pearl Daggers",
       "name_pl": "Pearl Daggers",
       "points": 35,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Silberstahlklinge",
@@ -1070,7 +1173,8 @@
         "knightly-order-blazing-sun",
         "knightly-order-fiery-heart",
         "knightly-order-white-wolf"
-      ]
+      ],
+      "onePerArmy": true
     },
     {
       "name_de": "Drachenbogen",
@@ -1080,7 +1184,8 @@
       "name_it": "Drago Arco",
       "name_pl": "Smoczy Łuk",
       "points": 25,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Von Trickschuss’ Wundersame Arkebuse",
@@ -1091,7 +1196,8 @@
       "name_pl": "Von Trickschotte's Wondrous Arquebus",
       "points": 25,
       "type": "weapon",
-      "armyComposition": "city-state-of-nuln"
+      "armyComposition": "city-state-of-nuln",
+      "onePerArmy": true
     },
     {
       "name_de": "Rüstung des Glücks",
@@ -1101,7 +1207,8 @@
       "name_it": "Armour of Fortune",
       "name_pl": "Zbroja Fortuny",
       "points": 45,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Gorgonenschild",
@@ -1118,7 +1225,8 @@
         "knightly-order-blazing-sun",
         "knightly-order-fiery-heart",
         "knightly-order-white-wolf"
-      ]
+      ],
+      "onePerArmy": true
     },
     {
       "name_de": "Tarnus' Rüstung",
@@ -1128,7 +1236,8 @@
       "name_it": "Armour of Tarnus",
       "name_pl": "Zbroja Tarnusa",
       "points": 35,
-      "type": "armor-mages"
+      "type": "armor-mages",
+      "onePerArmy": true
     },
     {
       "name_de": "Doppelt gesegnete Rüstung",
@@ -1138,7 +1247,8 @@
       "name_it": "Armour Twice-Blessed Armour",
       "name_pl": "Twice-Blessed Armour",
       "points": 25,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Der Weiße Umhang",
@@ -1148,7 +1258,8 @@
       "name_it": "The White Mantello",
       "name_pl": "Biały Płaszcz",
       "points": 30,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Jadeamulett*",
@@ -1159,7 +1270,8 @@
       "name_pl": "Jadeitowy Amulet*",
       "points": 25,
       "stackable": true,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": false
     },
     {
       "name_de": "Hexenjägeramulett*",
@@ -1170,7 +1282,8 @@
       "name_pl": "Witch Hunter's Ward*",
       "points": 20,
       "stackable": true,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": false
     },
     {
       "name_de": "Stundenglas des Schlächters",
@@ -1180,7 +1293,8 @@
       "name_it": "Slayer's Hourglass",
       "name_pl": "Slayer's Hourglass",
       "points": 10,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner der Pantherritter",
@@ -1191,7 +1305,8 @@
       "name_pl": "Banner of the Knights Panther",
       "points": 80,
       "type": "banner",
-      "armyComposition": "knightly-order-panther"
+      "armyComposition": "knightly-order-panther",
+      "onePerArmy": true
     },
     {
       "name_de": "Imperiales Banner",
@@ -1201,7 +1316,8 @@
       "name_it": "Imperial Banner",
       "name_pl": "Imperialny Sztandar",
       "points": 60,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Greifenstandarte",
@@ -1211,7 +1327,8 @@
       "name_it": "Griffon Standard",
       "name_pl": "Gryfi Sztandar",
       "points": 50,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Gobelin der Triumphe des Sigmar",
@@ -1221,7 +1338,8 @@
       "name_it": "Tapestry of Sigmar's Triumph",
       "name_pl": "Tapestry of Sigmar's Triumph",
       "points": 40,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Ikone des Morr",
@@ -1231,7 +1349,8 @@
       "name_it": "Icon of Morr",
       "name_pl": "Icon of Morr",
       "points": 25,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner des Freistaats Nuln",
@@ -1242,7 +1361,8 @@
       "name_pl": "The Banner of the Free State of Nuln",
       "points": 20,
       "type": "banner",
-      "armyComposition": "city-state-of-nuln"
+      "armyComposition": "city-state-of-nuln",
+      "onePerArmy": true
     },
     {
       "name_de": "The Strahlende Flagge",
@@ -1252,7 +1372,8 @@
       "name_it": "The Gleaming Pennant",
       "name_pl": "Błyszczący Proporzec",
       "points": 15,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner der Pflicht",
@@ -1262,7 +1383,8 @@
       "name_it": "Banner of Duty",
       "name_pl": "Sztandar Powinności",
       "points": 10,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Siegeslorbeer",
@@ -1272,7 +1394,8 @@
       "name_it": "Laurels of Victory",
       "name_pl": "Laury Zwycięstwa",
       "points": 40,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Blinzelmanns Fantastisches Fernrohr*",
@@ -1284,7 +1407,8 @@
       "points": 35,
       "type": "enchanted-item",
       "stackable": true,
-      "armyComposition": "city-state-of-nuln"
+      "armyComposition": "city-state-of-nuln",
+      "onePerArmy": false
     },
     {
       "name_de": "Glücksring",
@@ -1294,7 +1418,8 @@
       "name_it": "Ring of Fortune",
       "name_pl": "Ring of Fortune",
       "points": 20,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Ring des Taal",
@@ -1304,7 +1429,8 @@
       "name_it": "Ring of Taal",
       "name_pl": "Ring of Taal",
       "points": 20,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Das Silberhorn",
@@ -1314,7 +1440,8 @@
       "name_it": "The Argento Horn",
       "name_pl": "Srebrny Róg",
       "points": 15,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Eisenschleier",
@@ -1324,7 +1451,8 @@
       "name_it": "Shroud of Iron",
       "name_pl": "Żelazny Całun",
       "points": 10,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Buch von Ashur",
@@ -1334,7 +1462,8 @@
       "name_it": "Libro of Ashur",
       "name_pl": "Księga Ashura",
       "points": 85,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Zweischweifiger Stab",
@@ -1344,7 +1473,8 @@
       "name_it": "Twin-Tailed Wand",
       "name_pl": "Twin-Tailed Wand",
       "points": 40,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Homunkulus des Zauberers*",
@@ -1355,7 +1485,8 @@
       "name_pl": "Chowaniec Czarodzieja*",
       "points": 35,
       "stackable": true,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Mitternachtsfoliant",
@@ -1365,7 +1496,8 @@
       "name_it": "Tome of Midnight",
       "name_pl": "Tome of Midnight",
       "points": 30,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Magierstab*",
@@ -1376,7 +1508,8 @@
       "name_pl": "Kostur Czarodzieja*",
       "points": 20,
       "stackable": true,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Kristallkugel",
@@ -1386,7 +1519,8 @@
       "name_it": "Crystal Ball",
       "name_pl": "Crystal Ball",
       "points": 20,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     }
   ],
   "dwarfen-mountain-holds": [
@@ -1398,7 +1532,8 @@
       "name_it": "Master Rune of Smiting",
       "name_pl": "Mistrzowska Runa Porażenia",
       "points": 75,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "onePerArmy": true
     },
     {
       "name_de": "Skalf Schwarzhammers Meisterrune",
@@ -1408,7 +1543,8 @@
       "name_it": "Master Rune of Skalf Blackhammer",
       "name_pl": "Mistrzowska Runa Skalfa Czarnego Młota",
       "points": 65,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "onePerArmy": true
     },
     {
       "name_de": "Alaric Wirrkopfs Meisterrune",
@@ -1418,7 +1554,8 @@
       "name_it": "Master Rune of Alaric the Mad",
       "name_pl": "Mistrzowska Runa Alarica Szalonego",
       "points": 45,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "onePerArmy": true
     },
     {
       "name_de": "Meisterrune des Drachentötens",
@@ -1428,7 +1565,8 @@
       "name_it": "Master Rune of Drago Slaying",
       "name_pl": "Mistrzowska Runa Smokobójstwa",
       "points": 35,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "onePerArmy": true
     },
     {
       "name_de": "Meisterrune der Flugkraft",
@@ -1437,7 +1575,8 @@
       "name_fr": "Rune Majeure de Vol",
       "name_it": "Master Rune of Flight",
       "points": 25,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "onePerArmy": true
     },
     {
       "name_de": "Meisterrune der Flinkheit",
@@ -1446,7 +1585,8 @@
       "name_fr": "Rune Majeure de Rapidité",
       "name_it": "Master Rune of Swiftness",
       "points": 25,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "onePerArmy": true
     },
     {
       "name_de": "Artefaktbrechende Meisterrune",
@@ -1455,7 +1595,8 @@
       "name_fr": "Rune Majeure Brisante",
       "name_it": "Master Rune of Breaking",
       "points": 25,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "onePerArmy": true
     },
     {
       "name_de": "Paraderune",
@@ -1464,7 +1605,8 @@
       "name_fr": "Rune de Parade",
       "name_it": "Rune of Parrying",
       "points": 35,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "onePerArmy": false
     },
     {
       "name_de": "Bannrune",
@@ -1473,7 +1615,8 @@
       "name_fr": "Rune de Bannissement",
       "name_it": "Rune of Banishment",
       "points": 25,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "onePerArmy": false
     },
     {
       "maximum": 3,
@@ -1485,7 +1628,8 @@
       "name_it": "Rune of Fury*",
       "points": 25,
       "stackable": true,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "onePerArmy": false
     },
     {
       "maximum": 3,
@@ -1497,7 +1641,8 @@
       "name_it": "Grudge Rune*",
       "points": 20,
       "stackable": true,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "onePerArmy": false
     },
     {
       "maximum": 3,
@@ -1509,7 +1654,8 @@
       "name_it": "Rune of Might*",
       "points": 20,
       "stackable": true,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "onePerArmy": false
     },
     {
       "maximum": 3,
@@ -1521,7 +1667,8 @@
       "name_it": "Rune of Cleaving*",
       "points": 15,
       "stackable": true,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "onePerArmy": false
     },
     {
       "maximum": 3,
@@ -1533,7 +1680,8 @@
       "name_it": "Rune of Striking*",
       "points": 15,
       "stackable": true,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "onePerArmy": false
     },
     {
       "name_de": "Feuerrune",
@@ -1542,7 +1690,8 @@
       "name_fr": "Rune de Feu",
       "name_it": "Rune of Fuoco",
       "points": 10,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "onePerArmy": false
     },
     {
       "maximum": 3,
@@ -1554,63 +1703,72 @@
       "name_it": "Rune of Speed*",
       "points": 5,
       "stackable": true,
-      "type": "weapon-runes"
+      "type": "weapon-runes",
+      "onePerArmy": false
     },
     {
       "name_en": "Master Rune of Slaying",
       "name_cn": "大师级屠戮符文",
       "points": 50,
       "type": "ranged-weapon-runes",
-      "name_fr": "Rune Majeure de Tuerie"
+      "name_fr": "Rune Majeure de Tuerie",
+      "onePerArmy": true
     },
     {
       "name_en": "Master Rune of Piercing",
       "name_cn": "大师级穿透符文",
       "points": 40,
       "type": "ranged-weapon-runes",
-      "name_fr": "Rune Majeure de Perforation"
+      "name_fr": "Rune Majeure de Perforation",
+      "onePerArmy": true
     },
     {
       "name_en": "Master Rune of Bursting Flame",
       "name_cn": "大师级爆燃符文",
       "points": 35,
       "type": "ranged-weapon-runes",
-      "name_fr": "Rune Majeure d'Embrasement"
+      "name_fr": "Rune Majeure d'Embrasement",
+      "onePerArmy": true
     },
     {
       "name_en": "Rune of Concussive Force",
       "name_cn": "震荡符文",
       "points": 30,
       "type": "ranged-weapon-runes",
-      "name_fr": "Rune de Force Percutante"
+      "name_fr": "Rune de Force Percutante",
+      "onePerArmy": false
     },
     {
       "name_en": "Rune of Accuracy",
       "name_cn": "精准符文",
       "points": 20,
       "type": "ranged-weapon-runes",
-      "name_fr": "Rune de Précision"
+      "name_fr": "Rune de Précision",
+      "onePerArmy": false
     },
     {
       "name_en": "Rune of Rapid Fire",
       "name_cn": "速射符文",
       "points": 15,
       "type": "ranged-weapon-runes",
-      "name_fr": "Rune de Tir Rapide"
+      "name_fr": "Rune de Tir Rapide",
+      "onePerArmy": false
     },
     {
       "name_en": "Rune of Molten Steel",
       "name_cn": "熔钢符文",
       "points": 10,
       "type": "ranged-weapon-runes",
-      "name_fr": "Rune d'Acier en Fusion"
+      "name_fr": "Rune d'Acier en Fusion",
+      "onePerArmy": false
     },
     {
       "name_en": "Enchanted Rune",
       "name_cn": "附魔符文",
       "points": 5,
       "type": "ranged-weapon-runes",
-      "name_fr": "Rune Enchantée"
+      "name_fr": "Rune Enchantée",
+      "onePerArmy": false
     },
     {
       "name_de": "Adamant-Meisterrune",
@@ -1620,7 +1778,8 @@
       "name_it": "Master Rune of Adamant",
       "points": 100,
       "type": "armor-runes",
-      "nonExclusive": false
+      "nonExclusive": false,
+      "onePerArmy": true
     },
     {
       "name_de": "Gromril-Meisterrune",
@@ -1629,7 +1788,8 @@
       "name_fr": "Rune Majeure de Gromril",
       "name_it": "Master Rune of Gromril",
       "points": 45,
-      "type": "armor-runes"
+      "type": "armor-runes",
+      "onePerArmy": true
     },
     {
       "name_de": "Eisenrune",
@@ -1638,7 +1798,8 @@
       "name_fr": "Rune de Fer",
       "name_it": "Rune of Iron",
       "points": 35,
-      "type": "armor-runes"
+      "type": "armor-runes",
+      "onePerArmy": false
     },
     {
       "maximum": 3,
@@ -1650,7 +1811,8 @@
       "name_it": "Rune of Fortitude*",
       "points": 30,
       "stackable": true,
-      "type": "armor-runes"
+      "type": "armor-runes",
+      "onePerArmy": false
     },
     {
       "name_de": "Unverwundbarkeitsrune",
@@ -1659,7 +1821,8 @@
       "name_fr": "Rune de Préservation",
       "name_it": "Rune of Preservation",
       "points": 25,
-      "type": "armor-runes"
+      "type": "armor-runes",
+      "onePerArmy": false
     },
     {
       "maximum": 3,
@@ -1671,7 +1834,8 @@
       "name_it": "Rune of Shielding*",
       "points": 15,
       "stackable": true,
-      "type": "armor-runes"
+      "type": "armor-runes",
+      "onePerArmy": false
     },
     {
       "maximum": 3,
@@ -1683,7 +1847,8 @@
       "name_it": "Rune of Stone*",
       "points": 5,
       "stackable": true,
-      "type": "armor-runes"
+      "type": "armor-runes",
+      "onePerArmy": false
     },
     {
       "name_de": "Meisterrune der Flaute",
@@ -1692,7 +1857,8 @@
       "name_fr": "Rune Majeure de Calme",
       "name_it": "Master Rune of Calm",
       "points": 50,
-      "type": "talismanic-runes"
+      "type": "talismanic-runes",
+      "onePerArmy": true
     },
     {
       "name_de": "Meisterrune des Ausgleichs",
@@ -1701,7 +1867,8 @@
       "name_fr": "Rune Majeure d'Équilibre",
       "name_it": "Master Rune of Balance",
       "points": 35,
-      "type": "talismanic-runes"
+      "type": "talismanic-runes",
+      "onePerArmy": true
     },
     {
       "name_de": "Meisterrune des Trotzes",
@@ -1710,7 +1877,8 @@
       "name_fr": "Rune Majeure d'Insulte",
       "name_it": "Master Rune of Spite",
       "points": 35,
-      "type": "talismanic-runes"
+      "type": "talismanic-runes",
+      "onePerArmy": true
     },
     {
       "maximum": 3,
@@ -1722,7 +1890,8 @@
       "name_it": "Rune of Spellbreaking*",
       "points": 25,
       "stackable": true,
-      "type": "talismanic-runes"
+      "type": "talismanic-runes",
+      "onePerArmy": false
     },
     {
       "maximum": 3,
@@ -1734,7 +1903,8 @@
       "name_it": "Rune of Warding*",
       "points": 20,
       "stackable": true,
-      "type": "talismanic-runes"
+      "type": "talismanic-runes",
+      "onePerArmy": false
     },
     {
       "maximum": 3,
@@ -1746,7 +1916,8 @@
       "name_it": "Rune of Luck*",
       "points": 15,
       "stackable": true,
-      "type": "talismanic-runes"
+      "type": "talismanic-runes",
+      "onePerArmy": false
     },
     {
       "name_de": "Schmiedefeuerrune",
@@ -1755,7 +1926,8 @@
       "name_fr": "Rune du Fourneau",
       "name_it": "Rune of the Furnace",
       "points": 5,
-      "type": "talismanic-runes"
+      "type": "talismanic-runes",
+      "onePerArmy": false
     },
     {
       "name_de": "Rune der Wege",
@@ -1764,7 +1936,8 @@
       "name_fr": "Rune de Passage",
       "name_it": "Rune of Passage",
       "points": 5,
-      "type": "talismanic-runes"
+      "type": "talismanic-runes",
+      "onePerArmy": false
     },
     {
       "name_de": "Grungnis Meisterrune",
@@ -1773,7 +1946,8 @@
       "name_fr": "Rune Majeure de Grungni",
       "name_it": "Master Rune of Grungni",
       "points": 80,
-      "type": "banner-runes"
+      "type": "banner-runes",
+      "onePerArmy": true
     },
     {
       "name_de": "Stromni Rotbarts Meisterrune",
@@ -1782,7 +1956,8 @@
       "name_fr": "Rune Majeure de Stomni Barberouge",
       "name_it": "Master Rune of Stromni Redbeard",
       "points": 75,
-      "type": "banner-runes"
+      "type": "banner-runes",
+      "onePerArmy": true
     },
     {
       "name_de": "Meisterrune des Zögerns",
@@ -1791,7 +1966,8 @@
       "name_fr": "Rune Majeure d'Hésitation",
       "name_it": "Master Rune of Hesitation",
       "points": 45,
-      "type": "banner-runes"
+      "type": "banner-runes",
+      "onePerArmy": true
     },
     {
       "name_de": "Rune der Unordnung",
@@ -1800,7 +1976,8 @@
       "name_fr": "Rune de Confusion",
       "name_it": "Rune of Confusion",
       "points": 35,
-      "type": "banner-runes"
+      "type": "banner-runes",
+      "onePerArmy": false
     },
     {
       "name_de": "Angstrune",
@@ -1809,7 +1986,8 @@
       "name_fr": "Rune de Peur",
       "name_it": "Rune of Fear",
       "points": 30,
-      "type": "banner-runes"
+      "type": "banner-runes",
+      "onePerArmy": false
     },
     {
       "name_de": "Kampfrune",
@@ -1818,7 +1996,8 @@
       "name_fr": "Rune de Bataille",
       "name_it": "Rune of Battaglia",
       "points": 25,
-      "type": "banner-runes"
+      "type": "banner-runes",
+      "onePerArmy": false
     },
     {
       "name_de": "Marschrune",
@@ -1827,7 +2006,8 @@
       "name_fr": "Rune de Strollaz",
       "name_it": "Strollaz' Rune",
       "points": 25,
-      "type": "banner-runes"
+      "type": "banner-runes",
+      "onePerArmy": false
     },
     {
       "name_de": "Mutrune",
@@ -1836,7 +2016,8 @@
       "name_fr": "Rune de Courage",
       "name_it": "Rune of Courage",
       "points": 15,
-      "type": "banner-runes"
+      "type": "banner-runes",
+      "onePerArmy": false
     },
     {
       "name_de": "Meisterrune der Opferung",
@@ -1845,7 +2026,8 @@
       "name_fr": "Rune Majeure d'Immolation",
       "name_it": "Master Rune of Immolation",
       "points": 30,
-      "type": "engineering-runes"
+      "type": "engineering-runes",
+      "onePerArmy": true
     },
     {
       "name_de": "Meisterrune der Tarnung",
@@ -1854,7 +2036,8 @@
       "name_fr": "Rune Majeure de Camouflage",
       "name_it": "Master Rune of Disguise",
       "points": 25,
-      "type": "engineering-runes"
+      "type": "engineering-runes",
+      "onePerArmy": true
     },
     {
       "name_de": "Rune des Durchbohrens",
@@ -1863,7 +2046,8 @@
       "name_fr": "Rune de Pénétration",
       "name_it": "Rune of Skewering",
       "points": 20,
-      "type": "engineering-runes"
+      "type": "engineering-runes",
+      "onePerArmy": false
     },
     {
       "maximum": 3,
@@ -1875,7 +2059,8 @@
       "name_it": "Rune of Forging*",
       "points": 15,
       "stackable": true,
-      "type": "engineering-runes"
+      "type": "engineering-runes",
+      "onePerArmy": false
     },
     {
       "name_de": "Brandrune",
@@ -1884,7 +2069,8 @@
       "name_fr": "Rune d'Incanescence",
       "name_it": "Rune of Burning",
       "points": 10,
-      "type": "engineering-runes"
+      "type": "engineering-runes",
+      "onePerArmy": false
     },
     {
       "name_de": "Rune des Nachladens",
@@ -1893,7 +2079,8 @@
       "name_fr": "Rune de Rechargement",
       "name_it": "Rune of Reloading",
       "points": 5,
-      "type": "engineering-runes"
+      "type": "engineering-runes",
+      "onePerArmy": false
     },
     {
       "name_de": "Rune der Standhaftigkeit",
@@ -1902,7 +2089,8 @@
       "name_fr": "Rune d'Obstination",
       "name_it": "Stalwart Rune",
       "points": 5,
-      "type": "engineering-runes"
+      "type": "engineering-runes",
+      "onePerArmy": false
     },
     {
       "name_en": "Rune of the Dishonoured",
@@ -1910,7 +2098,8 @@
       "points": 50,
       "type": "runic-tattoos",
       "nonExclusive": true,
-      "name_fr": "Rune du Déshonoré"
+      "name_fr": "Rune du Déshonoré",
+      "onePerArmy": false
     },
     {
       "name_en": "Rune of Endless Battle",
@@ -1918,7 +2107,8 @@
       "points": 40,
       "type": "runic-tattoos",
       "nonExclusive": true,
-      "name_fr": "Rune des Batailles Éternelles"
+      "name_fr": "Rune des Batailles Éternelles",
+      "onePerArmy": false
     },
     {
       "name_en": "Rune of the Reckless",
@@ -1926,7 +2116,8 @@
       "points": 35,
       "type": "runic-tattoos",
       "nonExclusive": true,
-      "name_fr": "Rune du Téméraire"
+      "name_fr": "Rune du Téméraire",
+      "onePerArmy": false
     },
     {
       "name_en": "Rune of the Hateful",
@@ -1934,7 +2125,8 @@
       "points": 30,
       "type": "runic-tattoos",
       "nonExclusive": true,
-      "name_fr": "Rune du Haineux"
+      "name_fr": "Rune du Haineux",
+      "onePerArmy": false
     },
     {
       "name_en": "Rune of Grit",
@@ -1942,7 +2134,8 @@
       "points": 25,
       "type": "runic-tattoos",
       "nonExclusive": true,
-      "name_fr": "Rune de Granit"
+      "name_fr": "Rune de Granit",
+      "onePerArmy": false
     },
     {
       "name_en": "Rune of the Dauntless",
@@ -1950,7 +2143,8 @@
       "points": 15,
       "type": "runic-tattoos",
       "nonExclusive": true,
-      "name_fr": "Rune de l'Intrépide"
+      "name_fr": "Rune de l'Intrépide",
+      "onePerArmy": false
     },
     {
       "name_en": "Rune of Wrath",
@@ -1958,7 +2152,8 @@
       "points": 15,
       "type": "runic-tattoos",
       "nonExclusive": true,
-      "name_fr": "Rune de Rage"
+      "name_fr": "Rune de Rage",
+      "onePerArmy": false
     },
     {
       "name_en": "Warrior's Rune",
@@ -1966,7 +2161,8 @@
       "points": 10,
       "type": "runic-tattoos",
       "nonExclusive": true,
-      "name_fr": "Rune du Guerrier"
+      "name_fr": "Rune du Guerrier",
+      "onePerArmy": false
     },
     {
       "name_en": "Rune of Blazing Fury",
@@ -1974,7 +2170,8 @@
       "points": 5,
       "type": "runic-tattoos",
       "nonExclusive": true,
-      "name_fr": "Rune de Fureur Incandescente"
+      "name_fr": "Rune de Fureur Incandescente",
+      "onePerArmy": false
     }
   ],
   "orc-and-goblin-tribes": [
@@ -1985,7 +2182,8 @@
       "name_fr": "Hache de la Der des Der",
       "name_it": "Battleaxe of the last big Waaagh!",
       "points": 75,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Größere, schärfere Axt",
@@ -1993,7 +2191,8 @@
       "name_cn": "更大, 更利的战斧",
       "name_fr": "Grosse Hache Ki Koup' Pluss",
       "points": 55,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Martogs bester Kloppa",
@@ -2001,7 +2200,8 @@
       "name_cn": "玛特格的绝赞猛击",
       "name_fr": "Cogneur Trop Klass' de Martog",
       "points": 50,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Porkos Pieksa",
@@ -2010,7 +2210,8 @@
       "name_fr": "Pik'goret de Porko",
       "name_it": "Porko's Pigstikka",
       "points": 40,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Der spaltigste Spalta",
@@ -2019,7 +2220,8 @@
       "name_fr": "Kikoup' Ki Koupe",
       "name_it": "Da Choppiest Choppa",
       "points": 35,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Da beißende Axt.",
@@ -2027,7 +2229,8 @@
       "name_cn": "合金战斧",
       "name_fr": "La Hache Préciz'",
       "points": 30,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Klinge des Verräters*",
@@ -2036,7 +2239,8 @@
       "name_fr": "Lame du Traître*",
       "points": 25,
       "stackable": true,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": false
     },
     {
       "name_de": "Wollopas Einwegwunda",
@@ -2045,7 +2249,8 @@
       "name_fr": "Tap'K'un Koup de Wollopa",
       "name_it": "Wollopa's One Hit Wunda",
       "points": 15,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Trollhauthose*",
@@ -2055,7 +2260,8 @@
       "name_it": "Trollhide Trousers*",
       "points": 40,
       "stackable": true,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": false
     },
     {
       "name_de": "Knallharte Rüstung",
@@ -2063,7 +2269,8 @@
       "name_cn": "死硬盔甲",
       "name_fr": "Armure Très Durze",
       "points": 35,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Morks Rüstung",
@@ -2072,7 +2279,8 @@
       "name_fr": "Armure de Mork",
       "name_it": "Armour of Mork",
       "points": 30,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Rachsüchtiger Schild",
@@ -2080,7 +2288,8 @@
       "name_cn": "恶毒盾牌",
       "name_fr": "Bouclier Rancunier",
       "points": 20,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Glänzender Zaubererfinda",
@@ -2088,7 +2297,8 @@
       "name_cn": "闪亮巫师搜寻器",
       "name_fr": "Trouve-Mage Scintillant",
       "points": 45,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Götzenbild des Mork",
@@ -2096,7 +2306,8 @@
       "name_cn": "毛哥小神像",
       "name_fr": "Effigie de Mork",
       "points": 35,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Glühendes grünes Amulett",
@@ -2105,7 +2316,8 @@
       "name_fr": "Amulette Verte Luisante",
       "name_it": "Glowy Green Amuleto",
       "points": 35,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Zorgas Halsband",
@@ -2114,7 +2326,8 @@
       "name_fr": "Le Collier de Zorga",
       "name_it": "The Collar of Zorga",
       "points": 20,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Die große rot Lump'nflagge",
@@ -2123,7 +2336,8 @@
       "name_fr": "Le Grand Drapeau Rouj'",
       "name_it": "The Big Red Raggedy Flag",
       "points": 50,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Waaaghbanna",
@@ -2132,7 +2346,8 @@
       "name_fr": "Bannière Waaagh!",
       "name_it": "Waaagh! Banner",
       "points": 40,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Da Flagge der wütenden Jungs",
@@ -2140,7 +2355,8 @@
       "name_cn": "愤怒小子旗",
       "name_fr": "L'Drapeau des Gars Zenragés",
       "points": 35,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Da Spinnenbanner",
@@ -2148,7 +2364,8 @@
       "name_cn": "蜘蛛旗",
       "name_fr": "La Bannière Araignée",
       "points": 35,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Das Moschige Banna",
@@ -2157,7 +2374,8 @@
       "name_fr": "La Bannière du Karnaj'",
       "name_it": "Da Banner of Butchery",
       "points": 35,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Da Banner der Nomad'n",
@@ -2165,7 +2383,8 @@
       "name_cn": "游牧旗",
       "name_fr": "La Bannière des Nomadz",
       "points": 25,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner der Wildnis",
@@ -2173,7 +2392,8 @@
       "name_cn": "旷野旗",
       "name_fr": "Bannière des Terres Sauvaj'",
       "points": 20,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Guffs Flattabanna",
@@ -2182,7 +2402,8 @@
       "name_fr": "Bannière Venteuse de Guff",
       "name_it": "Guff's Windy Banner",
       "points": 20,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Halskette der gesegneten Zähne",
@@ -2190,7 +2411,8 @@
       "name_cn": "受祝大牙项链",
       "name_fr": "Collier de Dents Bénies",
       "points": 50,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Gargbosshut",
@@ -2199,7 +2421,8 @@
       "name_fr": "Casque eud' Chef",
       "name_it": "Big Boss 'At",
       "points": 50,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Grausige Trophäenstange",
@@ -2207,7 +2430,8 @@
       "name_cn": "吓人战利品架",
       "name_fr": "Râtelier à Trophées Macabres",
       "points": 30,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Die Kappe des denkenden Orks",
@@ -2215,7 +2439,8 @@
       "name_cn": "寻思帽.",
       "name_fr": "L'Chapeau d'Intello",
       "points": 25,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Koppnusshut*",
@@ -2226,7 +2451,8 @@
       "points": 15,
       "maximum": 1,
       "stackable": true,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Pilzwein*",
@@ -2236,7 +2462,8 @@
       "name_it": "Fungus Wine*",
       "points": 10,
       "stackable": true,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Stab des Babumm",
@@ -2244,7 +2471,8 @@
       "name_cn": "巴杜姆法杖",
       "name_fr": "Bâton de Badoumm",
       "points": 55,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Idol des Gork ",
@@ -2252,7 +2480,8 @@
       "name_cn": "搞哥雕像",
       "name_fr": "Idole de Gork",
       "points": 40,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Glitzernde Dingsdas",
@@ -2261,7 +2490,8 @@
       "name_fr": "Babiol' ki Brillent",
       "name_it": "Glittering Wotnots",
       "points": 40,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Buzgobs knorriger Stab",
@@ -2270,7 +2500,8 @@
       "name_fr": "Bâton Zarbi de Buzgob",
       "name_it": "Buzgob's Knobbly Bastone",
       "points": 35,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Götzenbild des Mork",
@@ -2279,7 +2510,8 @@
       "name_fr": "Idole de Mork",
       "name_it": "Idol of Mork",
       "points": 30,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Da Hexenbräu",
@@ -2287,7 +2519,8 @@
       "name_cn": "巫婆灵药",
       "name_fr": "L'Breuvage d'la Mégère",
       "points": 25,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     }
   ],
   "beastmen-brayherds": [
@@ -2298,7 +2531,8 @@
       "name_fr": "La Masse Noire",
       "name_it": "The Black Maul",
       "points": 80,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Primeval Club",
@@ -2307,7 +2541,8 @@
       "name_fr": "Massue Primordiale",
       "name_it": "Primeval Club",
       "points": 60,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Axe of Men",
@@ -2316,7 +2551,8 @@
       "name_fr": "Hache des Hommes",
       "name_it": "Axe of Men",
       "points": 50,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Mangelder",
@@ -2325,7 +2561,8 @@
       "name_fr": "Émasculateur",
       "name_it": "Mangelder",
       "points": 40,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "The Axes of Khorgor",
@@ -2334,7 +2571,8 @@
       "name_fr": "Les Haches de Khorgor",
       "name_it": "The Axes of Khorgor",
       "points": 40,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Hunter's Spear",
@@ -2343,7 +2581,8 @@
       "name_fr": "Lance du Chasseur",
       "name_it": "Hunter's Spear",
       "points": 35,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "The Brass Cleaver",
@@ -2352,7 +2591,8 @@
       "name_fr": "Le Hachoir d'Airain",
       "name_it": "The Brass Cleaver",
       "points": 30,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Scimitar of Skultar",
@@ -2361,7 +2601,8 @@
       "name_fr": "Cimeterre de Skultar",
       "name_it": "Scimitar of Skultar",
       "points": 25,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Pelt of the Dark Young",
@@ -2370,7 +2611,8 @@
       "name_fr": "Pelisse de l'Enfant Noir",
       "name_it": "Pelt of the Oscuro Young",
       "points": 40,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Full Plate Chaos Armour*",
@@ -2381,7 +2623,8 @@
       "points": 40,
       "stackable": true,
       "maximum": 1,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": false
     },
     {
       "name_de": "Heavy Chaos Armour*",
@@ -2392,7 +2635,8 @@
       "points": 30,
       "stackable": true,
       "maximum": 1,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": false
     },
     {
       "name_de": "The Blackened Plate",
@@ -2401,7 +2645,8 @@
       "name_fr": "L'Armure Noircie",
       "name_it": "The Blackened Plate",
       "points": 25,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "The Fur of Sharggu",
@@ -2411,7 +2656,8 @@
       "name_it": "The Fur of Sharggu",
       "points": 20,
       "nonExclusive": true,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Full Plate Chaos Armour*",
@@ -2422,7 +2668,8 @@
       "points": 40,
       "stackable": true,
       "maximum": 1,
-      "type": "armor-mages"
+      "type": "armor-mages",
+      "onePerArmy": false
     },
     {
       "name_de": "Heavy Chaos Armour*",
@@ -2433,7 +2680,8 @@
       "points": 30,
       "stackable": true,
       "maximum": 1,
-      "type": "armor-mages"
+      "type": "armor-mages",
+      "onePerArmy": false
     },
     {
       "name_de": "Chalice of Dark Rain",
@@ -2442,7 +2690,8 @@
       "name_fr": "Calice d'Averse Fuligineuse",
       "name_it": "Chalice of Dark Rain",
       "points": 50,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Rune of the True Beast",
@@ -2451,7 +2700,8 @@
       "name_fr": "Rune de la Vraie Bête",
       "name_it": "Rune of the True Beast",
       "points": 30,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Cornucopia of Corpulence",
@@ -2460,7 +2710,8 @@
       "name_fr": "Corne de Corpulence",
       "name_it": "Cornucopia of Corpulence",
       "points": 30,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Dark Heart*",
@@ -2470,7 +2721,8 @@
       "name_it": "Oscuro Heart*",
       "points": 25,
       "stackable": true,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": false
     },
     {
       "name_de": "Totem of Rust",
@@ -2479,7 +2731,8 @@
       "name_fr": "Totem de Rouille",
       "name_it": "Totem of Rust",
       "points": 50,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "The Gore Banner",
@@ -2488,7 +2741,8 @@
       "name_fr": "La Bannière Sanglante",
       "name_it": "The Gore Banner",
       "points": 50,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner of the Warped Moon",
@@ -2497,7 +2751,8 @@
       "name_fr": "Bannière de la Lune Difforme",
       "name_it": "Banner of the Warped Moon",
       "points": 45,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Manbane Standard",
@@ -2506,7 +2761,8 @@
       "name_fr": "Le Fléau des Hommes",
       "name_it": "Manbane Standard",
       "points": 40,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "The Beast Banner",
@@ -2515,7 +2771,8 @@
       "name_fr": "La Bannière Bestiale",
       "name_it": "The Beast Banner",
       "points": 40,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Vitriolic Totem",
@@ -2524,7 +2781,8 @@
       "name_fr": "Totem Vitriol",
       "name_it": "Vitriolic Totem",
       "points": 30,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner of Outrage",
@@ -2533,7 +2791,8 @@
       "name_fr": "Bannière de l'Outrage",
       "name_it": "Banner of Outrage",
       "points": 25,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "The Soiled Tapestry",
@@ -2542,7 +2801,8 @@
       "name_fr": "La Tapisserie Souillée",
       "name_it": "The Soiled Tapestry",
       "points": 15,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Stone of Spite",
@@ -2551,7 +2811,8 @@
       "name_fr": "Pierre de Rancœur",
       "name_it": "Stone of Spite",
       "points": 45,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Horn of the Great Hunt",
@@ -2560,7 +2821,8 @@
       "name_fr": "Cor de la Grande Chasse",
       "name_it": "Horn of the Great Hunt",
       "points": 35,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Horn of the First Beast",
@@ -2569,7 +2831,8 @@
       "name_fr": "Cor de la Première Bête",
       "name_it": "Horn of the First Beast",
       "points": 30,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Scourge of the Burdened",
@@ -2578,7 +2841,8 @@
       "name_fr": "Fléau des Accablés",
       "name_it": "Scourge of the Burdened",
       "points": 25,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Skin of Man",
@@ -2587,7 +2851,8 @@
       "name_fr": "Peau d'Homme",
       "name_it": "Skin of Man",
       "points": 15,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Cacophonous Dirge",
@@ -2596,7 +2861,8 @@
       "name_fr": "Complainte Cacophonique",
       "name_it": "Cacophonous Dirge",
       "points": 15,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "The Plague Chalice",
@@ -2605,7 +2871,8 @@
       "name_fr": "Le Calice Pestilentiel",
       "name_it": "The Plague Chalice",
       "points": 40,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Blood of the Shadowgave*",
@@ -2615,7 +2882,8 @@
       "name_it": "Blood of the Shadowgave*",
       "points": 35,
       "stackable": true,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Hagtree Fetish",
@@ -2624,7 +2892,8 @@
       "name_fr": "Fétiche d'Arbres aux Pendus",
       "name_it": "Hagtree Fetish",
       "points": 30,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Daemon Heart",
@@ -2633,7 +2902,8 @@
       "name_fr": "Cœur de Démon",
       "name_it": "Daemon Heart",
       "points": 30,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Jagged Dagger",
@@ -2642,7 +2912,8 @@
       "name_fr": "Dague Dentelée",
       "name_it": "Jagged Dagger",
       "points": 15,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Goretooth*",
@@ -2652,7 +2923,8 @@
       "name_it": "Goretooth*",
       "points": 15,
       "stackable": true,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     }
   ],
   "forest-spites": [
@@ -2664,7 +2936,8 @@
       "name_it": "A Blight of Terrors",
       "nonExclusive": true,
       "points": 50,
-      "type": "forest-spite"
+      "type": "forest-spite",
+      "onePerArmy": true
     },
     {
       "name_de": "Giftfeen",
@@ -2674,7 +2947,8 @@
       "name_it": "A Muster of Malevolents",
       "nonExclusive": true,
       "points": 40,
-      "type": "forest-spite"
+      "type": "forest-spite",
+      "onePerArmy": true
     },
     {
       "name_de": "Wirrlichter",
@@ -2684,7 +2958,8 @@
       "name_it": "A Befuddlement of Mischiefs",
       "nonExclusive": true,
       "points": 30,
-      "type": "forest-spite"
+      "type": "forest-spite",
+      "onePerArmy": true
     },
     {
       "name_de": "Blutfeen",
@@ -2694,7 +2969,8 @@
       "name_it": "A Murder of Spites",
       "nonExclusive": true,
       "points": 25,
-      "type": "forest-spite"
+      "type": "forest-spite",
+      "onePerArmy": true
     },
     {
       "name_de": "Schicksalsschwestern",
@@ -2704,7 +2980,8 @@
       "name_it": "A Lamentation of Despairs",
       "nonExclusive": true,
       "points": 20,
-      "type": "forest-spite"
+      "type": "forest-spite",
+      "onePerArmy": true
     },
     {
       "name_de": "Spinnlinge",
@@ -2714,7 +2991,8 @@
       "name_it": "An Annoyance of Netlings",
       "nonExclusive": true,
       "points": 15,
-      "type": "forest-spite"
+      "type": "forest-spite",
+      "onePerArmy": true
     },
     {
       "name_de": "Flimmerlichter",
@@ -2724,7 +3002,8 @@
       "name_it": "A Resplendence of Luminescents",
       "nonExclusive": true,
       "points": 10,
-      "type": "forest-spite"
+      "type": "forest-spite",
+      "onePerArmy": true
     }
   ],
   "tomb-kings-of-khemri": [
@@ -2735,7 +3014,8 @@
       "name_fr": "Destructeur d'Éternité",
       "name_it": "Destroyer of Eternities",
       "points": 75,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Insignien der Macht",
@@ -2744,7 +3024,8 @@
       "name_fr": "Crosse & Flagellum de Majesté",
       "name_it": "Crook & Flail of Radiance",
       "points": 50,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Schädelflegel",
@@ -2753,7 +3034,8 @@
       "name_fr": "Fléau de Crânes",
       "name_it": "Flail of Skulls",
       "points": 35,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Schlangenstab",
@@ -2762,7 +3044,8 @@
       "name_fr": "Bâton Serpent",
       "name_it": "Serpent Bastone",
       "points": 20,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "armyComposition": "nehekharan-royal-hosts",
@@ -2772,7 +3055,8 @@
       "name_fr": "Lame d'Antharak",
       "name_it": "Lama of Antarhak",
       "points": 45,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Die Klinge des Eroberers",
@@ -2781,7 +3065,8 @@
       "name_fr": "La Lame du Conquérant",
       "name_it": "The Conqueror's Lama",
       "points": 55,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Phakths Klingen der Gerechtigkeit",
@@ -2790,7 +3075,8 @@
       "name_fr": "Lames de Justice de Phakth",
       "name_it": "Phakth's Blades of Justice",
       "points": 35,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "armyComposition": "mortuary-cults",
@@ -2800,7 +3086,8 @@
       "name_fr": "Bâton des Éons",
       "name_it": "Bastone of Aeons",
       "points": 30,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Rüstung der Zeitalter",
@@ -2809,7 +3096,8 @@
       "name_fr": "Armure des Âges",
       "name_it": "Armour of the Ages",
       "points": 50,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "armyComposition": "nehekharan-royal-hosts",
@@ -2819,7 +3107,8 @@
       "name_fr": "Manteau Royal",
       "name_it": "Royal Mantle",
       "points": 40,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Schützende Schiene",
@@ -2828,7 +3117,8 @@
       "name_fr": "Éclisse Protectrice",
       "name_it": "Warding Splint",
       "points": 35,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Schild des Ptra",
@@ -2837,7 +3127,8 @@
       "name_fr": "Bouclier de Ptra",
       "name_it": "Scudo of Ptra",
       "points": 25,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Schützende Schiene",
@@ -2846,7 +3137,8 @@
       "name_fr": "Éclisse Protectrice",
       "name_it": "Warding Splint",
       "points": 35,
-      "type": "armor-mages"
+      "type": "armor-mages",
+      "onePerArmy": true
     },
     {
       "name_de": "Krone der Könige*",
@@ -2856,7 +3148,8 @@
       "name_it": "Crown of Kings*",
       "points": 30,
       "stackable": true,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": false
     },
     {
       "name_de": "Kragen des Shapesh",
@@ -2865,7 +3158,8 @@
       "name_fr": "Collier de Shapesh",
       "name_it": "Collar of Shapesh",
       "points": 25,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Amulett der Schlange",
@@ -2874,7 +3168,8 @@
       "name_fr": "Amulette du Serpent",
       "name_it": "Amuleto of the Serpent",
       "points": 30,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Reliquie der Wüstensonne",
@@ -2883,7 +3178,8 @@
       "name_fr": "Relique du Soleil du Désert",
       "name_it": "Relic of the Desert Sun",
       "points": 25,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner der Verfluchung",
@@ -2892,7 +3188,8 @@
       "name_fr": "Étendard de Malédiction",
       "name_it": "Standard of the Cursing Word",
       "points": 80,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Symbol des heiligen Auges",
@@ -2901,7 +3198,8 @@
       "name_fr": "Icône de l'Œil Sacré",
       "name_it": "Icon of the Sacred Eye",
       "points": 50,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Standarte des Rakaph",
@@ -2910,7 +3208,8 @@
       "name_fr": "Icône de Rakaph",
       "name_it": "Icon of Rakaph",
       "points": 40,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Trugbildbanner",
@@ -2919,7 +3218,8 @@
       "name_fr": "Bannière du Mirage",
       "name_it": "Mirage Banner",
       "points": 20,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Königliche Standarte des Settra",
@@ -2928,7 +3228,8 @@
       "name_fr": "Bannière Royale de Settra",
       "name_it": "Royal Standard of Settra",
       "points": 50,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Siegel der Jahrhunderte",
@@ -2937,7 +3238,8 @@
       "name_fr": "Icône des Siècles",
       "name_it": "Sigil of Centuries",
       "points": 45,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Gobelin der eroberten Länder",
@@ -2946,7 +3248,8 @@
       "name_fr": "Tapisserie des Terres Conquises",
       "name_it": "Tapestry of Conquered Lands",
       "points": 35,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner der Wüstenwinde",
@@ -2955,7 +3258,8 @@
       "name_fr": "Bannière des Vents du Désert",
       "name_it": "Banner of the Desert Winds",
       "points": 30,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Staubmantel",
@@ -2964,7 +3268,8 @@
       "name_fr": "Cape des Dunes",
       "name_it": "Mantello of the Dunes",
       "points": 50,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Siegeszeichen*",
@@ -2974,7 +3279,8 @@
       "name_it": "Icon of Rulership*",
       "points": 35,
       "stackable": true,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Totenmaske des Kharnutt",
@@ -2983,7 +3289,8 @@
       "name_fr": "Masque Mortuaire de Kharnutt",
       "name_it": "Death Mask of Kharnutt",
       "points": 20,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Stab des Erweckens",
@@ -2992,7 +3299,8 @@
       "name_fr": "Bâton d'Éveil",
       "name_it": "Bastone of Awakening",
       "points": 50,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Sphäre des Ptra",
@@ -3001,7 +3309,8 @@
       "name_fr": "Orbe de Ptra",
       "name_it": "Orb of Ptra",
       "points": 40,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Enkhils Kanope",
@@ -3010,7 +3319,8 @@
       "name_fr": "Canope d'Enkhil",
       "name_it": "Enkhil's Kanopi",
       "points": 30,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Urne der Anrufung*",
@@ -3020,7 +3330,8 @@
       "name_it": "Hieratic Jar*",
       "points": 25,
       "stackable": true,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Scarabäenbrosche",
@@ -3029,7 +3340,8 @@
       "name_fr": "Broche du Scarabée",
       "name_it": "Scarab Brooch",
       "points": 20,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Phâzerakts Kanope",
@@ -3038,7 +3350,8 @@
       "name_fr": "Canope de Phâzerakt",
       "name_it": "Phâzerakt's Kanopi",
       "points": 40,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Fluchweber-Zauberstab",
@@ -3047,7 +3360,8 @@
       "name_fr": "Baguette Tisse-Malheur",
       "name_it": "Curse-Weaver Bacchetta",
       "points": 20,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "maximum": 3,
@@ -3058,7 +3372,8 @@
       "name_it": "Tablets of Tahoth*",
       "points": 20,
       "stackable": true,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     }
   ],
   "warriors-of-chaos": [
@@ -3069,7 +3384,8 @@
       "name_fr": "Épée-démon",
       "name_it": "Daemonsword",
       "points": 75,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Obsidian Dread-Glaive",
@@ -3078,7 +3394,8 @@
       "name_fr": "Vouge d'Obsidienne",
       "name_it": "Obsidian Dread-Glaive",
       "points": 55,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Chaos Runesword",
@@ -3087,7 +3404,8 @@
       "name_fr": "Épée Runique du Chaos",
       "name_it": "Chaos Runesword",
       "points": 45,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Filth Mace",
@@ -3096,7 +3414,8 @@
       "name_fr": "Masse d'Infection",
       "name_it": "Filth Mace",
       "points": 40,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Dagger of the Dark Pantheon",
@@ -3105,7 +3424,8 @@
       "name_fr": "Dague du Sombre Panthéon",
       "name_it": "Dagger of the Dark Pantheon",
       "points": 35,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Chieftain's Blade",
@@ -3115,7 +3435,8 @@
       "name_it": "Chieftain's Blade",
       "points": 30,
       "type": "weapon",
-      "armyComposition": "wolves-of-the-sea"
+      "armyComposition": "wolves-of-the-sea",
+      "onePerArmy": true
     },
     {
       "name_de": "Taskmaster's Scourge",
@@ -3124,7 +3445,8 @@
       "name_fr": "Fouet du Garde-chiourme",
       "name_it": "Taskmaster's Scourge",
       "points": 25,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Spellthieving Sword",
@@ -3133,7 +3455,8 @@
       "name_fr": "Épée Voleuse de Sorts",
       "name_it": "Spellthieving Spada",
       "points": 20,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Armour of the Damned",
@@ -3142,7 +3465,8 @@
       "name_fr": "Armure des Damnés",
       "name_it": "Armour of the Damned",
       "points": 70,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Daemonic Platemail",
@@ -3151,7 +3475,8 @@
       "name_fr": "Plate Démoniaque",
       "name_it": "Daemonic Platemail",
       "points": 50,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Crimson Armour of Dargan",
@@ -3160,7 +3485,8 @@
       "name_fr": "Armure Pourpre de Dargan",
       "name_it": "Crimson Armour of Dargan",
       "points": 40,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Mighty Serpent's Scalemail",
@@ -3170,7 +3496,8 @@
       "name_it": "Mighty Serpent's Scalemail",
       "points": 40,
       "type": "armor",
-      "armyComposition": "wolves-of-the-sea"
+      "armyComposition": "wolves-of-the-sea",
+      "onePerArmy": true
     },
     {
       "name_de": "Talisman of the Carrion Crow",
@@ -3179,7 +3506,8 @@
       "name_fr": "Talisman du Corbeau Charognard",
       "name_it": "Talisman of the Carrion Crow",
       "points": 45,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Crown of Everlasting Conquest",
@@ -3188,7 +3516,8 @@
       "name_fr": "Couronne de Conquête Éternelle",
       "name_it": "Crown of Everlasting Conquest",
       "points": 40,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Talisman of the Soaring Eagle",
@@ -3197,7 +3526,8 @@
       "name_fr": "Talisman de l'Aigle",
       "name_it": "Talisman of the Soaring Eagle",
       "points": 35,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Brazen Collar*",
@@ -3207,7 +3537,8 @@
       "name_it": "Brazen Collar*",
       "points": 20,
       "stackable": true,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": false
     },
     {
       "name_de": "Banner of the Gods",
@@ -3216,7 +3547,8 @@
       "name_fr": "Bannière des Dieux",
       "name_it": "Banner of the Gods",
       "points": 75,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Doom Totem",
@@ -3225,7 +3557,8 @@
       "name_fr": "Totem Funeste",
       "name_it": "Doom Totem",
       "points": 65,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner of the Dark Powers",
@@ -3234,7 +3567,8 @@
       "name_fr": "Bannière des Puissances Obscures",
       "name_it": "Banner of the Dark Powers",
       "points": 50,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Blasted Standard",
@@ -3243,7 +3577,8 @@
       "name_fr": "Étendard de Fournaise",
       "name_it": "Blasted Standard",
       "points": 40,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner of Rage",
@@ -3252,7 +3587,8 @@
       "name_fr": "Bannière de Rage",
       "name_it": "Banner of Rage",
       "points": 35,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner of the Baying Hound",
@@ -3262,7 +3598,8 @@
       "name_it": "Banner of the Baying Hound",
       "points": 25,
       "type": "banner",
-      "armyComposition": "heralds-of-darkness"
+      "armyComposition": "heralds-of-darkness",
+      "onePerArmy": true
     },
     {
       "name_de": "Sea Raider's Crest",
@@ -3272,7 +3609,8 @@
       "name_it": "Sea Raider's Crest",
       "points": 25,
       "type": "banner",
-      "armyComposition": "wolves-of-the-sea"
+      "armyComposition": "wolves-of-the-sea",
+      "onePerArmy": true
     },
     {
       "name_de": "Icon of Darkness",
@@ -3281,7 +3619,8 @@
       "name_fr": "Icône des Ténèbres",
       "name_it": "Icon of Darkness",
       "points": 20,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Bloodskull Pendant",
@@ -3290,7 +3629,8 @@
       "name_fr": "Pendentif du Crâne de Sang",
       "name_it": "Bloodskull Pendant",
       "points": 45,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Rod of the Damned",
@@ -3299,7 +3639,8 @@
       "name_fr": "Baguette des Damnés",
       "name_it": "Rod of the Damned",
       "points": 40,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Daemon-Forged Barding",
@@ -3309,7 +3650,8 @@
       "name_it": "Daemon-Forged Barding",
       "points": 35,
       "type": "enchanted-item",
-      "armyComposition": "heralds-of-darkness"
+      "armyComposition": "heralds-of-darkness",
+      "onePerArmy": true
     },
     {
       "name_de": "Pendant of Damnation",
@@ -3318,7 +3660,8 @@
       "name_fr": "Pendentif de Damnation",
       "name_it": "Pendant of Damnation",
       "points": 30,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Helm of Many Eyes",
@@ -3327,7 +3670,8 @@
       "name_fr": "Heaume aux Yeux Innombrables",
       "name_it": "Helm of Many Eyes",
       "points": 20,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Favour of the Gods*",
@@ -3337,7 +3681,8 @@
       "name_it": "Favour of the Gods*",
       "points": 5,
       "stackable": true,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Skull of Katam",
@@ -3346,7 +3691,8 @@
       "name_fr": "Crâne de Katam",
       "name_it": "Skull of Katam",
       "points": 60,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Sceptre of Power",
@@ -3355,7 +3701,8 @@
       "name_fr": "Sceptre de Puissance",
       "name_it": "Sceptre of Power",
       "points": 55,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Infernal Puppet",
@@ -3364,7 +3711,8 @@
       "name_fr": "Marionnette Infernale",
       "name_it": "Infernal Puppet",
       "points": 50,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Grimoire of Ogvold",
@@ -3373,7 +3721,8 @@
       "name_fr": "Grimoire d'Ogvold",
       "name_it": "Grimoire of Ogvold",
       "points": 50,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Tome of the Dark Gods",
@@ -3382,7 +3731,8 @@
       "name_fr": "Tome des Dieux Sombres",
       "name_it": "Tome of the Dark Gods",
       "points": 35,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Spell Familiar*",
@@ -3393,7 +3743,8 @@
       "points": 15,
       "stackable": true,
       "maximum": 1,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     }
   ],
   "gifts-of-chaos": [
@@ -3404,8 +3755,8 @@
       "name_fr": "Sombre Majesté",
       "name_it": "Oscuro Majesty",
       "points": 50,
-      "stackable": true,
-      "type": "gift-of-chaos"
+      "type": "gift-of-chaos",
+      "onePerArmy": true
     },
     {
       "name_de": "Daemon-Flesh",
@@ -3414,8 +3765,8 @@
       "name_fr": "Chair Démoniaque",
       "name_it": "Daemon-Flesh",
       "points": 45,
-      "stackable": true,
-      "type": "gift-of-chaos"
+      "type": "gift-of-chaos",
+      "onePerArmy": true
     },
     {
       "name_de": "Extra Arm",
@@ -3424,8 +3775,8 @@
       "name_fr": "Bras Supplémentaire",
       "name_it": "Extra Arm",
       "points": 40,
-      "stackable": true,
-      "type": "gift-of-chaos"
+      "type": "gift-of-chaos",
+      "onePerArmy": true
     },
     {
       "name_de": "Diabolic Splendour",
@@ -3434,8 +3785,8 @@
       "name_fr": "Splendeur Diabolique",
       "name_it": "Diabolic Splendour",
       "points": 35,
-      "stackable": true,
-      "type": "gift-of-chaos"
+      "type": "gift-of-chaos",
+      "onePerArmy": true
     },
     {
       "name_de": "Enchanting Aura",
@@ -3444,8 +3795,8 @@
       "name_fr": "Aura Enchanteresse",
       "name_it": "Enchanting Aura",
       "points": 35,
-      "stackable": true,
-      "type": "gift-of-chaos"
+      "type": "gift-of-chaos",
+      "onePerArmy": true
     },
     {
       "name_de": "Aura of Pain",
@@ -3454,8 +3805,8 @@
       "name_fr": "Aura de Douleur",
       "name_it": "Aura of Pain",
       "points": 30,
-      "stackable": true,
-      "type": "gift-of-chaos"
+      "type": "gift-of-chaos",
+      "onePerArmy": true
     },
     {
       "name_de": "Master of Mortals",
@@ -3464,8 +3815,8 @@
       "name_fr": "Maître des Mortels",
       "name_it": "Master of Mortals",
       "points": 25,
-      "stackable": true,
-      "type": "gift-of-chaos"
+      "type": "gift-of-chaos",
+      "onePerArmy": true
     },
     {
       "name_de": "Acid Ichor",
@@ -3474,8 +3825,8 @@
       "name_fr": "Ichor Acide",
       "name_it": "Acid Ichor",
       "points": 15,
-      "stackable": true,
-      "type": "gift-of-chaos"
+      "type": "gift-of-chaos",
+      "onePerArmy": true
     },
     {
       "name_de": "Poisonous Slime",
@@ -3484,8 +3835,8 @@
       "name_fr": "Mucus Empoisonné",
       "name_it": "Poisonous Slime",
       "points": 15,
-      "stackable": true,
-      "type": "gift-of-chaos"
+      "type": "gift-of-chaos",
+      "onePerArmy": true
     }
   ],
   "chaos-mutations": [
@@ -3497,7 +3848,8 @@
       "name_it": "Slug-skin",
       "nonExclusive": true,
       "points": 50,
-      "type": "chaos-mutation"
+      "type": "chaos-mutation",
+      "onePerArmy": true
     },
     {
       "name_de": "Crown of Horns",
@@ -3507,7 +3859,8 @@
       "name_it": "Crown of Horns",
       "nonExclusive": true,
       "points": 45,
-      "type": "chaos-mutation"
+      "type": "chaos-mutation",
+      "onePerArmy": true
     },
     {
       "name_de": "Muscular Monstrosity",
@@ -3517,7 +3870,8 @@
       "name_it": "Muscular Monstrosity",
       "nonExclusive": true,
       "points": 35,
-      "type": "chaos-mutation"
+      "type": "chaos-mutation",
+      "onePerArmy": true
     },
     {
       "name_de": "Pelt of Midnight",
@@ -3527,7 +3881,8 @@
       "name_it": "Pelt of Midnight",
       "nonExclusive": true,
       "points": 35,
-      "type": "chaos-mutation"
+      "type": "chaos-mutation",
+      "onePerArmy": true
     },
     {
       "name_de": "Gouge-tusks",
@@ -3537,7 +3892,8 @@
       "name_it": "Gouge-tusks",
       "nonExclusive": true,
       "points": 30,
-      "type": "chaos-mutation"
+      "type": "chaos-mutation",
+      "onePerArmy": true
     },
     {
       "name_de": "Rune of the Beast Ascendant",
@@ -3547,7 +3903,8 @@
       "name_it": "Rune of the Beast Ascendant",
       "nonExclusive": true,
       "points": 25,
-      "type": "chaos-mutation"
+      "type": "chaos-mutation",
+      "onePerArmy": true
     },
     {
       "name_de": "Many-limbed Fiend",
@@ -3557,7 +3914,8 @@
       "name_it": "Many-limbed Fiend",
       "nonExclusive": true,
       "points": 20,
-      "type": "chaos-mutation"
+      "type": "chaos-mutation",
+      "onePerArmy": true
     },
     {
       "name_de": "Gnarled Hide",
@@ -3567,7 +3925,8 @@
       "name_it": "Gnarled Hide",
       "nonExclusive": true,
       "points": 15,
-      "type": "chaos-mutation"
+      "type": "chaos-mutation",
+      "onePerArmy": true
     },
     {
       "name_de": "Uncanny Senses",
@@ -3577,7 +3936,8 @@
       "name_it": "Uncanny Senses",
       "nonExclusive": true,
       "points": 10,
-      "type": "chaos-mutation"
+      "type": "chaos-mutation",
+      "onePerArmy": true
     }
   ],
   "wood-elf-realms": [
@@ -3588,7 +3948,8 @@
       "name_fr": "Lance du Crépuscule",
       "name_it": "Spear of Twilight",
       "points": 65,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Vaul's Wrath",
@@ -3597,7 +3958,8 @@
       "name_fr": "Colère de Vaul",
       "name_it": "Vaul's Wrath",
       "points": 55,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Klingen des Loec",
@@ -3606,7 +3968,8 @@
       "name_fr": "Lames de Loec",
       "name_it": "Blades of Loec",
       "points": 45,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Daith's Reaper",
@@ -3615,7 +3978,8 @@
       "name_fr": "Faucheuse de Daith",
       "name_it": "Daith's Reaper",
       "points": 40,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Bogen von Loren",
@@ -3624,7 +3988,8 @@
       "name_fr": "Arc de Loren",
       "name_it": "Arco of Loren",
       "points": 40,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Hunt Master's Pride",
@@ -3634,7 +3999,8 @@
       "name_it": "Hunt Master's Pride",
       "points": 35,
       "type": "weapon",
-      "armyComposition": "orions-wild-hunt"
+      "armyComposition": "orions-wild-hunt",
+      "onePerArmy": true
     },
     {
       "name_de": "Blades of Endless Flame",
@@ -3643,7 +4009,8 @@
       "name_fr": "Lames de Feu Éternel",
       "name_it": "Blades of Endless Flame",
       "points": 25,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Asyendis Fluch",
@@ -3652,7 +4019,8 @@
       "name_fr": "Fléau d'Asyendi",
       "name_it": "Asyendi's Bane",
       "points": 10,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "maximum": 1,
@@ -3663,7 +4031,8 @@
       "name_it": "Helm of the Hunt",
       "points": 50,
       "stackable": true,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": false
     },
     {
       "name_de": "Mantle of Rebirth",
@@ -3672,7 +4041,8 @@
       "name_fr": "Manteau du Renouveau",
       "name_it": "Mantle of Rebirth",
       "points": 40,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Railarians Mantel",
@@ -3681,7 +4051,8 @@
       "name_fr": "Cape de Railarian",
       "name_it": "Railarian's Mantle",
       "points": 35,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Merciws Ehre",
@@ -3690,7 +4061,8 @@
       "name_fr": "Gemme de Merciw",
       "name_it": "Merciw's Locus",
       "points": 35,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Cloak of Tumbling Leaves",
@@ -3699,7 +4071,8 @@
       "name_fr": "Cape de Feuilles Virevoltantes",
       "name_it": "Cloak of Tumbling Leaves",
       "points": 30,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Funkelstern",
@@ -3708,7 +4081,8 @@
       "name_fr": "Écheveau Féérique",
       "name_it": "Glamourweave",
       "points": 30,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Ariel's Favour",
@@ -3717,7 +4091,8 @@
       "name_fr": "Faveur d’Ariel",
       "name_it": "Ariel's Favour",
       "points": 30,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Orion's Favour",
@@ -3726,7 +4101,8 @@
       "name_fr": "Faveur d’Orion",
       "name_it": "Orion's Favour",
       "points": 25,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Tapestry of Talsyn",
@@ -3735,7 +4111,8 @@
       "name_fr": "Tapisserie de Talsyn",
       "name_it": "Tapestry of Talsyn",
       "points": 80,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Standarte des Bannwalds",
@@ -3744,7 +4121,8 @@
       "name_fr": "Bannière du Bois Sauvage",
       "name_it": "Banner of the Wildwood",
       "points": 40,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner des Jägerkönigs",
@@ -3753,7 +4131,8 @@
       "name_fr": "Bannière du Roi Chasseur",
       "name_it": "Banner of the Cacciatore Re",
       "points": 25,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner of the Wild Hunt",
@@ -3762,7 +4141,8 @@
       "name_fr": "Bannière de la Chasse Sauvage",
       "name_it": "Banner of the Wild Hunt",
       "points": 25,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Standard of Morning's Chill",
@@ -3771,7 +4151,8 @@
       "name_fr": "Étendard du Froid Matinal",
       "name_it": "Standard of Morning's Chill",
       "points": 25,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner of Springtide",
@@ -3780,7 +4161,8 @@
       "name_fr": "Bannière du Printemps",
       "name_it": "Banner of Springtide",
       "points": 20,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner der ewigen Königin",
@@ -3789,7 +4171,8 @@
       "name_fr": "Bannière de la Reine Éternelle",
       "name_it": "Banner of the Eternal Regina",
       "points": 20,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner des Midsommerabends",
@@ -3798,7 +4181,8 @@
       "name_fr": "Bannière du Solstice d'Été",
       "name_it": "Banner of Midsummer's Eve",
       "points": 15,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Seelenstein",
@@ -3807,7 +4191,8 @@
       "name_fr": "Pierre Spectrale",
       "name_it": "Wraithstone",
       "points": 50,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Pfeilhagel des Verderbens*",
@@ -3817,7 +4202,8 @@
       "name_it": "Hail of Doom Arrow*",
       "points": 35,
       "stackable": true,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Crown of Antlers",
@@ -3826,7 +4212,8 @@
       "name_fr": "Grande Ramure",
       "name_it": "Crown of Antlers",
       "points": 35,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Moonstone of the Hidden Ways",
@@ -3835,7 +4222,8 @@
       "name_fr": "Pierre de Lune des Sentiers Cachés",
       "name_it": "Moonstone of the Hidden Ways",
       "points": 30,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Heulender Pfeil*",
@@ -3845,7 +4233,8 @@
       "name_it": "Wailing Freccia*",
       "points": 20,
       "stackable": true,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Blight-Tipped Arrows*",
@@ -3855,7 +4244,8 @@
       "name_it": "Blight-Tipped Arrows*",
       "points": 15,
       "stackable": true,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Kugel des tiefen Waldes",
@@ -3864,7 +4254,8 @@
       "name_fr": "Sphère des Bois Profonds",
       "name_it": "Deepwood Sphere",
       "points": 45,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Eichenholzstab",
@@ -3873,7 +4264,8 @@
       "name_fr": "Bâton de Chêne",
       "name_it": "Oaken Stave",
       "points": 40,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Orb of Midsummer",
@@ -3882,7 +4274,8 @@
       "name_fr": "Orbe du Solstice d’Été",
       "name_it": "Orb of Midsummer",
       "points": 35,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Stab der Bergulme",
@@ -3891,7 +4284,8 @@
       "name_fr": "Baguette d'Orme Blanc",
       "name_it": "Bacchetta of Wych Elm",
       "points": 30,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Sigil of the Mage Queen",
@@ -3900,7 +4294,8 @@
       "name_fr": "Sceau de la Reine-Mage",
       "name_it": "Sigil of the Mage Queen",
       "points": 25,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Heartwood Pendant*",
@@ -3910,7 +4305,8 @@
       "name_it": "Heartwood Pendant*",
       "points": 15,
       "stackable": true,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     }
   ],
   "high-elf-realms": [
@@ -3922,7 +4318,8 @@
       "name_it": "Woodsman's Axe",
       "points": 90,
       "type": "weapon",
-      "armyComposition": "the-chracian-warhost"
+      "armyComposition": "the-chracian-warhost",
+      "onePerArmy": true
     },
     {
       "name_de": "Das Weiße Schwert",
@@ -3931,7 +4328,8 @@
       "name_fr": "Épée Blanche",
       "name_it": "The White Spada",
       "points": 70,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Die Schnelle Goldklinge",
@@ -3940,7 +4338,8 @@
       "name_fr": "Lame d'Or Bondissant",
       "name_it": "The Lama of Leaping Oro",
       "points": 50,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Bow of the Seafarer",
@@ -3949,7 +4348,8 @@
       "name_fr": "Arc du Voyageur",
       "name_it": "Bow of the Seafarer",
       "points": 50,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Star Lance",
@@ -3958,7 +4358,8 @@
       "name_fr": "Lance des Étoiles",
       "name_it": "Star Lance",
       "points": 45,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Blade of Sea Gold",
@@ -3968,7 +4369,8 @@
       "name_it": "Blade of Sea Gold",
       "points": 40,
       "type": "weapon",
-      "armyComposition": "sea-guard-garrison"
+      "armyComposition": "sea-guard-garrison",
+      "onePerArmy": true
     },
     {
       "name_de": "Jagdbogen",
@@ -3977,7 +4379,8 @@
       "name_fr": "Arc du Patrouilleur",
       "name_it": "Reaver Arco",
       "points": 40,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Feindfluch",
@@ -3986,7 +4389,8 @@
       "name_fr": "Épée du Bannissement",
       "name_it": "Foe Bane",
       "points": 20,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Armour of Stars",
@@ -3995,7 +4399,8 @@
       "name_fr": "Armure des Étoiles",
       "name_it": "Armour of Stars",
       "points": 40,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Rüstung von Caledor",
@@ -4004,7 +4409,8 @@
       "name_fr": "Armure de Caledor",
       "name_it": "Armour of Caledor",
       "points": 35,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "The Golden Shield",
@@ -4013,7 +4419,8 @@
       "name_fr": "Bouclier de l’Aube",
       "name_it": "The Golden Shield",
       "points": 30,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Drachenhelm",
@@ -4022,7 +4429,8 @@
       "name_fr": "Heaume Dragon",
       "name_it": "Drago Helm",
       "points": 10,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Circlet of Atrazar",
@@ -4031,7 +4439,8 @@
       "name_fr": "Diadème d’Atrazar",
       "name_it": "Circlet of Atrazar",
       "points": 55,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Sacred Incense",
@@ -4040,7 +4449,8 @@
       "name_fr": "Encens Sacré",
       "name_it": "Sacred Incense",
       "points": 35,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Umhang des Lehrmeisters",
@@ -4049,7 +4459,8 @@
       "name_fr": "Cape du Maître du Savoir",
       "name_it": "The Loremaster's Mantello",
       "points": 25,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Opalamulett*",
@@ -4059,7 +4470,8 @@
       "name_it": "Opal Amulet*",
       "points": 20,
       "stackable": true,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": false
     },
     {
       "name_de": "Banner of Resilience",
@@ -4068,7 +4480,8 @@
       "name_fr": "Bannière de Résilience",
       "name_it": "Banner of Resilience",
       "points": 80,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner des arkanen Schutzes",
@@ -4077,7 +4490,8 @@
       "name_fr": "Bannière de Protection Magique",
       "name_it": "Banner of Arcane Protection",
       "points": 70,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Schlachtbanner",
@@ -4086,7 +4500,8 @@
       "name_fr": "Bannière de Bataille",
       "name_it": "Battaglia Banner",
       "points": 60,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "The Banner of Lothern",
@@ -4095,7 +4510,8 @@
       "name_fr": "La Bannière de Lothern.",
       "name_it": "The Banner of Lothern",
       "points": 55,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Löwenstandarte",
@@ -4104,7 +4520,8 @@
       "name_fr": "Étendard du Lion",
       "name_it": "Lion Standard",
       "points": 25,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner of Balance",
@@ -4113,7 +4530,8 @@
       "name_fr": "Bannière d’Équilibre",
       "name_it": "Banner of Balance",
       "points": 25,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner von Ellyrion",
@@ -4122,7 +4540,8 @@
       "name_fr": "Bannière d'Ellyrion",
       "name_it": "Banner of Ellyrion",
       "points": 20,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner of Confidence",
@@ -4131,7 +4550,8 @@
       "name_fr": "Bannière d’Assurance",
       "name_it": "Banner of Confidence",
       "points": 20,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Nullstein",
@@ -4140,7 +4560,8 @@
       "name_fr": "Pierre de Nuit",
       "name_it": "Null Stone",
       "points": 75,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Amulet of the Tempest",
@@ -4150,7 +4571,8 @@
       "name_it": "Amulet of the Tempest",
       "points": 50,
       "type": "enchanted-item",
-      "armyComposition": "sea-guard-garrison"
+      "armyComposition": "sea-guard-garrison",
+      "onePerArmy": true
     },
     {
       "name_de": "Der Bartmantel",
@@ -4159,7 +4581,8 @@
       "name_fr": "Cape de Barbes",
       "name_it": "The Mantello of Beards",
       "points": 30,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Ring of Fury*",
@@ -4169,7 +4592,8 @@
       "name_it": "Ring of Fury*",
       "points": 25,
       "stackable": true,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Samen der Wiedergeburt*",
@@ -4179,7 +4603,8 @@
       "name_it": "Seed of Rebirth*",
       "points": 20,
       "stackable": true,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Gem of Courage*",
@@ -4190,7 +4615,8 @@
       "points": 15,
       "stackable": true,
       "type": "enchanted-item",
-      "armyComposition": "the-chracian-warhost"
+      "armyComposition": "the-chracian-warhost",
+      "onePerArmy": false
     },
     {
       "name_de": "The Vortex Shard",
@@ -4199,7 +4625,8 @@
       "name_fr": "L’Éclat de Vortex",
       "name_it": "The Vortex Shard",
       "points": 50,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Asuryans Sigille*",
@@ -4209,7 +4636,8 @@
       "name_it": "Sigil of Asuryan*",
       "points": 40,
       "stackable": true,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     },
     {
       "name_de": "The Trickster's Pendant",
@@ -4218,7 +4646,8 @@
       "name_fr": "Le Pendentif du Trompeur",
       "name_it": "The Trickster's Pendant",
       "points": 40,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Annulianischer Kristall",
@@ -4227,7 +4656,8 @@
       "name_fr": "Cristal des Annulii",
       "name_it": "Annulian Cristallo",
       "points": 30,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Silberstab",
@@ -4236,7 +4666,8 @@
       "name_fr": "Baguette d'Argent",
       "name_it": "Silvery Bacchetta",
       "points": 15,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Staff of Solidity",
@@ -4245,7 +4676,8 @@
       "name_fr": "Bâton de Solidité",
       "name_it": "Staff of Solidity",
       "points": 15,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     }
   ],
   "elven-honours": [
@@ -4257,7 +4689,8 @@
       "name_it": "Loremaster",
       "points": 35,
       "type": "elven-honour",
-      "armyComposition": "high-elf-realms"
+      "armyComposition": "high-elf-realms",
+      "onePerArmy": false
     },
     {
       "name_de": "Schattenpirscher",
@@ -4271,7 +4704,8 @@
         "high-elf-realms",
         "sea-guard-garrison",
         "the-chracian-warhost"
-      ]
+      ],
+      "onePerArmy": false
     },
     {
       "name_de": "Gesalbter Asuryan",
@@ -4281,7 +4715,8 @@
       "name_it": "Anointed of Asuryan",
       "points": 15,
       "type": "elven-honour",
-      "armyComposition": "high-elf-realms"
+      "armyComposition": "high-elf-realms",
+      "onePerArmy": false
     },
     {
       "name_de": "Blut von Caledor",
@@ -4291,7 +4726,8 @@
       "name_it": "Blood of Caledor",
       "points": 15,
       "type": "elven-honour",
-      "armyComposition": "high-elf-realms"
+      "armyComposition": "high-elf-realms",
+      "onePerArmy": false
     },
     {
       "name_de": "Chracianischer Jäger",
@@ -4302,7 +4738,8 @@
       "points": 10,
       "type": "elven-honour",
       "name": "chracian-hunter",
-      "armyComposition": ["high-elf-realms", "the-chracian-warhost"]
+      "armyComposition": ["high-elf-realms", "the-chracian-warhost"],
+      "onePerArmy": false
     },
     {
       "name_de": "Wächter von Saphery",
@@ -4312,7 +4749,8 @@
       "name_it": "Warden of Saphery",
       "points": 10,
       "type": "elven-honour",
-      "armyComposition": "high-elf-realms"
+      "armyComposition": "high-elf-realms",
+      "onePerArmy": false
     },
     {
       "name_de": "Reinherzig",
@@ -4326,7 +4764,8 @@
         "high-elf-realms",
         "sea-guard-garrison",
         "the-chracian-warhost"
-      ]
+      ],
+      "onePerArmy": false
     },
     {
       "name_de": "Seegarde",
@@ -4337,7 +4776,8 @@
       "points": 0,
       "type": "elven-honour",
       "name": "sea-guard",
-      "armyComposition": ["high-elf-realms", "sea-guard-garrison"]
+      "armyComposition": ["high-elf-realms", "sea-guard-garrison"],
+      "onePerArmy": false
     }
   ],
   "chaos-dwarfs": [
@@ -4348,7 +4788,8 @@
       "name_fr": "Marteau Noir d'Hashut",
       "name_it": "Black Hammer of Hashut",
       "points": 60,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Dark Maul",
@@ -4357,7 +4798,8 @@
       "name_fr": "Masse des Ténèbres",
       "name_it": "Oscuro Maul",
       "points": 50,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Dagger of Malice",
@@ -4366,7 +4808,8 @@
       "name_fr": "Dague de Malice",
       "name_it": "Dagger of Malice",
       "points": 35,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "The Graven Sceptre",
@@ -4375,7 +4818,8 @@
       "name_fr": "Le Sceptre Gravé",
       "name_it": "The Graven Sceptre",
       "points": 30,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Armour of Bazherak the Cruel",
@@ -4385,7 +4829,8 @@
       "name_it": "Armour of Bazherak the Cruel",
       "nonExclusive": true,
       "points": 50,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "The Mask of the Furnace",
@@ -4395,7 +4840,8 @@
       "name_it": "The Mask of the Furnace",
       "nonExclusive": true,
       "points": 40,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Mantle of Stone*",
@@ -4405,7 +4851,8 @@
       "name_it": "Mantle of Stone",
       "points": 30,
       "stackable": true,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": false
     },
     {
       "name_de": "Hellshard",
@@ -4414,7 +4861,8 @@
       "name_fr": "Éclat Infernal",
       "name_it": "Hellshard",
       "points": 20,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "The Lammasu's Beard",
@@ -4423,7 +4871,8 @@
       "name_fr": "Barbe du Lammasu",
       "name_it": "The Lammasu's Beard",
       "points": 65,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Ashen Banner",
@@ -4432,7 +4881,8 @@
       "name_fr": "Bannière Cendrée",
       "name_it": "Ashen Banner",
       "points": 30,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Overseer's Sigil",
@@ -4441,7 +4891,8 @@
       "name_fr": "Sceau des Contremaîtres",
       "name_it": "Overseer's Sigil",
       "points": 25,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Shroud of the Ancestor",
@@ -4450,7 +4901,8 @@
       "name_fr": "Suaire de l'Ancêtre",
       "name_it": "Shroud of the Ancestor",
       "points": 10,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Daemonic Familiar",
@@ -4459,7 +4911,8 @@
       "name_fr": "Familier Démoniaque",
       "name_it": "Daemonic Familiar",
       "points": 30,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Breath of Hashut",
@@ -4468,7 +4921,8 @@
       "name_fr": "Souffle d'Hashut",
       "name_it": "Breath of Hashut",
       "points": 25,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Obsidian Vambraces",
@@ -4477,7 +4931,8 @@
       "name_fr": "Crispins d'Obsidienne",
       "name_it": "Obsidian Vambraces",
       "points": 15,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Daemon Flask",
@@ -4486,7 +4941,8 @@
       "name_fr": "Flasque Démoniaque",
       "name_it": "Daemon Flask",
       "points": 50,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Vial of Lammasu Blood",
@@ -4495,7 +4951,8 @@
       "name_fr": "Fiole de Sang de Lammasu",
       "name_it": "Vial of Lammasu Blood",
       "points": 40,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Scroll of Binding*",
@@ -4505,7 +4962,8 @@
       "name_it": "Pergamena of Binding*",
       "points": 30,
       "stackable": true,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     }
   ],
   "lizardmen": [
@@ -4516,7 +4974,8 @@
       "name_fr": "Lame du Révéré Tzunki",
       "name_it": "Lama of Revered Tzunki",
       "points": 65,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Scimitar of the Sun Resplendent",
@@ -4525,7 +4984,8 @@
       "name_fr": "Cimeterre du Soleil Resplandissant",
       "name_it": "Scimitar of the Sun Resplendent",
       "points": 50,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Staff of the Lost Sun",
@@ -4534,7 +4994,8 @@
       "name_fr": "Bâton du Soleil Perdu",
       "name_it": "Bastone of the Lost Sun",
       "points": 40,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Piranha Blade",
@@ -4543,7 +5004,8 @@
       "name_fr": "Lame Piranha",
       "name_it": "Piranha Lama",
       "points": 35,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Shield of the Mirror Pool",
@@ -4552,7 +5014,8 @@
       "name_fr": "Bouclier du Bassin Miroitant",
       "name_it": "Scudo of the Mirror Pool",
       "points": 40,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Hide of the Cold Ones",
@@ -4561,7 +5024,8 @@
       "name_fr": "Peau de Sang-froid",
       "name_it": "Hide of the Cold Ones",
       "points": 20,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Glyph Necklace",
@@ -4570,7 +5034,8 @@
       "name_fr": "Collier de Glyphes",
       "name_it": "Glyph Necklace",
       "points": 45,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Aura of Quetzl",
@@ -4579,7 +5044,8 @@
       "name_fr": "Aura de Quetzl",
       "name_it": "Aura of Quetzl",
       "points": 40,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Sun Standard of Chotec",
@@ -4588,7 +5054,8 @@
       "name_fr": "Étendard du Soleil de Chotec",
       "name_it": "Sun Standard of Chotec",
       "points": 40,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Skavenpelt Banner",
@@ -4597,7 +5064,8 @@
       "name_fr": "Bannière en Peau de skaven",
       "name_it": "Skavenpelt Banner",
       "points": 35,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Totem of Prophecy",
@@ -4606,7 +5074,8 @@
       "name_fr": "Totem de Prophétie",
       "name_it": "Totem of Prophecy",
       "points": 30,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Jaguar Standard",
@@ -4615,7 +5084,8 @@
       "name_fr": "Bannière du Jaguar",
       "name_it": "Jaguar Standard",
       "points": 20,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Cloak of Feathers",
@@ -4624,7 +5094,8 @@
       "name_fr": "Cape de Plumes",
       "name_it": "Mantello of Feathers",
       "points": 40,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Venom of the Firefly Frog",
@@ -4633,7 +5104,8 @@
       "name_fr": "Venin du Crapaud Luciole",
       "name_it": "Venom of the Firefly Frog",
       "points": 15,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Horned One*",
@@ -4643,7 +5115,8 @@
       "name_it": "Horned One*",
       "points": 10,
       "stackable": true,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Cube of Darkness*",
@@ -4653,7 +5126,8 @@
       "name_it": "Cube of Darkness*",
       "points": 50,
       "stackable": true,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Itxi Grub*",
@@ -4663,7 +5137,8 @@
       "name_it": "Itxi Grub*",
       "points": 30,
       "stackable": true,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Cupped Hands of the Old Ones",
@@ -4672,7 +5147,8 @@
       "name_fr": "Mains en Creux des Anciens",
       "name_it": "Cupped Hands of the Old Ones",
       "points": 55,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     }
   ],
   "disciplines-old-ones": [
@@ -4683,7 +5159,8 @@
       "name_fr": "État supérieur de Conscience",
       "name_it": "Higher State of Mente",
       "points": 60,
-      "type": "discipline-old-ones"
+      "type": "discipline-old-ones",
+      "onePerArmy": false
     },
     {
       "name_de": "Becalming Cogitation",
@@ -4692,7 +5169,8 @@
       "name_fr": "Aphorisme Apaisant",
       "name_it": "Becalming Cogitation",
       "points": 50,
-      "type": "discipline-old-ones"
+      "type": "discipline-old-ones",
+      "onePerArmy": false
     },
     {
       "name_de": "Wandering Deliberations",
@@ -4701,7 +5179,8 @@
       "name_fr": "Réflexions Vagabondes",
       "name_it": "Wandering Deliberations",
       "points": 40,
-      "type": "discipline-old-ones"
+      "type": "discipline-old-ones",
+      "onePerArmy": false
     },
     {
       "name_de": "Transcendent Healing",
@@ -4710,7 +5189,8 @@
       "name_fr": "Guérison Transcendantale",
       "name_it": "Transcendent Healing",
       "points": 35,
-      "type": "discipline-old-ones"
+      "type": "discipline-old-ones",
+      "onePerArmy": false
     },
     {
       "name_de": "Sorcerous Void",
@@ -4719,7 +5199,8 @@
       "name_fr": "Présence Surnaturelle",
       "name_it": "Sorcerous Void",
       "points": 30,
-      "type": "discipline-old-ones"
+      "type": "discipline-old-ones",
+      "onePerArmy": false
     },
     {
       "name_de": "Harrowing Scrutiny",
@@ -4728,7 +5209,8 @@
       "name_fr": "Regard Pénétrant",
       "name_it": "Harrowing Scrutiny",
       "points": 20,
-      "type": "discipline-old-ones"
+      "type": "discipline-old-ones",
+      "onePerArmy": false
     },
     {
       "name_de": "Soul of Stone",
@@ -4737,7 +5219,8 @@
       "name_fr": "Âme de Marbre",
       "name_it": "Anima of Stone",
       "points": 10,
-      "type": "discipline-old-ones"
+      "type": "discipline-old-ones",
+      "onePerArmy": false
     }
   ],
   "dark-elves": [
@@ -4748,7 +5231,8 @@
       "name_fr": "Hache du Bourreau",
       "name_it": "Executioner's Axe",
       "points": 70,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Sword of Ruin",
@@ -4757,7 +5241,8 @@
       "name_fr": "Épée de la Ruine",
       "name_it": "Spada of Ruin",
       "points": 65,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Lifetaker",
@@ -4766,7 +5251,8 @@
       "name_fr": "Exécutrice",
       "name_it": "Lifetaker",
       "points": 35,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Whip of Agony",
@@ -4775,7 +5261,8 @@
       "name_fr": "Fouet de l'Agonie",
       "name_it": "Whip of Agony",
       "points": 30,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Shield of Ghrond",
@@ -4784,7 +5271,8 @@
       "name_fr": "Bouclier de Ghrond",
       "name_it": "Scudo of Ghrond",
       "points": 40,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Blood Armour",
@@ -4793,7 +5281,8 @@
       "name_fr": "Armure de Sang",
       "name_it": "Blood Armour",
       "points": 30,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Pendant of Khaeleth",
@@ -4802,7 +5291,8 @@
       "name_fr": "Pendentif de Khaeleth",
       "name_it": "Pendant of Khaeleth",
       "points": 40,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Pearl of Infinite Bleakness",
@@ -4811,7 +5301,8 @@
       "name_fr": "Perle de l'Infinie Tristesse",
       "name_it": "Pearl of Infinite Bleakness",
       "points": 15,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner of Nagarythe",
@@ -4820,7 +5311,8 @@
       "name_fr": "Bannière de Nagarythe",
       "name_it": "Banner of Nagarythe",
       "points": 65,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Standard of Slaughter",
@@ -4829,7 +5321,8 @@
       "name_fr": "Étendard du Massacre",
       "name_it": "Standard of Slaughter",
       "points": 40,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner of Har Ganeth",
@@ -4838,7 +5331,8 @@
       "name_fr": "Bannière de Har Ganeth",
       "name_it": "Banner of Har Ganeth",
       "points": 25,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Cold-Blooded Banner",
@@ -4847,7 +5341,8 @@
       "name_fr": "Bannière de Sang-froid",
       "name_it": "Cold-Blooded Banner",
       "points": 20,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Black Dragon Egg",
@@ -4856,7 +5351,8 @@
       "name_fr": "Œuf de Dragon Noir",
       "name_it": "Black Drago Egg",
       "points": 35,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Hydra's Tooth",
@@ -4865,7 +5361,8 @@
       "name_fr": "Dent d'Hydre",
       "name_it": "Hydra's Tooth",
       "points": 30,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "The Guiding Eye",
@@ -4874,7 +5371,8 @@
       "name_fr": "Œil de Guidance",
       "name_it": "The Guiding Eye",
       "points": 25,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Black Staff",
@@ -4883,7 +5381,8 @@
       "name_fr": "Bâton Noir",
       "name_it": "Black Bastone",
       "points": 55,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Focus Familiar*",
@@ -4893,7 +5392,8 @@
       "name_it": "Focus Familiar*",
       "points": 10,
       "stackable": true,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Tome of Furion",
@@ -4902,7 +5402,8 @@
       "name_fr": "Livre de Furion",
       "name_it": "Tome of Furion",
       "points": 15,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     }
   ],
   "ogre-kingdoms": [
@@ -4913,7 +5414,8 @@
       "name_fr": "Masse-tonnerre",
       "name_it": "Thundermace",
       "points": 90,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Fleischklopfer",
@@ -4922,7 +5424,8 @@
       "name_fr": "Attendrisseur",
       "name_it": "Tenderiser",
       "points": 70,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Schädelpflücker",
@@ -4931,7 +5434,8 @@
       "name_fr": "Vide-crâne",
       "name_it": "Skullplucker",
       "points": 45,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Blutspalter",
@@ -4940,7 +5444,8 @@
       "name_fr": "Tranche-sang",
       "name_it": "Bloodcleaver",
       "points": 30,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Bauchschlud",
@@ -4949,7 +5454,8 @@
       "name_fr": "Plaque Ventrale de La Gueule",
       "name_it": "Gut Maw",
       "points": 45,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Mastodon Rüstung",
@@ -4958,7 +5464,8 @@
       "name_fr": "Armure Mastodonte",
       "name_it": "Mastodon Armour",
       "points": 40,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Glanzsplitter",
@@ -4967,7 +5474,8 @@
       "name_fr": "Éclat Scintillant",
       "name_it": "Spangleshard",
       "points": 35,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Cathayanisches Schutzhalsband",
@@ -4976,7 +5484,8 @@
       "name_fr": "Pendentif de Jais Cathayen",
       "name_it": "Cathayan Jet Pendant",
       "points": 10,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Drachenhautbanner",
@@ -4985,7 +5494,8 @@
       "name_fr": "Bannière en Peau de Dragon",
       "name_it": "Dragonhide Banner",
       "points": 45,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Runenschlund",
@@ -4994,7 +5504,8 @@
       "name_fr": "Rune de La Gueule",
       "name_it": "Rune Maw",
       "points": 40,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Kannibalentotem",
@@ -5003,7 +5514,8 @@
       "name_fr": "Totem Cannibale",
       "name_it": "Cannibal Totem",
       "points": 30,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Bullenstandarte",
@@ -5012,7 +5524,8 @@
       "name_fr": "Étendard du Buffle",
       "name_it": "Bull Standard",
       "points": 20,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Jadelöwe",
@@ -5021,7 +5534,8 @@
       "name_fr": "Lion de Jade",
       "name_it": "Jade Lion",
       "points": 25,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Dämonenslayer-Narben",
@@ -5030,7 +5544,8 @@
       "name_fr": "Scarifications Démoniaques",
       "name_it": "Daemon-Slayer Scars",
       "points": 20,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Lorbeeren*",
@@ -5040,7 +5555,8 @@
       "name_it": "Fistful of Laurels*",
       "points": 15,
       "type": "enchanted-item",
-      "stackable": true
+      "stackable": true,
+      "onePerArmy": false
     },
     {
       "name_de": "Halbling-Kochbuch",
@@ -5049,7 +5565,8 @@
       "name_fr": "Livre de Recettes Halfling",
       "name_it": "Halfling Cookbook",
       "points": 30,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Höllenherz",
@@ -5058,7 +5575,8 @@
       "name_fr": "Cœur Infernal",
       "name_it": "Hellheart",
       "points": 20,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Gruts Sichel",
@@ -5067,7 +5585,8 @@
       "name_fr": "Serpe de Grut",
       "name_it": "Grut's Sickle",
       "points": 40,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     }
   ],
   "big-names": [
@@ -5078,7 +5597,8 @@
       "name_fr": "Cherche-gueule",
       "name_it": "Mawseeker",
       "points": 30,
-      "type": "big-name"
+      "type": "big-name",
+      "onePerArmy": false
     },
     {
       "name_de": "Bergfresser",
@@ -5087,7 +5607,8 @@
       "name_fr": "Mange-montagne",
       "name_it": "Mountaineater",
       "points": 25,
-      "type": "big-name"
+      "type": "big-name",
+      "onePerArmy": false
     },
     {
       "name_de": "Riesenbrecher",
@@ -5096,7 +5617,8 @@
       "name_fr": "Brise-géant",
       "name_it": "Giantbreaker",
       "points": 20,
-      "type": "big-name"
+      "type": "big-name",
+      "onePerArmy": false
     },
     {
       "name_de": "Sippenfresser",
@@ -5105,7 +5627,8 @@
       "name_fr": "Mâche-frère",
       "name_it": "Kineater",
       "points": 15,
-      "type": "big-name"
+      "type": "big-name",
+      "onePerArmy": false
     },
     {
       "name_de": "Sturmläufer",
@@ -5114,7 +5637,8 @@
       "name_fr": "Longues-jambes",
       "name_it": "Longstrider",
       "points": 10,
-      "type": "big-name"
+      "type": "big-name",
+      "onePerArmy": false
     },
     {
       "name_de": "Bestienschlächter",
@@ -5123,7 +5647,8 @@
       "name_fr": "Trucide-fauve",
       "name_it": "Beastkiller",
       "points": 5,
-      "type": "big-name"
+      "type": "big-name",
+      "onePerArmy": false
     },
     {
       "name_de": "Todpreller",
@@ -5132,7 +5657,8 @@
       "name_fr": "Trompe-la-mort",
       "name_it": "Deathcheater",
       "points": 5,
-      "type": "big-name"
+      "type": "big-name",
+      "onePerArmy": false
     }
   ],
   "skaven": [
@@ -5144,7 +5670,8 @@
       "name_fr": "Lame Fatale",
       "name_it": "The Fellblade",
       "points": 100,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Weinende Klinge",
@@ -5154,7 +5681,8 @@
       "name_fr": "Lame Suintante",
       "name_it": "Weeping Lama",
       "points": 50,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Klinge von Nurglitch",
@@ -5164,7 +5692,8 @@
       "name_fr": "Lame de Nurglitch",
       "name_it": "Lama of Nurglitch",
       "points": 35,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Todesglobus*",
@@ -5175,7 +5704,8 @@
       "name_it": "Death Globe*",
       "points": 25,
       "stackable": true,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": false
     },
     {
       "name_de": "Warpstein-Rüstung*",
@@ -5186,7 +5716,8 @@
       "name_it": "Warpstone Armour*",
       "points": 25,
       "stackable": true,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": false
     },
     {
       "name_de": "Vorsichtiger Schild",
@@ -5196,7 +5727,8 @@
       "name_fr": "Bouclier de Couardise",
       "name_it": "Cautious Scudo",
       "points": 20,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Warpstein-Rüstung*",
@@ -5207,7 +5739,8 @@
       "name_it": "Warpstone Armour*",
       "points": 25,
       "stackable": true,
-      "type": "armor-mages"
+      "type": "armor-mages",
+      "onePerArmy": false
     },
     {
       "name_de": "Schattenmagnet",
@@ -5217,7 +5750,8 @@
       "name_fr": "Breloque d'Obscurité Magnétique",
       "name_it": "Shadow Magnet",
       "points": 40,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Warpstein-Amulett",
@@ -5227,7 +5761,8 @@
       "name_fr": "Amulette de Malepierre",
       "name_it": "Warpstone Amuleto",
       "points": 35,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Sturmbanner",
@@ -5237,7 +5772,8 @@
       "name_fr": "Bannière d'Orage",
       "name_it": "Storm Banner",
       "points": 65,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Großes Banner der Überlegenheit",
@@ -5247,7 +5783,8 @@
       "name_fr": "Bannière de Supériorité",
       "name_it": "Grand Banner of Superiority",
       "points": 50,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Zwergenfell-Banner",
@@ -5257,7 +5794,8 @@
       "name_fr": "Bannière en Peau de Nain",
       "name_it": "Nano Hide Banner",
       "points": 40,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner des Ungezieferhuschens",
@@ -5267,7 +5805,8 @@
       "name_fr": "Bannière de Vivacité Vermineuse",
       "name_it": "Banner of Verminous Scurrying",
       "points": 35,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Messingkugel",
@@ -5277,7 +5816,8 @@
       "name_fr": "Orbe d'Airain",
       "name_it": "Brass Orb",
       "points": 50,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Skalm",
@@ -5287,7 +5827,8 @@
       "name_fr": "Skataplasme",
       "name_it": "Skalm",
       "points": 35,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Skavenbrew*",
@@ -5298,7 +5839,8 @@
       "name_it": "Skavenbrew*",
       "points": 20,
       "stackable": true,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Warp-Kondensator",
@@ -5308,7 +5850,8 @@
       "name_fr": "Condensateur d'Énergie Magique",
       "name_it": "Warp Condenser",
       "points": 50,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Sturmdämon",
@@ -5318,7 +5861,8 @@
       "name_fr": "Orbe des Tempêtes",
       "name_it": "Storm Daemon",
       "points": 30,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Warpstein-Token*",
@@ -5329,7 +5873,8 @@
       "name_it": "Warpstone Tokens*",
       "points": 15,
       "stackable": true,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     }
   ],
   "vampire-counts": [
@@ -5341,7 +5886,8 @@
       "name_fr": "Bannière des Tertres",
       "name_it": "Banner of the Barrows",
       "points": 65,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Drakenhofbanner",
@@ -5351,7 +5897,8 @@
       "name_fr": "Bannière de Drakenhof",
       "name_it": "Drakenhof Banner",
       "points": 50,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Kreischendes Banner",
@@ -5361,7 +5908,8 @@
       "name_fr": "Bannière Hurlante",
       "name_it": "The Screaming Banner",
       "points": 45,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Standarte der höllischen Lebenskraft",
@@ -5371,7 +5919,8 @@
       "name_fr": "Étendard de Vigueur Infernale",
       "name_it": "Standard of Hellish Vigour",
       "points": 40,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_de": "Frostklinge",
@@ -5381,7 +5930,8 @@
       "name_fr": "Lame de Givre",
       "name_it": "Frostblade",
       "points": 60,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Schwert der Könige",
@@ -5391,7 +5941,8 @@
       "name_fr": "Épée des Rois",
       "name_it": "Spada of Kings",
       "points": 55,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Bluttrinker",
@@ -5401,7 +5952,8 @@
       "name_fr": "Buveur de Sang",
       "name_it": "Blood Drinker",
       "points": 45,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Schreckenslanze",
@@ -5411,7 +5963,8 @@
       "name_fr": "Lance d'Effroi",
       "name_it": "Dreadlance",
       "points": 40,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_de": "Rüstung des Gehäuteten",
@@ -5421,7 +5974,8 @@
       "name_fr": "Haubert de l'Écorché",
       "name_it": "The Flayed Hauberk",
       "points": 35,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Die verfluchte Rüstung",
@@ -5431,7 +5985,8 @@
       "name_fr": "Armure Maudite",
       "name_it": "The Accursed Armour",
       "points": 30,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_de": "Rüstung des Gehäuteten",
@@ -5441,7 +5996,8 @@
       "name_fr": "Haubert de l'Écorché",
       "name_it": "The Flayed Hauberk",
       "points": 35,
-      "type": "armor-mages"
+      "type": "armor-mages",
+      "onePerArmy": true
     },
     {
       "name_de": "Helm der absoluten Kontrolle",
@@ -5451,7 +6007,8 @@
       "name_fr": "Heaume de Commandement",
       "name_it": "Helm of Commandment",
       "points": 40,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Staubhand",
@@ -5461,7 +6018,8 @@
       "name_fr": "Main de Poussière",
       "name_it": "Hand of Dust",
       "points": 35,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Umhang aus Nebel und Schatten",
@@ -5471,7 +6029,8 @@
       "name_fr": "Cape de Brume et d'Ombres",
       "name_it": "Mantello of Mist & Shadows",
       "points": 30,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Schädelstab",
@@ -5481,7 +6040,8 @@
       "name_fr": "Bâton de Crâne",
       "name_it": "Skull Bastone",
       "points": 50,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Zepter des Noirot",
@@ -5491,7 +6051,8 @@
       "name_fr": "Sepctrez de Jacques De Noirot",
       "name_it": "Sceptre of De Noirot",
       "points": 35,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_de": "Zaubervertrauter*",
@@ -5502,7 +6063,8 @@
       "name_it": "Spell Familiar*",
       "points": 15,
       "stackable": true,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": false
     },
     {
       "name_de": "Carsteinring",
@@ -5512,7 +6074,8 @@
       "name_fr": "Anneaux des Carstein",
       "name_it": "Von Carstein Anello",
       "points": 40,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_de": "Krone der Verdammten",
@@ -5522,7 +6085,8 @@
       "name_fr": "Couronne des Damnés",
       "name_it": "Crown of the Damned",
       "points": 35,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     }
   ],
   "daemonic-gifts-common": [
@@ -5533,7 +6097,8 @@
       "name_fr": "Lame d'Éther",
       "name_it": "Æther Lama",
       "points": 55,
-      "type": "daemonic-gift-common"
+      "type": "daemonic-gift-common",
+      "onePerArmy": true
     },
     {
       "name-fr": "Nombreux Bras*",
@@ -5544,7 +6109,8 @@
       "points": 55,
       "stackable": true,
       "type": "daemonic-gift-common",
-      "name_fr": "Bras Multiples*"
+      "name_fr": "Bras Multiples*",
+      "onePerArmy": false
     },
     {
       "name_de": "Winged Horror",
@@ -5553,7 +6119,8 @@
       "name_fr": "Horreur Ailée",
       "name_it": "Winged Horror",
       "points": 45,
-      "type": "daemonic-gift-common"
+      "type": "daemonic-gift-common",
+      "onePerArmy": true
     },
     {
       "name_de": "Daemonic Robes",
@@ -5562,7 +6129,8 @@
       "name_fr": "Robes Démoniaques",
       "name_it": "Daemonic Robes",
       "points": 35,
-      "type": "daemonic-gift-common"
+      "type": "daemonic-gift-common",
+      "onePerArmy": true
     }
   ],
   "daemonic-icons-common": [
@@ -5573,7 +6141,8 @@
       "name_fr": "Bannière de Victoire Impie",
       "name_it": "Banner of Unholy Victory",
       "points": 60,
-      "type": "daemonic-icon-common"
+      "type": "daemonic-icon-common",
+      "onePerArmy": true
     },
     {
       "name_de": "Totem of Eternal War",
@@ -5582,7 +6151,8 @@
       "name_fr": "Totem de la Guerre Éternelle",
       "name_it": "Totem of Eternal War",
       "points": 45,
-      "type": "daemonic-icon-common"
+      "type": "daemonic-icon-common",
+      "onePerArmy": true
     },
     {
       "name_de": "Standard of Chaotic Glory",
@@ -5591,7 +6161,8 @@
       "name_fr": "Étendard de Gloire Chaotique",
       "name_it": "Standard of Chaotic Glory",
       "points": 30,
-      "type": "daemonic-icon-common"
+      "type": "daemonic-icon-common",
+      "onePerArmy": true
     }
   ],
   "daemonic-gifts-khorne": [
@@ -5602,7 +6173,8 @@
       "name_fr": "Mange Sorts",
       "name_it": "Spell Eater",
       "points": 50,
-      "type": "daemonic-gift-khorne"
+      "type": "daemonic-gift-khorne",
+      "onePerArmy": true
     },
     {
       "name_de": "Armour of Khorne",
@@ -5611,7 +6183,8 @@
       "name_fr": "Armure de Khorne",
       "name_it": "Armour of Khorne",
       "points": 40,
-      "type": "daemonic-gift-khorne"
+      "type": "daemonic-gift-khorne",
+      "onePerArmy": true
     },
     {
       "name_de": "Axe of Khorne*",
@@ -5621,7 +6194,8 @@
       "name_it": "Axe of Khorne*",
       "points": 35,
       "stackable": true,
-      "type": "daemonic-gift-khorne"
+      "type": "daemonic-gift-khorne",
+      "onePerArmy": false
     },
     {
       "name_de": "Might of Khorne",
@@ -5630,7 +6204,8 @@
       "name_fr": "Puissance de Khorne",
       "name_it": "Might of Khorne",
       "points": 25,
-      "type": "daemonic-gift-khorne"
+      "type": "daemonic-gift-khorne",
+      "onePerArmy": true
     },
     {
       "name_de": "Collar of Khorne*",
@@ -5640,7 +6215,8 @@
       "name_it": "Collar of Khorne*",
       "points": 25,
       "stackable": true,
-      "type": "daemonic-gift-khorne"
+      "type": "daemonic-gift-khorne",
+      "onePerArmy": false
     }
   ],
   "daemonic-icons-khorne": [
@@ -5651,7 +6227,8 @@
       "name_fr": "Totem des Crânes",
       "name_it": "Skull Totem",
       "points": 50,
-      "type": "daemonic-icon-khorne"
+      "type": "daemonic-icon-khorne",
+      "onePerArmy": true
     },
     {
       "name_de": "Great Standard of Sundering",
@@ -5660,7 +6237,8 @@
       "name_fr": "Grand Étendard de l'Écrasement",
       "name_it": "Great Standard of Sundering",
       "points": 45,
-      "type": "daemonic-icon-khorne"
+      "type": "daemonic-icon-khorne",
+      "onePerArmy": true
     },
     {
       "name_de": "Icon of Endless War",
@@ -5669,7 +6247,8 @@
       "name_fr": "Icône de Guerre Infinie",
       "name_it": "Icon of Endless War",
       "points": 30,
-      "type": "daemonic-icon-khorne"
+      "type": "daemonic-icon-khorne",
+      "onePerArmy": true
     }
   ],
   "daemonic-gifts-nurgle": [
@@ -5680,7 +6259,8 @@
       "name_fr": "Infestation de Nurglings",
       "name_it": "Nurgling Infestation",
       "points": 45,
-      "type": "daemonic-gift-nurgle"
+      "type": "daemonic-gift-nurgle",
+      "onePerArmy": true
     },
     {
       "name_de": "Sloppity Bilepiper",
@@ -5689,7 +6269,8 @@
       "name_fr": "Comique Trippier",
       "name_it": "Sloppity Bilepiper",
       "points": 35,
-      "type": "daemonic-gift-nurgle"
+      "type": "daemonic-gift-nurgle",
+      "onePerArmy": true
     },
     {
       "name_de": "Spoilpox Scrivener",
@@ -5698,7 +6279,8 @@
       "name_fr": "Scribe Gâchevariole",
       "name_it": "Spoilpox Scrivener",
       "points": 30,
-      "type": "daemonic-gift-nurgle"
+      "type": "daemonic-gift-nurgle",
+      "onePerArmy": true
     },
     {
       "name_de": "Trappings of Nurgle",
@@ -5707,7 +6289,8 @@
       "name_fr": "Atours de Nurgle",
       "name_it": "Trappings of Nurgle",
       "points": 30,
-      "type": "daemonic-gift-nurgle"
+      "type": "daemonic-gift-nurgle",
+      "onePerArmy": true
     },
     {
       "name_de": "Stream of Contagion*",
@@ -5717,7 +6300,8 @@
       "name_it": "Stream of Contagion*",
       "points": 25,
       "stackable": true,
-      "type": "daemonic-gift-nurgle"
+      "type": "daemonic-gift-nurgle",
+      "onePerArmy": false
     }
   ],
   "daemonic-icons-nurgle": [
@@ -5728,7 +6312,8 @@
       "name_fr": "Icône de Virulence Infinie",
       "name_it": "Icon of Eternal Virulence",
       "points": 50,
-      "type": "daemonic-icon-nurgle"
+      "type": "daemonic-icon-nurgle",
+      "onePerArmy": true
     },
     {
       "name_de": "Standard of Seeping Decay",
@@ -5737,7 +6322,8 @@
       "name_fr": "Étendard de la Décrépitude Purulente",
       "name_it": "Standard of Seeping Decay",
       "points": 35,
-      "type": "daemonic-icon-nurgle"
+      "type": "daemonic-icon-nurgle",
+      "onePerArmy": true
     },
     {
       "name_de": "Rotten Icon",
@@ -5746,7 +6332,8 @@
       "name_fr": "Icône Pourrie",
       "name_it": "Rotten Icon",
       "points": 10,
-      "type": "daemonic-icon-nurgle"
+      "type": "daemonic-icon-nurgle",
+      "onePerArmy": true
     }
   ],
   "daemonic-gifts-slaanesh": [
@@ -5757,7 +6344,8 @@
       "name_fr": "Enchantement Infernal",
       "name_it": "Infernal Enrapturess",
       "points": 50,
-      "type": "daemonic-gift-slaanesh"
+      "type": "daemonic-gift-slaanesh",
+      "onePerArmy": true
     },
     {
       "name_de": "Allure of Slaanesh",
@@ -5766,7 +6354,8 @@
       "name_fr": "Beauté de Slaanesh",
       "name_it": "Allure of Slaanesh",
       "points": 35,
-      "type": "daemonic-gift-slaanesh"
+      "type": "daemonic-gift-slaanesh",
+      "onePerArmy": true
     },
     {
       "name_de": "Siren Song",
@@ -5775,7 +6364,8 @@
       "name_fr": "Chant de la Sirène",
       "name_it": "Siren Song",
       "points": 30,
-      "type": "daemonic-gift-slaanesh"
+      "type": "daemonic-gift-slaanesh",
+      "onePerArmy": true
     },
     {
       "name_de": "Soporific Musk*",
@@ -5785,7 +6375,8 @@
       "name_it": "Soporific Musk*",
       "points": 30,
       "stackable": true,
-      "type": "daemonic-gift-slaanesh"
+      "type": "daemonic-gift-slaanesh",
+      "onePerArmy": false
     },
     {
       "name_de": "Enrapturing Gaze*",
@@ -5795,7 +6386,8 @@
       "name_it": "Enrapturing Gaze*",
       "points": 20,
       "stackable": true,
-      "type": "daemonic-gift-slaanesh"
+      "type": "daemonic-gift-slaanesh",
+      "onePerArmy": false
     }
   ],
   "daemonic-icons-slaanesh": [
@@ -5806,7 +6398,8 @@
       "name_fr": "Bannière du Consentement",
       "name_it": "Banner of Acquiescence",
       "points": 55,
-      "type": "daemonic-icon-slaanesh"
+      "type": "daemonic-icon-slaanesh",
+      "onePerArmy": true
     },
     {
       "name_de": "Rapturous Standard",
@@ -5815,7 +6408,8 @@
       "name_fr": "Étendard d'Enthousiasme",
       "name_it": "Rapturous Standard",
       "points": 35,
-      "type": "daemonic-icon-slaanesh"
+      "type": "daemonic-icon-slaanesh",
+      "onePerArmy": true
     },
     {
       "name_de": "Siren Standard",
@@ -5824,7 +6418,8 @@
       "name_fr": "Étendard de la Sirène",
       "name_it": "Siren Standard",
       "points": 25,
-      "type": "daemonic-icon-slaanesh"
+      "type": "daemonic-icon-slaanesh",
+      "onePerArmy": true
     }
   ],
   "daemonic-gifts-tzeentch": [
@@ -5835,7 +6430,8 @@
       "name_fr": "Bâton du Changement",
       "name_it": "Bastone of Change",
       "points": 65,
-      "type": "daemonic-gift-tzeentch"
+      "type": "daemonic-gift-tzeentch",
+      "onePerArmy": true
     },
     {
       "name_de": "Will of Tzeentch",
@@ -5844,7 +6440,8 @@
       "name_fr": "Volonté de Tzeentch",
       "name_it": "Will of Tzeentch",
       "points": 55,
-      "type": "daemonic-gift-tzeentch"
+      "type": "daemonic-gift-tzeentch",
+      "onePerArmy": true
     },
     {
       "name_de": "Power Vortex",
@@ -5853,7 +6450,8 @@
       "name_fr": "Vortex de Puissance",
       "name_it": "Potere Vortex",
       "points": 35,
-      "type": "daemonic-gift-tzeentch"
+      "type": "daemonic-gift-tzeentch",
+      "onePerArmy": true
     },
     {
       "name_de": "Iridescent Corona*",
@@ -5863,7 +6461,8 @@
       "name_it": "Iridescent Corona*",
       "points": 30,
       "stackable": true,
-      "type": "daemonic-gift-tzeentch"
+      "type": "daemonic-gift-tzeentch",
+      "onePerArmy": false
     },
     {
       "name_de": "Twin Heads",
@@ -5872,7 +6471,8 @@
       "name_fr": "Têtes Jumelles",
       "name_it": "Twin Heads",
       "points": 20,
-      "type": "daemonic-gift-tzeentch"
+      "type": "daemonic-gift-tzeentch",
+      "onePerArmy": true
     }
   ],
   "daemonic-icons-tzeentch": [
@@ -5883,7 +6483,8 @@
       "name_fr": "Bannière de Discorde",
       "name_it": "Banner of Discord",
       "points": 60,
-      "type": "daemonic-icon-tzeentch"
+      "type": "daemonic-icon-tzeentch",
+      "onePerArmy": true
     },
     {
       "name_de": "Banner of Change",
@@ -5892,7 +6493,8 @@
       "name_fr": "Bannière du Changement",
       "name_it": "Banner of Change",
       "points": 45,
-      "type": "daemonic-icon-tzeentch"
+      "type": "daemonic-icon-tzeentch",
+      "onePerArmy": true
     },
     {
       "name_de": "Icon of Sorcery*",
@@ -5902,7 +6504,8 @@
       "name_it": "Icon of Sorcery*",
       "points": 35,
       "stackable": true,
-      "type": "daemonic-icon-tzeentch"
+      "type": "daemonic-icon-tzeentch",
+      "onePerArmy": false
     }
   ],
   "vampiric-powers": [
@@ -5915,7 +6518,8 @@
       "name_it": "Curse of the Revenant",
       "nonExclusive": true,
       "points": 50,
-      "type": "vampiric-power"
+      "type": "vampiric-power",
+      "onePerArmy": true
     },
     {
       "name_de": "Bezauberndes Wesen",
@@ -5926,7 +6530,8 @@
       "name_it": "Beguile",
       "nonExclusive": true,
       "points": 40,
-      "type": "vampiric-power"
+      "type": "vampiric-power",
+      "onePerArmy": true
     },
     {
       "name_de": "Übernatürlicher Schrecken",
@@ -5937,7 +6542,8 @@
       "name_it": "Supernatural Horror",
       "nonExclusive": true,
       "points": 20,
-      "type": "vampiric-power"
+      "type": "vampiric-power",
+      "onePerArmy": true
     },
     {
       "name_de": "Ritter der Nacht",
@@ -5948,7 +6554,8 @@
       "name_it": "Lord of the Night",
       "nonExclusive": true,
       "points": 15,
-      "type": "vampiric-power"
+      "type": "vampiric-power",
+      "onePerArmy": true
     },
     {
       "name_de": "Meister der schwarzen Künste",
@@ -5959,7 +6566,8 @@
       "name_it": "Master of the Black Arts",
       "nonExclusive": true,
       "points": 30,
-      "type": "vampiric-power"
+      "type": "vampiric-power",
+      "onePerArmy": true
     },
     {
       "name_en": "Dark Acolyte {renegade}",
@@ -5970,7 +6578,8 @@
       "name_it": "Oscuro Acolyte",
       "nonExclusive": true,
       "points": 30,
-      "type": "vampiric-power"
+      "type": "vampiric-power",
+      "onePerArmy": true
     },
     {
       "name_de": "Fliegender Schrecken",
@@ -5981,7 +6590,8 @@
       "name_it": "Flying Horror",
       "nonExclusive": true,
       "points": 35,
-      "type": "vampiric-power"
+      "type": "vampiric-power",
+      "onePerArmy": true
     }
   ],
   "forbidden-poisons": [
@@ -5993,7 +6603,8 @@
       "name_fr": "Lotus Noir",
       "name_it": "Black Lotus",
       "points": 5,
-      "type": "forbidden-poison"
+      "type": "forbidden-poison",
+      "onePerArmy": false
     },
     {
       "name_de": "Dark Venom",
@@ -6003,7 +6614,8 @@
       "name_fr": "Venin Fuligineux",
       "name_it": "Oscuro Venom",
       "points": 15,
-      "type": "forbidden-poison"
+      "type": "forbidden-poison",
+      "onePerArmy": false
     },
     {
       "name_de": "Manbane",
@@ -6013,7 +6625,8 @@
       "name_fr": "Fléau des Hommes",
       "name_it": "Manbane",
       "points": 15,
-      "type": "forbidden-poison"
+      "type": "forbidden-poison",
+      "onePerArmy": false
     }
   ],
   "gifts-of-khaine": [
@@ -6025,7 +6638,8 @@
       "name_fr": "Cri de Guerre",
       "name_it": "Cry of War",
       "points": 15,
-      "type": "gift-of-khaine"
+      "type": "gift-of-khaine",
+      "onePerArmy": false
     },
     {
       "name_de": "Rune of Khaine",
@@ -6035,7 +6649,8 @@
       "name_fr": "Rune de Khaine",
       "name_it": "Rune of Khaine",
       "points": 10,
-      "type": "gift-of-khaine"
+      "type": "gift-of-khaine",
+      "onePerArmy": false
     },
     {
       "name_de": "Witchbrew",
@@ -6045,7 +6660,8 @@
       "name_fr": "Brouet de Sang",
       "name_it": "Witchbrew",
       "points": 20,
-      "type": "gift-of-khaine"
+      "type": "gift-of-khaine",
+      "onePerArmy": false
     }
   ],
   "kindreds": [
@@ -6057,7 +6673,8 @@
       "name_fr": "Aspect du Chien de Chasse",
       "name_it": "Aspect of the Hound",
       "points": 20,
-      "type": "kindred"
+      "type": "kindred",
+      "onePerArmy": false
     },
     {
       "name_de": "Aspect of the Bear",
@@ -6067,7 +6684,8 @@
       "name_fr": "Aspect de l’Ours",
       "name_it": "Aspect of the Bear",
       "points": 15,
-      "type": "kindred"
+      "type": "kindred",
+      "onePerArmy": false
     },
     {
       "name_de": "Aspect of the Boar",
@@ -6077,7 +6695,8 @@
       "name_fr": "Aspect du Sanglier",
       "name_it": "Aspect of the Boar",
       "points": 10,
-      "type": "kindred"
+      "type": "kindred",
+      "onePerArmy": false
     },
     {
       "name_de": "Aspect of the Cat",
@@ -6087,7 +6706,8 @@
       "name_fr": "Aspect du Chat",
       "name_it": "Aspect of the Cat",
       "points": 10,
-      "type": "kindred"
+      "type": "kindred",
+      "onePerArmy": false
     },
     {
       "name_de": "Glamour Weave Kindred",
@@ -6097,7 +6717,8 @@
       "name_fr": "Clan des Tisserêves",
       "name_it": "Glamour Weave Kindred",
       "points": 25,
-      "type": "kindred"
+      "type": "kindred",
+      "onePerArmy": false
     },
     {
       "name_de": "Eternal Kindred",
@@ -6107,7 +6728,8 @@
       "name_fr": "Clan Éternel",
       "name_it": "Eternal Kindred",
       "points": 20,
-      "type": "kindred"
+      "type": "kindred",
+      "onePerArmy": false
     },
     {
       "name_de": "Wild Rider Kindred",
@@ -6117,7 +6739,8 @@
       "name_fr": "Clan des Cavaliers Sauvages",
       "name_it": "Wild Rider Kindred",
       "points": 20,
-      "type": "kindred"
+      "type": "kindred",
+      "onePerArmy": false
     },
     {
       "name_de": "Scout Kindred",
@@ -6127,7 +6750,8 @@
       "name_fr": "Clan d’Éclaireurs",
       "name_it": "Scout Kindred",
       "points": 15,
-      "type": "kindred"
+      "type": "kindred",
+      "onePerArmy": false
     }
   ],
   "grand-cathay": [
@@ -6139,7 +6763,8 @@
       "name_fr": "The Monkey King's Wisdom",
       "name_it": "The Monkey King's Wisdom",
       "points": 75,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_en": "Jade Blade of the Great Fleet",
@@ -6149,7 +6774,8 @@
       "name_fr": "Jade Blade of the Great Fleet",
       "name_it": "Jade Blade of the Great Fleet",
       "points": 70,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_en": "Spirit Longma Spear",
@@ -6159,7 +6785,8 @@
       "name_fr": "Spirit Longma Spear",
       "name_it": "",
       "points": 25,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_en": "Sun & Moon Blades",
@@ -6169,7 +6796,8 @@
       "name_fr": "Sun & Moon Blades",
       "name_it": "Sun & Moon Blades",
       "points": 20,
-      "type": "weapon"
+      "type": "weapon",
+      "onePerArmy": true
     },
     {
       "name_en": "The Armour of the Warbird",
@@ -6179,7 +6807,8 @@
       "name_fr": "The Armour of the Warbird",
       "name_it": "The Armour of the Warbird",
       "points": 45,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_en": "Shield of Nan-Gau",
@@ -6189,7 +6818,8 @@
       "name_fr": "Shield of Nan-Gau",
       "name_it": "Shield of Nan-Gau",
       "points": 20,
-      "type": "armor"
+      "type": "armor",
+      "onePerArmy": true
     },
     {
       "name_en": "Crystal of Kunlan",
@@ -6199,7 +6829,8 @@
       "name_fr": "Crystal of Kunlan",
       "name_it": "Crystal of Kunlan",
       "points": 35,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_en": "Crown of Jade",
@@ -6209,7 +6840,8 @@
       "name_fr": "Crown of Jade",
       "name_it": "Crown of Jade",
       "points": 20,
-      "type": "talisman"
+      "type": "talisman",
+      "onePerArmy": true
     },
     {
       "name_en": "Standard of Wei-Jin",
@@ -6219,7 +6851,8 @@
       "name_fr": "Standard of Wei-Jin",
       "name_it": "Standard of Wei-Jin",
       "points": 40,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_en": "Icon of Heavenly Fury",
@@ -6229,7 +6862,8 @@
       "name_fr": "Icon of Heavenly Fury",
       "name_it": "Icon of Heavenly Fury",
       "points": 35,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_en": "Dragon's Eye Banner",
@@ -6239,7 +6873,8 @@
       "name_fr": "Dragon's Eye Banner",
       "name_it": "Dragon's Eye Banner",
       "points": 30,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_en": "Banner of the Bastion",
@@ -6249,7 +6884,8 @@
       "name_fr": "Banner of the Bastion",
       "name_it": "Banner of the Bastion",
       "points": 25,
-      "type": "banner"
+      "type": "banner",
+      "onePerArmy": true
     },
     {
       "name_en": "Maw Shard",
@@ -6259,7 +6895,8 @@
       "name_fr": "Maw Shard",
       "name_it": "Maw Shard",
       "points": 40,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_en": "Alchemist's Mask",
@@ -6269,7 +6906,8 @@
       "name_fr": "Alchemist's Mask",
       "name_it": "Alchemist's Mask",
       "points": 35,
-      "type": "enchanted-item"
+      "type": "enchanted-item",
+      "onePerArmy": true
     },
     {
       "name_en": "Spirit Lantern*",
@@ -6279,8 +6917,9 @@
       "name_fr": "Spirit Lantern*",
       "name_it": "Spirit Lantern*",
       "points": 25,
+      "stackable": true,
       "type": "enchanted-item",
-      "stackable": true
+      "onePerArmy": false
     },
     {
       "name_en": "Cloak of Po Mei",
@@ -6290,7 +6929,8 @@
       "name_fr": "Cloak of Po Mei",
       "name_it": "Cloak of Po Mei",
       "points": 50,
-      "type": "arcane-item"
+      "type": "arcane-item",
+      "onePerArmy": true
     },
     {
       "name_en": "Guardian Feng Shi Bo*",
@@ -6300,8 +6940,9 @@
       "name_fr": "Guardian Feng Shi Bo*",
       "name_it": "Guardian Feng Shi Bo*",
       "points": 35,
+      "stackable": true,
       "type": "arcane-item",
-      "stackable": true
+      "onePerArmy": false
     },
     {
       "name_en": "Learned Feng Shi Bo*",
@@ -6311,8 +6952,9 @@
       "name_fr": "Learned Feng Shi Bo*",
       "name_it": "Learned Feng Shi Bo*",
       "points": 15,
+      "stackable": true,
       "type": "arcane-item",
-      "stackable": true
+      "onePerArmy": false
     }
   ]
 }

--- a/src/i18n/cn.json
+++ b/src/i18n/cn.json
@@ -75,6 +75,8 @@
   "misc.error.grandMelee25": "Max 25% of your points for a single character or unit",
   "misc.error.grandMeleeLevel3": "0-1 Level 3 Wizard per 1000 points",
   "misc.error.grandMeleeLevel4": "0-1 Level 4 Wizard per 2000 points",
+  "misc.error.itemUsedElsewhereBy": "This item is in use by {usedby}",
+  "misc.and": "and",
   "editor.add": "添加",
   "editor.lords": "领主",
   "editor.heroes": "英雄",

--- a/src/i18n/cn.json
+++ b/src/i18n/cn.json
@@ -76,7 +76,6 @@
   "misc.error.grandMeleeLevel3": "0-1 Level 3 Wizard per 1000 points",
   "misc.error.grandMeleeLevel4": "0-1 Level 4 Wizard per 2000 points",
   "misc.error.itemUsedElsewhereBy": "This item is in use by {usedby}",
-  "misc.and": "and",
   "editor.add": "添加",
   "editor.lords": "领主",
   "editor.heroes": "英雄",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -76,7 +76,6 @@
   "misc.error.grandMeleeLevel3": "0-1 Stufe 3 Zauberer pro 1000 Punkten",
   "misc.error.grandMeleeLevel4": "0-1 Stufe 4 Zauberer pro 1000 Punkten",
   "misc.error.itemUsedElsewhereBy": "This item is in use by {usedby}",
-  "misc.and": "und",
   "editor.add": "Hinzufügen",
   "editor.lords": "Kommandanten",
   "editor.heroes": "Helden",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -75,6 +75,8 @@
   "misc.error.grandMelee25": "Max 25% der Punkte für ein Charakter oder eine Einheit",
   "misc.error.grandMeleeLevel3": "0-1 Stufe 3 Zauberer pro 1000 Punkten",
   "misc.error.grandMeleeLevel4": "0-1 Stufe 4 Zauberer pro 1000 Punkten",
+  "misc.error.itemUsedElsewhereBy": "This item is in use by {usedby}",
+  "misc.and": "und",
   "editor.add": "Hinzufügen",
   "editor.lords": "Kommandanten",
   "editor.heroes": "Helden",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -75,6 +75,8 @@
   "misc.error.grandMelee25": "Max 25% of your points for a single character or unit",
   "misc.error.grandMeleeLevel3": "0-1 Level 3 Wizard per 1000 points",
   "misc.error.grandMeleeLevel4": "0-1 Level 4 Wizard per 2000 points",
+  "misc.error.itemUsedElsewhereBy": "This item is in use by {usedby}",
+  "misc.and": "and",
   "editor.add": "Add",
   "editor.lords": "Lords",
   "editor.heroes": "Heroes",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -76,7 +76,6 @@
   "misc.error.grandMeleeLevel3": "0-1 Level 3 Wizard per 1000 points",
   "misc.error.grandMeleeLevel4": "0-1 Level 4 Wizard per 2000 points",
   "misc.error.itemUsedElsewhereBy": "This item is in use by {usedby}",
-  "misc.and": "and",
   "editor.add": "Add",
   "editor.lords": "Lords",
   "editor.heroes": "Heroes",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -76,7 +76,6 @@
   "misc.error.grandMeleeLevel3": "0-1 Level 3 Wizard per 1000 points",
   "misc.error.grandMeleeLevel4": "0-1 Level 4 Wizard per 2000 points",
   "misc.error.itemUsedElsewhereBy": "Este artículo está en uso por {usedby}",
-  "misc.and": "y",
   "editor.add": "Añadir",
   "editor.lords": "Comandantes",
   "editor.heroes": "Héroes",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -75,6 +75,8 @@
   "misc.error.grandMelee25": "Max 25% of your points for a single character or unit",
   "misc.error.grandMeleeLevel3": "0-1 Level 3 Wizard per 1000 points",
   "misc.error.grandMeleeLevel4": "0-1 Level 4 Wizard per 2000 points",
+  "misc.error.itemUsedElsewhereBy": "Este artículo está en uso por {usedby}",
+  "misc.and": "y",
   "editor.add": "Añadir",
   "editor.lords": "Comandantes",
   "editor.heroes": "Héroes",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -76,7 +76,6 @@
   "misc.error.grandMeleeLevel3": "0-1 Level 3 Wizard per 1000 points",
   "misc.error.grandMeleeLevel4": "0-1 Level 4 Wizard per 2000 points",
   "misc.error.itemUsedElsewhereBy": "This item is in use by {usedby}",
-  "misc.and": "et",
   "editor.add": "Ajouter",
   "editor.lords": "Seigneurs",
   "editor.heroes": "Héros",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -75,6 +75,8 @@
   "misc.error.grandMelee25": "Max 25% of your points for a single character or unit",
   "misc.error.grandMeleeLevel3": "0-1 Level 3 Wizard per 1000 points",
   "misc.error.grandMeleeLevel4": "0-1 Level 4 Wizard per 2000 points",
+  "misc.error.itemUsedElsewhereBy": "This item is in use by {usedby}",
+  "misc.and": "et",
   "editor.add": "Ajouter",
   "editor.lords": "Seigneurs",
   "editor.heroes": "Héros",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -75,6 +75,8 @@
   "misc.error.grandMelee25": "Max 25% of your points for a single character or unit",
   "misc.error.grandMeleeLevel3": "0-1 Level 3 Wizard per 1000 points",
   "misc.error.grandMeleeLevel4": "0-1 Level 4 Wizard per 2000 points",
+  "misc.error.itemUsedElsewhereBy": "This item is in use by {usedby}",
+  "misc.and": "e",
   "editor.add": "Aggiungi",
   "editor.lords": "Grandi Eroi",
   "editor.heroes": "Eroi",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -76,7 +76,6 @@
   "misc.error.grandMeleeLevel3": "0-1 Level 3 Wizard per 1000 points",
   "misc.error.grandMeleeLevel4": "0-1 Level 4 Wizard per 2000 points",
   "misc.error.itemUsedElsewhereBy": "This item is in use by {usedby}",
-  "misc.and": "e",
   "editor.add": "Aggiungi",
   "editor.lords": "Grandi Eroi",
   "editor.heroes": "Eroi",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -76,7 +76,6 @@
   "misc.error.grandMeleeLevel3": "0-1 Level 3 Wizard per 1000 points",
   "misc.error.grandMeleeLevel4": "0-1 Level 4 Wizard per 2000 points",
   "misc.error.itemUsedElsewhereBy": "This item is in use by {usedby}",
-  "misc.and": "i",
   "editor.add": "Dodaj",
   "editor.lords": "Lordowie",
   "editor.heroes": "Bochaterowie",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -75,6 +75,8 @@
   "misc.error.grandMelee25": "Max 25% of your points for a single character or unit",
   "misc.error.grandMeleeLevel3": "0-1 Level 3 Wizard per 1000 points",
   "misc.error.grandMeleeLevel4": "0-1 Level 4 Wizard per 2000 points",
+  "misc.error.itemUsedElsewhereBy": "This item is in use by {usedby}",
+  "misc.and": "i",
   "editor.add": "Dodaj",
   "editor.lords": "Lordowie",
   "editor.heroes": "Bochaterowie",

--- a/src/pages/magic/Magic.js
+++ b/src/pages/magic/Magic.js
@@ -1,5 +1,5 @@
 import { Fragment, useEffect, useState } from "react";
-import { useParams, useLocation } from "react-router-dom";
+import { Link, useParams, useLocation } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { FormattedMessage, useIntl } from "react-intl";
 import classNames from "classnames";
@@ -15,7 +15,7 @@ import { setItems } from "../../state/items";
 import { editUnit } from "../../state/lists";
 import { useLanguage } from "../../utils/useLanguage";
 import { updateLocalList } from "../../utils/list";
-import { equalsOrIncludes, humanReadableList } from "../../utils/string";
+import { equalsOrIncludes } from "../../utils/string";
 import { getGameSystems } from "../../utils/game-systems";
 import {
   isMultipleAllowedItem,
@@ -334,10 +334,15 @@ export const Magic = ({ isMobile }) => {
         undefined
       : maxAllowedOfItem(magicItem, selectedAmount, unitPointsRemaining);
 
-    const usedElsewhereBy = humanReadableList(
-      usedElsewhereErrors?.map((error) => error.unit[`name_${language}`] || error.unit.name_en),
-      intl.formatMessage({id: "misc.and" })
-    );
+    const usedElsewhereBy = <span>
+      {usedElsewhereErrors?.map(
+        (error, index) => 
+          <>
+            <Link to={error.url}>{error.unit[`name_${language}`] || error.unit.name_en}</Link>
+            {index !== usedElsewhereErrors.length - 1 ? ', ' : ''}
+          </>
+      )}
+    </span>;
 
     return (
       <Fragment key={`${magicItem.name_en}-${magicItem.id}`}>
@@ -390,12 +395,14 @@ export const Magic = ({ isMobile }) => {
         </div>
         {usedElsewhereErrors && usedElsewhereErrors.length > 0 &&
           <ErrorMessage key={`${magicItem.name_en}-${magicItem.id}-usedElsewhere`} spaceAfter spaceBefore={isMobile}>
-            <FormattedMessage 
-              id="misc.error.itemUsedElsewhereBy"
-              values={{
-                usedby: usedElsewhereBy,
-              }}
-            />
+            <span>
+              <FormattedMessage 
+                id="misc.error.itemUsedElsewhereBy"
+                values={{
+                  usedby: usedElsewhereBy,
+                }}
+              />
+            </span>
           </ErrorMessage>
         }
 
@@ -614,7 +621,6 @@ export const Magic = ({ isMobile }) => {
                       selectedAmount,
                       isChecked,
                       isTypeLimitReached,
-                      isChecked,
                       usedElsewhereErrors
                     })}
 

--- a/src/pages/magic/Magic.js
+++ b/src/pages/magic/Magic.js
@@ -9,6 +9,7 @@ import { getUnitMagicPoints } from "../../utils/points";
 import { fetcher } from "../../utils/fetcher";
 import { Header, Main } from "../../components/page";
 import { NumberInput } from "../../components/number-input";
+import { ErrorMessage } from "../../components/error-message";
 import { RulesIndex, RuleWithIcon } from "../../components/rules-index";
 import { setItems } from "../../state/items";
 import { editUnit } from "../../state/lists";
@@ -18,6 +19,7 @@ import { equalsOrIncludes } from "../../utils/string";
 import { getGameSystems } from "../../utils/game-systems";
 import {
   isMultipleAllowedItem,
+  itemsUsedElsewhere,
   maxAllowedOfItem,
 } from "../../utils/magic-item-limitations";
 
@@ -254,6 +256,16 @@ export const Magic = ({ isMobile }) => {
   }, [list]);
 
   useEffect(() => {
+    if (unit && list && unitId) {
+      if (command) {
+        itemsUsedElsewhere(unit?.command[command]?.magic?.selected || [], list, unitId)
+      } else {
+        itemsUsedElsewhere(unit?.items[group || 0]?.selected || [], list, unitId)
+      }
+    }
+  }, [unit, list, unitId])
+
+  useEffect(() => {
     army &&
       list &&
       unit &&
@@ -309,6 +321,7 @@ export const Magic = ({ isMobile }) => {
     itemGroup,
     isConditional,
     isTypeLimitReached,
+    showError,
   }) => {
     const isCommand = Boolean(
       unit && commandOptions[command]?.magic?.types.length
@@ -368,6 +381,11 @@ export const Magic = ({ isMobile }) => {
             />
           </label>
         </div>
+        {showError &&
+          <ErrorMessage key={'asdf'} spaceAfter spaceBefore={isMobile}>
+            <FormattedMessage id={"This item is in use by another unit"} />
+          </ErrorMessage>
+        }
 
         {isMultipleAllowedItem(magicItem) && isChecked && max !== 1 && (
           <NumberInput
@@ -582,6 +600,7 @@ export const Magic = ({ isMobile }) => {
                       selectedAmount,
                       isChecked,
                       isTypeLimitReached,
+                      isChecked
                     })}
 
                     {magicItem.conditional && isChecked

--- a/src/pages/magic/Magic.js
+++ b/src/pages/magic/Magic.js
@@ -334,15 +334,13 @@ export const Magic = ({ isMobile }) => {
         undefined
       : maxAllowedOfItem(magicItem, selectedAmount, unitPointsRemaining);
 
-    const usedElsewhereBy = <span>
-      {usedElsewhereErrors?.map(
-        (error, index) => 
-          <>
-            <Link to={error.url}>{error.unit[`name_${language}`] || error.unit.name_en}</Link>
-            {index !== usedElsewhereErrors.length - 1 ? ', ' : ''}
-          </>
-      )}
-    </span>;
+    const usedElsewhereBy = usedElsewhereErrors?.map(
+      (error, index) => 
+        <Fragment key={`${error.unit.id}-error-link`}>
+          <Link to={error.url}>{error.unit[`name_${language}`] || error.unit.name_en}</Link>
+          {index !== usedElsewhereErrors.length - 1 ? ', ' : ''}
+        </Fragment>
+    );
 
     return (
       <Fragment key={`${magicItem.name_en}-${magicItem.id}`}>

--- a/src/pages/magic/Magic.js
+++ b/src/pages/magic/Magic.js
@@ -259,11 +259,11 @@ export const Magic = ({ isMobile }) => {
 
   useEffect(() => {
     if (unit && list && unitId) {
+      let items = (unit?.items && unit.items[group || 0]?.selected) || [];
       if (command) {
-        setUsedElsewhere(itemsUsedElsewhere(unit?.command[command]?.magic?.selected || [], list, unitId));
-      } else {
-        setUsedElsewhere(itemsUsedElsewhere(unit?.items[group || 0]?.selected || [], list, unitId));
+        items = items.concat(unit?.command[command]?.magic?.selected || []);
       }
+      setUsedElsewhere(itemsUsedElsewhere(items, list, unitId));
     }
   }, [unit, list, unitId])
 
@@ -389,7 +389,7 @@ export const Magic = ({ isMobile }) => {
           </label>
         </div>
         {usedElsewhereErrors && usedElsewhereErrors.length > 0 &&
-          <ErrorMessage key={'asdf'} spaceAfter spaceBefore={isMobile}>
+          <ErrorMessage key={`${magicItem.name_en}-${magicItem.id}-usedElsewhere`} spaceAfter spaceBefore={isMobile}>
             <FormattedMessage 
               id="misc.error.itemUsedElsewhereBy"
               values={{

--- a/src/utils/magic-item-limitations.js
+++ b/src/utils/magic-item-limitations.js
@@ -49,13 +49,13 @@ export const maxAllowedOfItem = (
  * @returns {object[]} List of error messages for items that have failed validation
  */
 export const itemsUsedElsewhere = (items, list, excludeId) => {
-  let unit_categories = ['characters', 'core', 'special', 'rare', 'mercenaries', 'allies'];
+  const unitCategories = ['characters', 'core', 'special', 'rare', 'mercenaries', 'allies'];
   let errors = [];
   for (let i in items) {
     let item = items[i];
     if (item.onePerArmy === true) {
-      for (let category_index in unit_categories) {
-        let category = unit_categories[category_index];
+      for (let categoryIndex in unitCategories) {
+        let category = unitCategories[categoryIndex];
         for (let j in list[category]) {
           let unit = list[category][j];
           if (unit.id !== excludeId) {

--- a/src/utils/magic-item-limitations.js
+++ b/src/utils/magic-item-limitations.js
@@ -49,7 +49,7 @@ export const maxAllowedOfItem = (
  * @returns {object[]} List of error messages for items that have failed validation
  */
 export const itemsUsedElsewhere = (items, list, excludeId) => {
-  let combinedUnits = [].concat(list.characters, list.core, list.special, list.rare, list.mercenaries);
+  let combinedUnits = [].concat(list.characters, list.core, list.special, list.rare, list.mercenaries, list.allies);
   let errors = [];
   for (let i in items) {
     let item = items[i];

--- a/src/utils/magic-item-limitations.js
+++ b/src/utils/magic-item-limitations.js
@@ -53,7 +53,7 @@ export const itemsUsedElsewhere = (items, list, excludeId) => {
   let errors = [];
   for (let i in items) {
     let item = items[i];
-    if (item.stackable !== true) {
+    if (item.onePerArmy === true) {
       for (let j in combinedUnits) {
         let unit = combinedUnits[j];
         if (unit.id !== excludeId) {

--- a/src/utils/magic-item-limitations.js
+++ b/src/utils/magic-item-limitations.js
@@ -51,7 +51,6 @@ export const maxAllowedOfItem = (
 export const itemsUsedElsewhere = (items, list, excludeId) => {
   let unit_categories = ['characters', 'core', 'special', 'rare', 'mercenaries', 'allies'];
   let errors = [];
-  console.log(list);
   for (let i in items) {
     let item = items[i];
     if (item.onePerArmy === true) {
@@ -74,15 +73,17 @@ export const itemsUsedElsewhere = (items, list, excludeId) => {
               }
             }
             for (let commandGroup in unit.command) {
-              for (let targetItem in unit.command[commandGroup].magic?.selected) {
-                if (unit.command[commandGroup].magic.selected[targetItem].name_en === item.name_en) {
-                  errors.push(
-                    {
-                      itemName: item.name_en,
-                      unit: unit,
-                      url: `/editor/${list.id}/${category}/${unit.id}/magic/${commandGroup}`
-                    }
-                  );
+              if (unit.command[commandGroup].active) {
+                for (let targetItem in unit.command[commandGroup].magic?.selected) {
+                  if (unit.command[commandGroup].magic.selected[targetItem].name_en === item.name_en) {
+                    errors.push(
+                      {
+                        itemName: item.name_en,
+                        unit: unit,
+                        url: `/editor/${list.id}/${category}/${unit.id}/magic/${commandGroup}`
+                      }
+                    );
+                  }
                 }
               }
             }

--- a/src/utils/magic-item-limitations.js
+++ b/src/utils/magic-item-limitations.js
@@ -40,7 +40,8 @@ export const maxAllowedOfItem = (
 };
 
 /**
- * Checks if non-extremely common items are used elsewhere in a list
+ * Checks if items are used elsewhere in an army list, unless an item is extremely common or
+ * otherwise can be used by multiple units.
  * 
  * @param {object[]} items Array of magic items to be looked for in the list
  * @param {object} list The army list to be checked
@@ -67,7 +68,7 @@ export const itemsUsedElsewhere = (items, list, excludeId) => {
             if (allItems[targetItem].name_en === item.name_en) {
               errors.push(
                 {
-                  itemID: item.name_en,
+                  itemName: item.name_en,
                   unit: unit,
                 }
               );
@@ -77,5 +78,5 @@ export const itemsUsedElsewhere = (items, list, excludeId) => {
       }
     }
   }
-  return errors
+  return errors;
 }

--- a/src/utils/magic-item-limitations.js
+++ b/src/utils/magic-item-limitations.js
@@ -38,3 +38,44 @@ export const maxAllowedOfItem = (
 
   return pointsRemainingMax;
 };
+
+/**
+ * Checks if non-extremely common items are used elsewhere in a list
+ * 
+ * @param {object[]} items Array of magic items to be looked for in the list
+ * @param {object} list The army list to be checked
+ * @param {string} excludeId The id of the character/unit with the items, which will be skipped by the check
+ * @returns {object[]} List of error messages for items that have failed validation
+ */
+export const itemsUsedElsewhere = (items, list, excludeId) => {
+  let combinedUnits = [].concat(list.characters, list.core, list.special, list.rare, list.mercenaries);
+  let errors = [];
+  for (let i in items) {
+    let item = items[i];
+    if (item.stackable !== true) {
+      for (let j in combinedUnits) {
+        let unit = combinedUnits[j];
+        if (unit.id !== excludeId) {
+          let allItems = [];
+          if (unit.items?.length > 0) {
+            allItems = allItems.concat(unit.items.map((group) => group.selected || []).flat());
+          }
+          if (unit.command?.length > 0) {
+            allItems = allItems.concat(unit.command.map((command) => command.magic?.selected || []).flat());
+          }
+          for (let targetItem in allItems) {
+            if (allItems[targetItem].name_en === item.name_en) {
+              errors.push(
+                {
+                  itemID: item.name_en,
+                  unit: unit,
+                }
+              );
+            }
+          }
+        }
+      }
+    }
+  }
+  return errors
+}

--- a/src/utils/magic-item-limitations.test.js
+++ b/src/utils/magic-item-limitations.test.js
@@ -1,6 +1,7 @@
 import {
   isMultipleAllowedItem,
   maxAllowedOfItem,
+  itemsUsedElsewhere,
 } from "./magic-item-limitations";
 import magicItems from "../../public/games/the-old-world/magic-items.json";
 
@@ -67,3 +68,87 @@ describe("maxAllowedOfItem", () => {
     expect(maxAllowedOfItem(item, selectedAmount, unitPointsRemaining)).toBe(3);
   });
 });
+
+const princeID = "prince.rbexhgs";
+// List with a Prince and a Mage with no overlapping items
+const itemsElswhereList = {
+  "name": "High Elf Realms",
+  "game": "the-old-world",
+  "army": "high-elf-realms",
+  "characters": [
+    {
+      "name_en": "Prince",
+      "id": princeID,
+      "items": [
+        {
+          "name_en": "Magic Items",
+          "selected": [
+            {
+              "name_en": "Berserker Blade",
+              "type": "weapon",
+              "id": "general-8"
+            },
+            {
+              "name_en": "Dragon Helm",
+              "type": "armor",
+              "id": "high-elf-realms-11"
+            }
+          ],
+        }
+      ],
+    },{
+      "name_en": "Mage",
+      "id": "mage.qhhrfk",
+      "items": [
+        {
+          "name_en": "Magic Items",
+          "selected": [],
+        }
+      ]
+    }
+  ],
+  "core": [],
+  "special": [],
+  "rare": [],
+  "mercenaries": [],
+  "allies": [],
+  "armyComposition": "high-elf-realms",
+}
+
+describe("itemsUsedElsewhere", () => {
+  test("Warns if an item is used by more than one hero", () => {
+    const items = [
+      magicItems.general.find(
+        (item) => item.name_en === "Berserker Blade"
+      )
+    ];
+    
+    // Deep copy of list
+    // structuredClone would do this cleaner, but it doesn't seem supported
+    // by whatever version of node is running here.
+    const list = JSON.parse(JSON.stringify(itemsElswhereList));
+
+    //Add a Noble with an item shared with the Prince
+    list.characters.push(
+      {
+        "name_en": "Noble",
+        "id": "noble.xglrvqwbe",
+        "items": [
+          {
+            "name_en": "Magic Items",
+            "selected": [
+              {
+                "name_en": "Berserker Blade",
+                "type": "weapon",
+                "id": "general-8"
+              }
+            ],
+          }
+        ],
+      }
+    );
+    expect(itemsUsedElsewhere(items, list, princeID)).toHaveLength(1);
+  });
+});
+
+

--- a/src/utils/magic-item-limitations.test.js
+++ b/src/utils/magic-item-limitations.test.js
@@ -145,6 +145,7 @@ describe("itemsUsedElsewhere", () => {
     list.characters.push(
       {
         "name_en": "Noble",
+        "id": "noble.xglrvqwbe",
         "items": [
           {
             "name_en": "Magic Items",
@@ -179,6 +180,7 @@ describe("itemsUsedElsewhere", () => {
     list.core.push(
       {
         "name_en": "Silver Helms",
+        "id": "silver-helms.qjbtqm",
         "command": [
           {
             "name_en": "High Helm (champion)",
@@ -206,6 +208,7 @@ describe("itemsUsedElsewhere", () => {
     list.characters.push(
       {
         "name_en": "Noble",
+        "id": "noble.xglrvqwbe",
         "items": [
           {
             "name_en": "Elven Honours",

--- a/src/utils/magic-item-limitations.test.js
+++ b/src/utils/magic-item-limitations.test.js
@@ -125,7 +125,7 @@ describe("itemsUsedElsewhere", () => {
     
     // Deep copy of list
     // structuredClone would do this cleaner, but it doesn't seem supported
-    // by whatever version of node is running here.
+    // by whatever version of node is running tests here.
     const list = JSON.parse(JSON.stringify(itemsElswhereList));
 
     //Add a Noble with an item shared with the Prince

--- a/src/utils/magic-item-limitations.test.js
+++ b/src/utils/magic-item-limitations.test.js
@@ -83,26 +83,39 @@ const itemsElswhereList = {
         {
           "name_en": "Magic Items",
           "selected": [
-            {
-              "name_en": "Berserker Blade",
-              "type": "weapon",
-              "id": "general-8"
-            },
-            {
-              "name_en": "Dragon Helm",
-              "type": "armor",
-              "id": "high-elf-realms-11"
-            }
-          ],
+            magicItems.general.find(
+              (item) => item.name_en === "Berserker Blade"
+            ),
+            magicItems["high-elf-realms"].find(
+              (item) => item.name_en === "Dragon Helm"
+            )
+          ]
+        },
+        {
+          "name_en": "Elven Honours",
+          "selected": [
+            magicItems["elven-honours"].find(
+              (item) => item.name_en === "Sea Guard"
+            )
+          ]
         }
-      ],
-    },{
+      ]
+    }, {
       "name_en": "Mage",
       "id": "mage.qhhrfk",
       "items": [
         {
           "name_en": "Magic Items",
-          "selected": [],
+          "selected": [
+            {
+              "name_en": "Elven Honours",
+              "selected": [
+                magicItems["elven-honours"].find(
+                  (item) => item.name_en === "Pure of Heart"
+                )
+              ]
+            }
+          ]
         }
       ]
     }
@@ -116,39 +129,96 @@ const itemsElswhereList = {
 }
 
 describe("itemsUsedElsewhere", () => {
+  test("No errors if no items are shared", () => {
+    const items = itemsElswhereList.characters[0].items[0].selected; // Berserker Blade and Dragon Helm
+    // Deep copy of list. structuredClone() would do this cleaner, but it 
+    // doesn't seem supported by whatever version of node is running tests here.
+    const list = JSON.parse(JSON.stringify(itemsElswhereList));
+    expect(itemsUsedElsewhere(items, list, princeID)).toHaveLength(0);
+  })
+
   test("Warns if an item is used by more than one hero", () => {
-    const items = [
-      magicItems.general.find(
-        (item) => item.name_en === "Berserker Blade"
-      )
-    ];
-    
-    // Deep copy of list
-    // structuredClone would do this cleaner, but it doesn't seem supported
-    // by whatever version of node is running tests here.
+    const items = itemsElswhereList.characters[0].items[0].selected; // Berserker Blade and Dragon Helm
     const list = JSON.parse(JSON.stringify(itemsElswhereList));
 
-    //Add a Noble with an item shared with the Prince
+    //Add a Noble with Berserk Blade, which is shared with the Prince
     list.characters.push(
       {
         "name_en": "Noble",
-        "id": "noble.xglrvqwbe",
         "items": [
           {
             "name_en": "Magic Items",
             "selected": [
-              {
-                "name_en": "Berserker Blade",
-                "type": "weapon",
-                "id": "general-8"
-              }
-            ],
+              magicItems.general.find(
+                (item) => item.name_en === "Berserker Blade"
+              )
+            ]
           }
-        ],
+        ]
       }
     );
-    expect(itemsUsedElsewhere(items, list, princeID)).toHaveLength(1);
+    
+    let elsewhereErrors = itemsUsedElsewhere(items, list, princeID);
+    expect(elsewhereErrors).toHaveLength(1);
+
+    //Add a Dragon Helm to the Noble, which is shared with the Prince
+    list.characters[2].items[0].selected.push(
+      magicItems["high-elf-realms"].find(
+        (item) => item.name_en === "Dragon Helm"
+      )
+    );
+    elsewhereErrors = itemsUsedElsewhere(items, list, princeID);
+    expect(elsewhereErrors).toHaveLength(2);
+  });
+
+  test("Warns if a character's item is used by command models", () => {
+    const items = itemsElswhereList.characters[0].items[0].selected; // Berserker Blade and Dragon Helm
+    const list = JSON.parse(JSON.stringify(itemsElswhereList));
+
+    //Add a unit of Silver Helms whose champion has a Berserker Blade
+    list.core.push(
+      {
+        "name_en": "Silver Helms",
+        "command": [
+          {
+            "name_en": "High Helm (champion)",
+            "active": true,
+            "magic": {
+              "selected": [
+                magicItems.general.find(
+                  (item) => item.name_en === "Berserker Blade"
+                )
+              ]
+            }
+          }
+        ]
+      }
+    );
+    let elsewhereErrors = itemsUsedElsewhere(items, list, princeID);
+    expect(elsewhereErrors).toHaveLength(1);
+  });
+
+  test("No error if an item can be used by more than one unit", () => {
+    const items = itemsElswhereList.characters[0].items[1].selected; // Elven Honour Sea Guard
+    const list = JSON.parse(JSON.stringify(itemsElswhereList));
+
+    //Add a Noble with the Sea Guard Honour
+    list.characters.push(
+      {
+        "name_en": "Noble",
+        "items": [
+          {
+            "name_en": "Elven Honours",
+            "selected": [
+              magicItems["elven-honours"].find(
+                (item) => item.name_en === "Sea Guard"
+              )
+            ]
+          }
+        ]
+      }
+    );
+    let elsewhereErrors = itemsUsedElsewhere(items, list, princeID);
+    expect(elsewhereErrors).toHaveLength(0);
   });
 });
-
-

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -29,7 +29,7 @@ export const equalsOrIncludes = (strOrArray, x) => (
  * 
  * @param {string[]} words Array of strings to join
  * @param {string} conjunction Conjunction word joining the last two words. Defaults to 'and'
- * @returns {string} Joined string with commas and 'and'
+ * @returns {string} Joined string with commas and conjunction
  */
 export const humanReadableList = (words, conjunction) => {
   conjunction = conjunction || 'and';

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -22,3 +22,21 @@ export const equalsOrIncludes = (strOrArray, x) => (
   x === strOrArray ||
   (Array.isArray(strOrArray) && strOrArray.includes(x))
 );
+
+/**
+ * Turns an array of strings into a single string joined with commas and 'and'. Does not use the Oxford comma.
+ * For example given ['a', 'b', 'c'] it returns "a, b and c".
+ * 
+ * @param {string[]} words Array of strings to join
+ * @param {string} conjunction Conjunction word joining the last two words. Defaults to 'and'
+ * @returns {string} Joined string with commas and 'and'
+ */
+export const humanReadableList = (words, conjunction) => {
+  conjunction = conjunction || 'and';
+  if (!words || words.length === 0)
+    return '';
+  if (words.length < 2)
+    return words.join(` ${conjunction} `);
+  const allButLast = words.slice(0, -1).join(', ');
+  return `${allButLast} ${conjunction} ${words[words.length - 1]}`;
+}

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -22,21 +22,3 @@ export const equalsOrIncludes = (strOrArray, x) => (
   x === strOrArray ||
   (Array.isArray(strOrArray) && strOrArray.includes(x))
 );
-
-/**
- * Turns an array of strings into a single string joined with commas and 'and'. Does not use the Oxford comma.
- * For example given ['a', 'b', 'c'] it returns "a, b and c".
- * 
- * @param {string[]} words Array of strings to join
- * @param {string} conjunction Conjunction word joining the last two words. Defaults to 'and'
- * @returns {string} Joined string with commas and conjunction
- */
-export const humanReadableList = (words, conjunction) => {
-  conjunction = conjunction || 'and';
-  if (!words || words.length === 0)
-    return '';
-  if (words.length < 2)
-    return words.join(` ${conjunction} `);
-  const allButLast = words.slice(0, -1).join(', ');
-  return `${allButLast} ${conjunction} ${words[words.length - 1]}`;
-}

--- a/src/utils/string.test.js
+++ b/src/utils/string.test.js
@@ -41,31 +41,31 @@ describe("equalsOrIncludes", () => {
 });
 
 describe('humanReadableList', () => {
-    test('returns empty string for empty array', () => {
+    test('Returns empty string for empty array', () => {
         expect(humanReadableList([])).toBe('');
     });
 
-    test('returns single word for one-element array', () => {
+    test('Returns single word for one-element array', () => {
         expect(humanReadableList(['Dan'])).toBe('Dan');
     });
 
-    test('joins two words with "and"', () => {
+    test('Joins two words with "and"', () => {
         expect(humanReadableList(['Dan', 'David'])).toBe('Dan and David');
     });
 
-    test('joins three words with commas and "and"', () => {
+    test('Joins three words with commas and "and"', () => {
         expect(humanReadableList(['Dan', 'David', 'Joe'])).toBe('Dan, David and Joe');
     });
 
-    test('joins more than three words correctly', () => {
+    test('Joins more than three words correctly', () => {
         expect(humanReadableList(['Dan', 'David', 'Joe', 'Amy'])).toBe('Dan, David, Joe and Amy');
     });
 
-    test('can use other conjunctions', () => {
+    test('Can use other conjunctions', () => {
         expect(humanReadableList(['Dan', 'David', 'Joe', 'Amy'], 'or')).toBe('Dan, David, Joe or Amy');
     });
 
-    test('handles null or undefined input', () => {
+    test('Handles null or undefined input', () => {
         expect(humanReadableList(null)).toBe('');
         expect(humanReadableList(undefined)).toBe('');
     });

--- a/src/utils/string.test.js
+++ b/src/utils/string.test.js
@@ -1,4 +1,4 @@
-import { normalizeRuleName, equalsOrIncludes } from "./string";
+import { normalizeRuleName, equalsOrIncludes, humanReadableList } from "./string";
 
 describe("normalizeRuleName", () => {
   test("Lower cases rules names", () => {
@@ -38,4 +38,35 @@ describe("equalsOrIncludes", () => {
   test("Returns false if object is array and target isn't in it", () => {
     expect(equalsOrIncludes(["tomb-kings", "mortuary-cults"], "kings")).toBe(false);
   });
+});
+
+describe('humanReadableList', () => {
+    test('returns empty string for empty array', () => {
+        expect(humanReadableList([])).toBe('');
+    });
+
+    test('returns single word for one-element array', () => {
+        expect(humanReadableList(['Dan'])).toBe('Dan');
+    });
+
+    test('joins two words with "and"', () => {
+        expect(humanReadableList(['Dan', 'David'])).toBe('Dan and David');
+    });
+
+    test('joins three words with commas and "and"', () => {
+        expect(humanReadableList(['Dan', 'David', 'Joe'])).toBe('Dan, David and Joe');
+    });
+
+    test('joins more than three words correctly', () => {
+        expect(humanReadableList(['Dan', 'David', 'Joe', 'Amy'])).toBe('Dan, David, Joe and Amy');
+    });
+
+    test('can use other conjunctions', () => {
+        expect(humanReadableList(['Dan', 'David', 'Joe', 'Amy'], 'or')).toBe('Dan, David, Joe or Amy');
+    });
+
+    test('handles null or undefined input', () => {
+        expect(humanReadableList(null)).toBe('');
+        expect(humanReadableList(undefined)).toBe('');
+    });
 });

--- a/src/utils/string.test.js
+++ b/src/utils/string.test.js
@@ -1,4 +1,4 @@
-import { normalizeRuleName, equalsOrIncludes, humanReadableList } from "./string";
+import { normalizeRuleName, equalsOrIncludes } from "./string";
 
 describe("normalizeRuleName", () => {
   test("Lower cases rules names", () => {
@@ -38,35 +38,4 @@ describe("equalsOrIncludes", () => {
   test("Returns false if object is array and target isn't in it", () => {
     expect(equalsOrIncludes(["tomb-kings", "mortuary-cults"], "kings")).toBe(false);
   });
-});
-
-describe('humanReadableList', () => {
-    test('Returns empty string for empty array', () => {
-        expect(humanReadableList([])).toBe('');
-    });
-
-    test('Returns single word for one-element array', () => {
-        expect(humanReadableList(['Dan'])).toBe('Dan');
-    });
-
-    test('Joins two words with "and"', () => {
-        expect(humanReadableList(['Dan', 'David'])).toBe('Dan and David');
-    });
-
-    test('Joins three words with commas and "and"', () => {
-        expect(humanReadableList(['Dan', 'David', 'Joe'])).toBe('Dan, David and Joe');
-    });
-
-    test('Joins more than three words correctly', () => {
-        expect(humanReadableList(['Dan', 'David', 'Joe', 'Amy'])).toBe('Dan, David, Joe and Amy');
-    });
-
-    test('Can use other conjunctions', () => {
-        expect(humanReadableList(['Dan', 'David', 'Joe', 'Amy'], 'or')).toBe('Dan, David, Joe or Amy');
-    });
-
-    test('Handles null or undefined input', () => {
-        expect(humanReadableList(null)).toBe('');
-        expect(humanReadableList(undefined)).toBe('');
-    });
 });


### PR DESCRIPTION
Most magic items and many item-like abilities can only be used once per army. This PR adds an error message if a such an item is used by more than one unit, and includes a link to the item selection panel for that unit to aid in quickly fixing the issue.

Whether or not an item triggers this validation is controlled with a new property on the item definitions in `magic-items.json`, `onePerArmy`. If this property is false or undefined it will not trigger validation.
![UsedElsewhereDemo](https://github.com/user-attachments/assets/10323be9-0df0-483a-bdcc-a13390807f7e)

