### PR TITLE
Fix for Chaotic Traits per model costs for allies

### DIFF
--- a/src/pages/magic/Magic.jsx
+++ b/src/pages/magic/Magic.jsx
@@ -159,10 +159,11 @@ export const Magic = ({ isMobile }) => {
     perModel,
   }) => {
     let points = regularPoints;
+    const isCharacter = type === "characters" || (!!unit.unitType && unit.unitType === "characters");
 
-    if (type !== "characters" && perUnitPoints) {
+    if (!isCharacter && perUnitPoints) {
       points = perUnitPoints;
-    } else if (type !== "characters" && perModelPoints) {
+    } else if (!isCharacter && perModelPoints) {
       points = perModelPoints;
     }
 
@@ -183,8 +184,7 @@ export const Magic = ({ isMobile }) => {
                 id: "app.points",
               })
         }`}
-        {perModel &&
-          type !== "characters" &&
+        {perModel && !isCharacter &&
           ` ${intl.formatMessage({
             id: "unit.perModel",
           })}`}

--- a/src/utils/points.js
+++ b/src/utils/points.js
@@ -231,16 +231,17 @@ export const getUnitPoints = (unit, settings) => {
 
 const getMagicItemPoints = ({ item, unit }) => {
   let unitPoints = 0;
+  const isCharacter = unit.type === "characters" || (!!unit.unitType && unit.unitType === "characters");
 
   // Units with points per model
-  if (unit.type !== "characters" && item.perModel) {
+  if (!isCharacter && item.perModel) {
     unitPoints +=
       (unit.strength || 1) *
       (item.amount ? item.amount * item.perModelPoints : item.perModelPoints);
   }
 
   // Units with points per unit
-  else if (unit.type !== "characters" && item.perUnitPoints) {
+  else if (!isCharacter && item.perUnitPoints) {
     unitPoints += item.amount
       ? item.amount * item.perUnitPoints
       : item.perUnitPoints;


### PR DESCRIPTION
When added as allies, Chaos Warrior characters were using the per model/per unit costs instead of the character costs for Chaotic traits, because they were seeing their `type` as `"allies"` instead of `"characters"`. Fortunately we can just use `unittype` as a back up check.