### PR TITLE
Change suggested army sizes when selecting battle march.

### DIFF
--- a/src/pages/new-list/NewList.js
+++ b/src/pages/new-list/NewList.js
@@ -60,9 +60,15 @@ export const NewList = ({ isMobile }) => {
     },
   ];
   const listsPoints = [...lists.map((list) => list.points)].reverse();
-  const quickActions = lists.length
-    ? [...new Set([...listsPoints, 500, 1000, 1500, 2000, 2500])].slice(0, 5)
-    : [500, 1000, 1500, 2000, 2500];
+  const quickActions =
+    compositionRule === "battle-march"
+      ? [500, 600, 750]
+      : lists.length
+      ? [...new Set([...listsPoints, 500, 1000, 1500, 2000, 2500])].slice(
+          0,
+          5
+        )
+      : [500, 1000, 1500, 2000, 2500];
   const createList = () => {
     const newId = getRandomId();
     const newList = {


### PR DESCRIPTION
Change the suggested points sizes for battle march armies


I am getting some weird effect though.
<img width="378" height="576" alt="Screenshot 2025-10-27 at 8 36 22 AM" src="https://github.com/user-attachments/assets/6f734a55-af87-4010-a5d2-ee0fa2bf8670" />
I don't understand why this change would cause that though.