### PR TITLE
goblin-oddnod -> oddnob

### DIFF
--- a/public/games/the-old-world/orc-and-goblin-tribes.json
+++ b/public/games/the-old-world/orc-and-goblin-tribes.json
@@ -1687,7 +1687,7 @@
       "name_cn": "地精怪老大",
       "name_de": "Goblin-Oddboss",
       "name_fr": "Zarbnob Gobelin",
-      "id": "goblin-oddnod",
+      "id": "goblin-oddnob",
       "points": 135,
       "command": [
         {


### PR DESCRIPTION
Spelling correction on Goblin Oddnob's id from `oddnod` to `oddnob`