### PR TITLE
Show localized names for detachments and item categories for languages besides en and de

### DIFF
--- a/src/pages/magic/Magic.js
+++ b/src/pages/magic/Magic.js
@@ -15,7 +15,7 @@ import { setItems } from "../../state/items";
 import { editUnit } from "../../state/lists";
 import { useLanguage } from "../../utils/useLanguage";
 import { updateLocalList } from "../../utils/list";
-import { equalsOrIncludes } from "../../utils/string";
+import { equalsOrIncludes, namesForSpread } from "../../utils/string";
 import { getUnitName } from "../../utils/unit";
 import { getGameSystems } from "../../utils/game-systems";
 import {
@@ -302,8 +302,7 @@ export const Magic = ({ isMobile }) => {
           const allItems = itemCategories.map((itemCategory) => {
             return {
               items: data[itemCategory],
-              name_de: nameMap[itemCategory].name_de,
-              name_en: nameMap[itemCategory].name_en,
+              ...namesForSpread(nameMap[itemCategory]),
               id: itemCategory,
             };
           });

--- a/src/pages/unit/Unit.js
+++ b/src/pages/unit/Unit.js
@@ -30,6 +30,7 @@ import { useLanguage } from "../../utils/useLanguage";
 import { updateLocalList } from "../../utils/list";
 import { getRandomId } from "../../utils/id";
 import { getArmyData } from "../../utils/army";
+import { namesForSpread } from "../../utils/string";
 import {
   getUnitName,
   getUnitOptionNotes,
@@ -125,8 +126,7 @@ export const Unit = ({ isMobile, previewData = {} }) => {
 
     unitDetachments.push({
       id: `${id}.${getRandomId()}`,
-      name_de: detachment.name_de,
-      name_en: detachment.name_en,
+      ...namesForSpread(detachment),
       points: detachment.points,
       strength: detachment.minDetachmentSize || 5,
       minDetachmentSize: detachment.minDetachmentSize || 5,

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -22,3 +22,17 @@ export const equalsOrIncludes = (strOrArray, x) => (
   x === strOrArray ||
   (Array.isArray(strOrArray) && strOrArray.includes(x))
 );
+
+/**
+ * Picks out the various localized names of a unit or item object
+ * and puts them in a nice object for easy attribute spreading
+ */
+export const namesForSpread = (obj) => ({
+  name_en: obj.name_en,
+  name_de: obj.name_de,
+  name_fr: obj.name_fr,
+  name_cn: obj.name_cn,
+  name_es: obj.name_es,
+  name_it: obj.name_it,
+  name_pl: obj.name_pl,
+});


### PR DESCRIPTION
There are two instances of objects being created with just the English and German names; one in the Magic items tab, with the item category names, and one in detachments. I've made a simple helper function to grab all localized names and make an object that can easily spread only the name attributes. I could include each localized name individually, but this method is a little more future proof, in case we add more languages in the future.

Before:
<img width="491" height="403" alt="image" src="https://github.com/user-attachments/assets/71bf7d49-4151-417e-a422-1e98cbff30f4" />
<img width="469" height="234" alt="image" src="https://github.com/user-attachments/assets/a23c804d-23f3-42aa-92ed-11654cacd7f9" />

After:
<img width="463" height="411" alt="image" src="https://github.com/user-attachments/assets/fccfbb43-08eb-4055-bd36-48fd8a55aa53" />
<img width="470" height="262" alt="image" src="https://github.com/user-attachments/assets/e008346f-2141-49bd-baef-49c929cccbcd" />
