### PR TITLE
Mark Gifts of Chaos as nonexclusive

### DIFF
--- a/public/games/the-old-world/magic-items.json
+++ b/public/games/the-old-world/magic-items.json
@@ -3755,6 +3755,7 @@
       "name_cn": "黑暗圣像",
       "name_fr": "Sombre Majesté",
       "name_it": "Oscuro Majesty",
+      "nonExclusive": true,
       "points": 50,
       "type": "gift-of-chaos",
       "onePerArmy": true
@@ -3765,6 +3766,7 @@
       "name_cn": "恶魔皮肤",
       "name_fr": "Chair Démoniaque",
       "name_it": "Daemon-Flesh",
+      "nonExclusive": true,
       "points": 45,
       "type": "gift-of-chaos",
       "onePerArmy": true
@@ -3775,6 +3777,7 @@
       "name_cn": "额外手臂",
       "name_fr": "Bras Supplémentaire",
       "name_it": "Extra Arm",
+      "nonExclusive": true,
       "points": 40,
       "type": "gift-of-chaos",
       "onePerArmy": true
@@ -3785,6 +3788,7 @@
       "name_cn": "恶毒炫目",
       "name_fr": "Splendeur Diabolique",
       "name_it": "Diabolic Splendour",
+      "nonExclusive": true,
       "points": 35,
       "type": "gift-of-chaos",
       "onePerArmy": true
@@ -3795,6 +3799,7 @@
       "name_cn": "迷惑光环",
       "name_fr": "Aura Enchanteresse",
       "name_it": "Enchanting Aura",
+      "nonExclusive": true,
       "points": 35,
       "type": "gift-of-chaos",
       "onePerArmy": true
@@ -3805,6 +3810,7 @@
       "name_cn": "痛苦光环",
       "name_fr": "Aura de Douleur",
       "name_it": "Aura of Pain",
+      "nonExclusive": true,
       "points": 30,
       "type": "gift-of-chaos",
       "onePerArmy": true
@@ -3815,6 +3821,7 @@
       "name_cn": "凡人之主",
       "name_fr": "Maître des Mortels",
       "name_it": "Master of Mortals",
+      "nonExclusive": true,
       "points": 25,
       "type": "gift-of-chaos",
       "onePerArmy": true
@@ -3825,6 +3832,7 @@
       "name_cn": "腐败酸液",
       "name_fr": "Ichor Acide",
       "name_it": "Acid Ichor",
+      "nonExclusive": true,
       "points": 15,
       "type": "gift-of-chaos",
       "onePerArmy": true
@@ -3835,6 +3843,7 @@
       "name_cn": "剧毒粘液",
       "name_fr": "Mucus Empoisonné",
       "name_it": "Poisonous Slime",
+      "nonExclusive": true,
       "points": 15,
       "type": "gift-of-chaos",
       "onePerArmy": true


### PR DESCRIPTION
Characters in the Warriors of Chaos can take more than one Gift of Chaos (up to their points value), though each can only be taken once per army. Thus `nonExclusive: true` should be on their definitions.