### PR TITLE
Add vitest imports to fix tests

### DIFF
--- a/src/utils/magic-item-limitations.test.js
+++ b/src/utils/magic-item-limitations.test.js
@@ -1,3 +1,4 @@
+import { expect, test, describe } from "vitest";
 import {
   isMultipleAllowedItem,
   maxAllowedOfItem,

--- a/src/utils/string.test.js
+++ b/src/utils/string.test.js
@@ -1,3 +1,4 @@
+import { expect, test, describe } from "vitest";
 import { normalizeRuleName, equalsOrIncludes } from "./string";
 
 describe("normalizeRuleName", () => {


### PR DESCRIPTION
The switch to vitest broke our extensive suite of tests. A simple import of the appropriate functions fixes it.