### PR TITLE
Slayers can only be generals in Slayer Host

### DIFF
--- a/public/games/the-old-world/dwarfen-mountain-holds.json
+++ b/public/games/the-old-world/dwarfen-mountain-holds.json
@@ -1312,8 +1312,8 @@
           "name_es": "General",
           "points": 0,
           "notes": {
-            "name_en": "Must be your general",
-            "name_fr": "Doit être votre général"
+            "name_en": "Must be your general in a Slayer Host army",
+            "name_fr": "Doit être votre général dans une armée d’Ost Tueur"
           }
         }
       ],


### PR DESCRIPTION
Per the "[Worst Among Equals](https://tow.whfb.app/special-rules/worst-among-equals)" rule for the Slayer Host, Daemon and Dragon Slayers can be the general of a Slayer Host, but their Loner rule prohibits them from being Generals in other lists.

Also I clarified the note about Ungrim needing to be General, which only applies to Slayer Hosts. I'd like to make the General always active for him in a Slayer Host, but having two Command options with the same name was screwing with the UI, making the option not toggle-able in Grand Army and Royal Host lists.