### PR TITLE
Fix for adding new magic items breaking indexes for old lists

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.js]
+indent_size = 2


### PR DESCRIPTION
The code uses the index position of magic items within their respective groups, so when we added new magic items and didn't put them at the end of the list, they created a mismatch of old id for an existing selected item and new id due to it's position changing in the list.

**To give an example:

- Talisman of protection was index 23
- We added 8 items ahead of it in value, it became index 31, but index 23 would still be selected in old lists
- Best case: people would see Spellshield (the new index 23) selected instead even though they didn't select it. Deselecting it would fix the issue for them
- Worst case: Where they didn't have access to armor (like in the case of a wizard) they wouldn't then be able to see Spellshield in order to de-select it** 

If we had added everything to the end of the list, this would have been avoided.

This change adds fall back behavior to allow recovery for old lists where the selected item id's were different by matching on the name. 
Disclaimer: I was only able to understand some of the ways we're using item ID's here, everything I tested seemed to be fine after the change but there may be something I missed. This is to say please treat this change as: SUSPECT

and definitely do something better than what I did for the checkbox on line 724 if you can, I still feel icky for having put that there