### PR TITLE
Add "Rule of Pride" validation for rune items

### DIFF
--- a/src/i18n/cn.json
+++ b/src/i18n/cn.json
@@ -89,6 +89,7 @@
   "misc.error.grandMeleeLevel3": "0-1 Level 3 Wizard per 1000 points",
   "misc.error.grandMeleeLevel4": "0-1 Level 4 Wizard per 2000 points",
   "misc.error.itemUsedElsewhereBy": "This item is in use by {usedby}",
+  "misc.error.runesUsedElsewhereBy": "This set of runes is in use by {usedby}",
   "editor.add": "添加",
   "editor.lords": "领主",
   "editor.heroes": "英雄",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -89,6 +89,7 @@
   "misc.error.grandMeleeLevel3": "0-1 Stufe 3 Zauberer pro 1000 Punkten",
   "misc.error.grandMeleeLevel4": "0-1 Stufe 4 Zauberer pro 1000 Punkten",
   "misc.error.itemUsedElsewhereBy": "{usedby} nutzt bereits diesen Gegenstand",
+  "misc.error.runesUsedElsewhereBy": "This set of runes is in use by {usedby}",
   "editor.add": "Hinzufügen",
   "editor.lords": "Kommandanten",
   "editor.heroes": "Helden",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -89,6 +89,7 @@
   "misc.error.grandMeleeLevel3": "0-1 Level 3 Wizard per 1000 points",
   "misc.error.grandMeleeLevel4": "0-1 Level 4 Wizard per 2000 points",
   "misc.error.itemUsedElsewhereBy": "This item is in use by {usedby}",
+  "misc.error.runesUsedElsewhereBy": "This set of runes is in use by {usedby}",
   "editor.add": "Add",
   "editor.lords": "Lords",
   "editor.heroes": "Heroes",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -89,6 +89,7 @@
   "misc.error.grandMeleeLevel3": "0-1 Level 3 Wizard per 1000 points",
   "misc.error.grandMeleeLevel4": "0-1 Level 4 Wizard per 2000 points",
   "misc.error.itemUsedElsewhereBy": "Este artículo está en uso por {usedby}",
+  "misc.error.runesUsedElsewhereBy": "This set of runes is in use by {usedby}",
   "editor.add": "Añadir",
   "editor.lords": "Comandantes",
   "editor.heroes": "Héroes",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -89,6 +89,7 @@
   "misc.error.grandMeleeLevel3": "0-1 Level 3 Wizard per 1000 points",
   "misc.error.grandMeleeLevel4": "0-1 Level 4 Wizard per 2000 points",
   "misc.error.itemUsedElsewhereBy": "This item is in use by {usedby}",
+  "misc.error.runesUsedElsewhereBy": "This set of runes is in use by {usedby}",
   "editor.add": "Ajouter",
   "editor.lords": "Seigneurs",
   "editor.heroes": "Héros",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -89,6 +89,7 @@
   "misc.error.grandMeleeLevel3": "0-1 Level 3 Wizard per 1000 points",
   "misc.error.grandMeleeLevel4": "0-1 Level 4 Wizard per 2000 points",
   "misc.error.itemUsedElsewhereBy": "This item is in use by {usedby}",
+  "misc.error.runesUsedElsewhereBy": "This set of runes is in use by {usedby}",
   "editor.add": "Aggiungi",
   "editor.lords": "Grandi Eroi",
   "editor.heroes": "Eroi",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -89,6 +89,7 @@
   "misc.error.grandMeleeLevel3": "0-1 Level 3 Wizard per 1000 points",
   "misc.error.grandMeleeLevel4": "0-1 Level 4 Wizard per 2000 points",
   "misc.error.itemUsedElsewhereBy": "This item is in use by {usedby}",
+  "misc.error.runesUsedElsewhereBy": "This set of runes is in use by {usedby}",
   "editor.add": "Dodaj",
   "editor.lords": "Lordowie",
   "editor.heroes": "Bochaterowie",

--- a/src/pages/magic/Magic.js
+++ b/src/pages/magic/Magic.js
@@ -22,6 +22,7 @@ import {
   isMultipleAllowedItem,
   itemsUsedElsewhere,
   maxAllowedOfItem,
+  runeLoadoutElsewhere
 } from "../../utils/magic-item-limitations";
 
 import { nameMap } from "./name-map";
@@ -73,6 +74,7 @@ export const Magic = ({ isMobile }) => {
       .find(({ id }) => id === list.game)
       .armies.find(({ id }) => armyId === id);
   const [usedElsewhere, setUsedElsewhere] = useState([]);
+  const [runesUsedElsewhere, setRunesUsedElsewhere] = useState([]);
 
   // Use list army for arcane journals
   if (!army) {
@@ -266,6 +268,12 @@ export const Magic = ({ isMobile }) => {
         items = items.concat(unit?.command[command]?.magic?.selected || []);
       }
       setUsedElsewhere(itemsUsedElsewhere(items, list, unitId));
+      const isRune = 
+        (unit?.items && unit.items[group || 0]?.types?.some((type) => type.indexOf("runes") >= 0)) ||
+        (command && unit?.command[command]?.magic?.types?.some((type) => type.indexOf("runes") >= 0));
+      if (isRune) {
+        setRunesUsedElsewhere(runeLoadoutElsewhere(items, list, unitId));
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [unit, list, unitId]);
@@ -616,14 +624,41 @@ export const Magic = ({ isMobile }) => {
                 const usedElsewhereErrors = usedElsewhere.filter(
                   (e) => e.itemName === magicItem.name_en
                 );
+                const runesElsewhereErrors = isFirstItemType && runesUsedElsewhere.filter(
+                  (e) => e.runeType === magicItem.type
+                );
+                const runesUsedBy = runesElsewhereErrors?.length > 0 && runesElsewhereErrors.map((error, index) => (
+                  <Fragment key={`${error.unit.id}-rune-error-link`}>
+                    <Link to={error.url}>
+                      {getUnitName({ unit: error.unit, language })}
+                    </Link>
+                    {index !== runesElsewhereErrors.length - 1 ? ", " : ""}
+                  </Fragment>
+                ));
 
                 return (
                   <Fragment key={`${magicItem.name_en}${magicItem.id}`}>
                     {isFirstItemType && (
-                      <h3 className="magic__type">
-                        {nameMap[magicItem.type][`name_${language}`] ||
-                          nameMap[magicItem.type].name_en}
-                      </h3>
+                      <>
+                        <h3 className="magic__type">
+                          {nameMap[magicItem.type][`name_${language}`] ||
+                            nameMap[magicItem.type].name_en}
+                        </h3>
+                        {runesUsedBy && (
+                          <ErrorMessage
+                            key={`${magicItem.name_en}-${magicItem.id}-usedElsewhere`}
+                          >
+                            <span>
+                              <FormattedMessage
+                                id="misc.error.runesUsedElsewhereBy"
+                                values={{
+                                  usedby: runesUsedBy,
+                                }}
+                              />
+                            </span>
+                          </ErrorMessage>
+                        )}
+                      </>
                     )}
                     {getCheckbox({
                       magicItem,

--- a/src/pages/magic/Magic.js
+++ b/src/pages/magic/Magic.js
@@ -268,15 +268,17 @@ export const Magic = ({ isMobile }) => {
         items = items.concat(unit?.command[command]?.magic?.selected || []);
       }
       setUsedElsewhere(itemsUsedElsewhere(items, list, unitId));
+
+      const typeIsRunic = (type) => type.indexOf("runes") >= 0 || type === "runic-tattoos";
       const isRune = 
-        (unit?.items && unit.items[group || 0]?.types?.some((type) => type.indexOf("runes") >= 0)) ||
-        (command && unit?.command[command]?.magic?.types?.some((type) => type.indexOf("runes") >= 0));
+        (unit?.items && unit.items[group || 0]?.types?.some(typeIsRunic)) ||
+        (command && unit?.command[command]?.magic?.types?.some(typeIsRunic));
       if (isRune) {
         setRunesUsedElsewhere(runeLoadoutElsewhere(items, list, unitId));
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [unit, list, unitId]);
+  }, [unit, list, unitId, command]);
 
   useEffect(() => {
     army &&

--- a/src/utils/magic-item-limitations.js
+++ b/src/utils/magic-item-limitations.js
@@ -168,6 +168,5 @@ export const runeLoadoutElsewhere = (runes, list, excludeId) => {
       }
     }
   }
-  console.log(errors);
   return errors;
 }

--- a/src/utils/magic-item-limitations.js
+++ b/src/utils/magic-item-limitations.js
@@ -133,8 +133,10 @@ export const runeLoadoutElsewhere = (runes, list, excludeId) => {
             }
             if (targetItemRunes.length === itemRunes.length) {
               if (itemRunes.every(
-                rune => targetItemRunes.some((targetRune) => rune.name_en === targetRune.name_en))
-              ) {
+                rune => targetItemRunes.some(
+                  (targetRune) => rune.name_en === targetRune.name_en && (rune.amount || 1) == (targetRune.amount || 1)
+                )
+              )) {
                 errors.push({
                   runeType: runeType,
                   unit: unit,
@@ -153,8 +155,10 @@ export const runeLoadoutElsewhere = (runes, list, excludeId) => {
               }
               if (itemRunes.length === targetItemRunes.length) {
                 if (itemRunes.every(
-                  rune => targetItemRunes.some((targetRune) => rune.name_en === targetRune.name_en))
-                ) {
+                  rune => targetItemRunes.some(
+                    (targetRune) => rune.name_en === targetRune.name_en && (rune.amount || 1) == (targetRune.amount || 1)
+                  )
+                )) {
                   errors.push({
                     runeType: runeType,
                     unit: unit,

--- a/src/utils/magic-item-limitations.test.js
+++ b/src/utils/magic-item-limitations.test.js
@@ -142,7 +142,7 @@ describe("itemsUsedElsewhere", () => {
     const items = itemsElswhereList.characters[0].items[0].selected; // Berserker Blade and Dragon Helm
     const list = JSON.parse(JSON.stringify(itemsElswhereList));
 
-    //Add a Noble with Berserk Blade, which is shared with the Prince
+    // Add a Noble with Berserk Blade, which is shared with the Prince
     list.characters.push(
       {
         "name_en": "Noble",
@@ -163,7 +163,7 @@ describe("itemsUsedElsewhere", () => {
     let elsewhereErrors = itemsUsedElsewhere(items, list, princeID);
     expect(elsewhereErrors).toHaveLength(1);
 
-    //Add a Dragon Helm to the Noble, which is shared with the Prince
+    // Add a Dragon Helm to the Noble, which is shared with the Prince
     list.characters[2].items[0].selected.push(
       magicItems["high-elf-realms"].find(
         (item) => item.name_en === "Dragon Helm"
@@ -177,7 +177,7 @@ describe("itemsUsedElsewhere", () => {
     const items = itemsElswhereList.characters[0].items[0].selected; // Berserker Blade and Dragon Helm
     const list = JSON.parse(JSON.stringify(itemsElswhereList));
 
-    //Add a unit of Silver Helms whose champion has a Berserker Blade
+    // Add a unit of Silver Helms whose champion has a Berserker Blade
     list.core.push(
       {
         "name_en": "Silver Helms",
@@ -205,7 +205,7 @@ describe("itemsUsedElsewhere", () => {
     const items = itemsElswhereList.characters[0].items[1].selected; // Elven Honour Sea Guard
     const list = JSON.parse(JSON.stringify(itemsElswhereList));
 
-    //Add a Noble with the Sea Guard Honour
+    // Add a Noble with the Sea Guard Honour
     list.characters.push(
       {
         "name_en": "Noble",
@@ -239,12 +239,7 @@ const runesElsewhereList = {
       "items": [
         {
           "name_en": "Runes",
-          "types": [
-            "weapon-runes",
-            "ranged-weapon-runes",
-            "armor-runes",
-            "talismanic-runes"
-          ],
+          "types": ["weapon-runes", "ranged-weapon-runes", "armor-runes", "talismanic-runes"],
           "selected": [
             magicItems["dwarfen-mountain-holds"].find(
               (item) => item.name_en === "Rune of Striking*"
@@ -293,18 +288,18 @@ const runesElsewhereList = {
 
 describe("runeLoadoutElsewhere", () => {
   test("No errors if no rune loadouts are shared", () => {
-    const items = runesElsewhereList.characters[0].items[0].selected; // Runes of Striking and Cleaving
     // Deep copy of list. structuredClone() would do this cleaner, but it 
     // doesn't seem supported by whatever version of node is running tests here.
     const list = JSON.parse(JSON.stringify(runesElsewhereList));
+    const items = list.characters[0].items[0].selected; // Runes of Striking and Cleaving
     expect(runeLoadoutElsewhere(items, list, kingId)).toHaveLength(0);
   });
   
   test("Warns if a rune loadout is used by more than one hero", () => {
-    const items = runesElsewhereList.characters[0].items[0].selected; // Runes of Striking and Cleaving
     const list = JSON.parse(JSON.stringify(runesElsewhereList));
+    const items = list.characters[0].items[0].selected; // Runes of Striking and Cleaving
 
-    //Add a Thane with Rune of Striking, which is shared with the King, but not a fully shared loadout
+    // Add a Thane with Rune of Striking, which is shared with the King, but not a fully shared loadout
     list.characters.push(
       {
         "name_en": "Thane",
@@ -321,11 +316,10 @@ describe("runeLoadoutElsewhere", () => {
         ]
       }
     );
-    
     let elsewhereErrors = runeLoadoutElsewhere(items, list, kingId);
     expect(elsewhereErrors).toHaveLength(0);
 
-    //Add a Rune of Cleaving to the Thane, completing a shared loudout with the King
+    // Add a Rune of Cleaving to the Thane, completing a shared loudout with the King
     list.characters[2].items[0].selected.push(
       magicItems["dwarfen-mountain-holds"].find(
         (item) => item.name_en === "Rune of Cleaving*"
@@ -334,7 +328,7 @@ describe("runeLoadoutElsewhere", () => {
     elsewhereErrors = runeLoadoutElsewhere(items, list, kingId);
     expect(elsewhereErrors).toHaveLength(1);
     
-    //Add a Rune of Speed to the Thane, making the loadout different again
+    // Add a Rune of Speed to the Thane, making the loadout different again
     list.characters[2].items[0].selected.push(
       magicItems["dwarfen-mountain-holds"].find(
         (item) => item.name_en === "Rune of Speed*"
@@ -345,10 +339,10 @@ describe("runeLoadoutElsewhere", () => {
   });
 
   test("Warns if a rune loadout is shared by a unit command model", () => {
-    const items = runesElsewhereList.characters[0].items[0].selected; // Runes of Striking and Cleaving
     const list = JSON.parse(JSON.stringify(runesElsewhereList));
+    const items = list.characters[0].items[0].selected; // Runes of Striking and Cleaving
 
-    //Add Dwarf Warriors champion with Rune of Striking, which is shared with the King, but not a fully shared loadout
+    // Add Dwarf Warriors champion with Rune of Striking, which is shared with the King, but not a fully shared loadout
     list.core.push(
       {
         "name_en": "Dwarf Warriors",
@@ -375,7 +369,7 @@ describe("runeLoadoutElsewhere", () => {
     let elsewhereErrors = runeLoadoutElsewhere(items, list, kingId);
     expect(elsewhereErrors).toHaveLength(0);
 
-    //Add a Rune of Cleaving to the champion, completing a shared loudout with the King
+    // Add a Rune of Cleaving to the champion, completing a shared loudout with the King
     list.core[0].command[0].magic.selected.push(
       magicItems["dwarfen-mountain-holds"].find(
         (item) => item.name_en === "Rune of Cleaving*"
@@ -384,12 +378,52 @@ describe("runeLoadoutElsewhere", () => {
     elsewhereErrors = runeLoadoutElsewhere(items, list, kingId);
     expect(elsewhereErrors).toHaveLength(1);
     
-    //Add a Rune of Speed to the champion, making the loadout different again
+    // Add a Rune of Speed to the champion, making the loadout different again
     list.core[0].command[0].magic.selected.push(
       magicItems["dwarfen-mountain-holds"].find(
         (item) => item.name_en === "Rune of Speed*"
       )
     );
+    elsewhereErrors = runeLoadoutElsewhere(items, list, kingId);
+    expect(elsewhereErrors).toHaveLength(0);
+  });
+
+  test("Takes stackable amounts into account when comparing rune loadouts", () => {
+    const list = JSON.parse(JSON.stringify(runesElsewhereList));
+    list.characters[0].items[0].selected[0].amount = 2; // Give King a second Rune of Striking
+    const items = list.characters[0].items[0].selected; // Runes of Striking (x2) and Cleaving
+
+    // Add a Thane with Runes of Striking (x1) and Cleaving
+    list.characters.push(
+      {
+        "name_en": "Thane",
+        "id": "thane.gwrngoed",
+        "items": [
+          {
+            "name_en": "Magic Items",
+            "selected": [
+              magicItems["dwarfen-mountain-holds"].find(
+                (item) => item.name_en === "Rune of Striking*"
+              ),
+              magicItems["dwarfen-mountain-holds"].find(
+                (item) => item.name_en === "Rune of Cleaving*"
+              )
+            ]
+          }
+        ]
+      }
+    );
+    let elsewhereErrors = runeLoadoutElsewhere(items, list, kingId);
+    expect(elsewhereErrors).toHaveLength(0);
+
+    // Give a second Rune of Striking, matching the King
+    list.characters[2].items[0].selected[0].amount = 2;
+    elsewhereErrors = runeLoadoutElsewhere(items, list, kingId);
+    expect(elsewhereErrors).toHaveLength(1);
+
+    // Change the Thane to 1 Rune of Striking and 2 of Cleaving
+    list.characters[2].items[0].selected[0].amount = 1;
+    list.characters[2].items[0].selected[1].amount = 2;
     elsewhereErrors = runeLoadoutElsewhere(items, list, kingId);
     expect(elsewhereErrors).toHaveLength(0);
   });


### PR DESCRIPTION
The Rule of Pride states that no two items can have the same set of runes on them. This PR adds validation of this rule to the Magic panel, showing a warning if another unit's runes match. Several unit tests have been included.

![RunesUsedElsewhereDemo](https://github.com/user-attachments/assets/b3c58682-c85a-4c9e-92c6-a05e99c7c132)

There are some loopholes in the rules for runes that this doesn't quite account for; legally I believe you could split runes across a unit's heavy armour and shield to have effectively the same loadout on two units, but as we assign runes by unit instead of by item, we can't support that.