### PR TITLE
Restrict magic shields to those who can take mundane ones

### DIFF
--- a/src/pages/magic/Magic.js
+++ b/src/pages/magic/Magic.js
@@ -55,7 +55,8 @@ const updateIds = (items) => {
 
 export const isAllowedShield = (unit) => {
     return (unit.equipment && unit.equipment.find(option => option.name_en.toLowerCase().includes("shield")))
-        || (unit.options  && unit.options.find(option => option.name_en.toLowerCase().includes("shield")));
+        || (unit.options && unit.options.find(option => option.name_en.toLowerCase().includes("shield")))
+        || (unit.armor && unit.armor.find(option => option.name_en.toLowerCase().includes("shield")));
 }
 
 export const isMagicShield = (magicItem) => {


### PR DESCRIPTION
Restricts access to magic shields to characters/units which are already allowed to take mundane ones, as per Rulebook p. 340

Tested locally for all vanilla factions (not including renegades)
