### PR TITLE
Settra must be the general

### DIFF
--- a/public/games/the-old-world/tomb-kings-of-khemri.json
+++ b/public/games/the-old-world/tomb-kings-of-khemri.json
@@ -1268,7 +1268,9 @@
           "name_de": "General",
           "name_fr": "Général",
           "name_es": "General",
-          "points": 0
+          "points": 0,
+          "active": true,
+          "alwaysActive": true
         }
       ],
       "equipment": [


### PR DESCRIPTION
If Settra is in an army list, he must be the general; thus always select the General command option and don't make it toggle-able.