### PR TITLE
Correct Deepwood Scouts 0-1 per 1000 rule

### DIFF
--- a/src/utils/rules.js
+++ b/src/utils/rules.js
@@ -2019,7 +2019,7 @@ export const rules = {
           min: 1,
         },
         {
-          ids: ["deepwood-scouts"],
+          ids: ["deepwood-scouts-core"],
           min: 0,
           max: 1,
           points: 1000,


### PR DESCRIPTION
For some reason the Deepwood Scouts option in the Core section has a different id, `deepwood-scouts-core`, from the regular special version, `deepwood-scouts`. I've changed it here, but maybe the solution that's more consistent with other similar units is to change it in `wood-elf-realms.json`.