### PR TITLE
#416 Lexorank list ordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ yarn-error.log*
 
 # AI assistant settings
 .claude/
+.node-version

--- a/docs/lexorank-ordering.md
+++ b/docs/lexorank-ordering.md
@@ -1,0 +1,104 @@
+# Lexorank List Ordering
+
+## What is it?
+
+Lexorank replaces position-based ordering (array index) with explicit **rank strings**
+that sort alphabetically. Each list item gets a `rank` field — a short string like
+`"m"`, `"d"`, `"v"` — and display order is determined by sorting these strings.
+
+When you move an item, only that item's rank changes. A new rank is generated that
+sorts between its new neighbors. No other items are touched.
+
+## Why it's needed
+
+### The problem with array-position ordering
+
+Currently, list order is implicit — it's just the index in the JSON array. This
+creates three problems:
+
+**1. Sync requires sending everything**
+
+If a user reorders one list, the entire array must be synced because every item's
+"position" (its index) has changed. There's no way to express "item X moved" without
+sending all items in their new positions.
+
+With lexorank, reordering one item changes only that item's `rank` field. Only the
+changed item needs to be synced.
+
+**2. Database storage loses order**
+
+When lists are stored in a database JSON column (e.g. PostgreSQL `jsonb`), the array
+order is not guaranteed to survive a round-trip. The database may serialize the array
+differently on read. This means lists come back in a different order than they went in.
+
+With lexorank, order is stored explicitly in each item's `rank` field. The array can
+be in any order — just sort by `rank` to display correctly. This makes database-backed
+sync possible.
+
+**3. Concurrent edits conflict**
+
+If two devices reorder different lists at the same time, both send their full array.
+One will overwrite the other. There's no way to merge two different orderings of the
+same array.
+
+With lexorank, each device only changes the `rank` of the item it moved. Two
+concurrent reorders of different items produce two independent field changes that
+merge cleanly with last-write-wins per item.
+
+## How it works
+
+### Generating ranks
+
+`generateRank(prev, next)` returns a string that sorts between `prev` and `next`.
+Ranks use a 62-character alphabet in ASCII order: `0-9 A-Z a-z`. Index comparison
+and string comparison agree, so `sort()` Just Works.
+
+```
+generateRank(null, null)  → "U"      (midpoint of full range)
+generateRank("U", null)   → "j"      (midpoint between "U" and max)
+generateRank(null, "U")   → "F"      (midpoint between min and "U")
+generateRank("a", "z")    → "m"      (midpoint between "a" and "z")
+generateRank("a", "b")    → "aU"     (extends when adjacent — always room)
+```
+
+The algorithm finds the lexicographic midpoint between two strings character by
+character. When adjacent characters leave no room (like `"a"` and `"b"`), it extends
+the string to create space. This means you can always insert between any two items —
+there's no limit.
+
+### Folder grouping
+
+`sortByRank` handles folders by:
+
+1. Sorting top-level items and folders by rank
+2. After each folder, inserting its contents (also sorted by rank)
+
+Moving a folder only changes the folder's rank. Its contents follow automatically
+because they reference the folder by ID, and `sortByRank` always groups them after
+their folder header.
+
+### Migration from legacy ordering
+
+`ensureRanks` handles existing lists that don't have ranks yet. It walks through
+lists in their current order and generates ranks that preserve that order. It also
+infers folder membership from position for truly legacy items that have no `folder`
+field.
+
+This means adopting lexorank is non-breaking — existing lists get ranks assigned on
+first load and continue to display in their current order.
+
+## List item fields
+
+Lexorank adds these fields to each list item:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `rank` | `string` | Sort key — determines display order |
+| `folder` | `string\|null` | ID of containing folder, or null for top-level |
+
+## Files
+
+- `src/utils/lexorank.js` — Core algorithm: `generateRank(prev, next)`, `isValidRank(rank)`
+- `src/utils/lexorank.test.js` — Tests for rank generation
+- `src/utils/list-ordering.js` — List operations: `sortByRank`, `ensureRanks`, `reorderList`, `reorderFolder`, `rankAtTop`, `rankAfter`
+- `src/utils/list-ordering.test.js` — Tests for list ordering

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,6 +28,7 @@ import { Login } from "./pages/login";
 import { setLists } from "./state/lists";
 import { setSettings } from "./state/settings";
 import { Header, Main } from "./components/page";
+import { ensureRanks } from "./utils/list-ordering";
 
 import {
   useDropboxAuthentication,
@@ -65,10 +66,15 @@ export const App = () => {
   useOWRAuthentication();
 
   useEffect(() => {
-    const localLists = localStorage.getItem("owb.lists");
+    const localLists = JSON.parse(localStorage.getItem("owb.lists")) || [];
     const localSettings = localStorage.getItem("owb.settings");
 
-    dispatch(setLists(JSON.parse(localLists)));
+    const { lists: rankedLists, needsUpdate } = ensureRanks(localLists);
+    if (needsUpdate) {
+      localStorage.setItem("owb.lists", JSON.stringify(rankedLists));
+    }
+
+    dispatch(setLists(rankedLists));
     dispatch(setSettings(JSON.parse(localSettings)));
   }, [dispatch]);
 

--- a/src/components/list/List.css
+++ b/src/components/list/List.css
@@ -5,7 +5,20 @@
 }
 
 .list--hidden {
-  display: none;
+  height: 0;
+  overflow: hidden;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  min-height: 0;
+}
+
+.list--hidden > .list__inner {
+  height: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  min-height: 0;
 }
 
 .list__inner::before {

--- a/src/components/list/OrderableList.jsx
+++ b/src/components/list/OrderableList.jsx
@@ -29,11 +29,16 @@ export const OrderableList = ({
   id,
   children,
   onMoved,
+  onBeforeCapture,
   onDragStart,
   onDragUpdate,
+  onDragEnd,
   intoFolder,
 }) => {
   const handleDragEnd = (result) => {
+    // Always fire a cleanup callback so callers can reset transient drag
+    // state even when the drop is cancelled (no destination).
+    onDragEnd?.(result);
     if (!result.destination) {
       return;
     }
@@ -45,9 +50,10 @@ export const OrderableList = ({
 
   return (
     <DragDropContext
-      onDragEnd={handleDragEnd}
+      onBeforeCapture={onBeforeCapture}
       onBeforeDragStart={onDragStart}
       onDragUpdate={onDragUpdate}
+      onDragEnd={handleDragEnd}
     >
       <Droppable droppableId={`droppable-${id}`}>
         {(provided, _snapshot) => (
@@ -60,6 +66,7 @@ export const OrderableList = ({
                     key={child.key}
                     draggableId={child.key}
                     index={index}
+                    isDragDisabled={!!child.props?.dragDisabled}
                   >
                     {(provided, snapshot) => {
                       // Clone style — rbd's object is frozen.

--- a/src/components/list/OrderableList.jsx
+++ b/src/components/list/OrderableList.jsx
@@ -21,7 +21,18 @@ import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
  * @param {React.ReactElement[]} props.children
  * @param {string} props.id
  */
-export const OrderableList = ({ id, children, onMoved, onDragStart }) => {
+// X offset (in px) applied to the dragged element when the drop will land
+// inside a folder. Visual cue that the item is about to be filed.
+const INTO_FOLDER_OFFSET_PX = 24;
+
+export const OrderableList = ({
+  id,
+  children,
+  onMoved,
+  onDragStart,
+  onDragUpdate,
+  intoFolder,
+}) => {
   const handleDragEnd = (result) => {
     if (!result.destination) {
       return;
@@ -33,7 +44,11 @@ export const OrderableList = ({ id, children, onMoved, onDragStart }) => {
   };
 
   return (
-    <DragDropContext onDragEnd={handleDragEnd} onBeforeDragStart={onDragStart}>
+    <DragDropContext
+      onDragEnd={handleDragEnd}
+      onBeforeDragStart={onDragStart}
+      onDragUpdate={onDragUpdate}
+    >
       <Droppable droppableId={`droppable-${id}`}>
         {(provided, _snapshot) => (
           <ol {...provided.droppableProps} ref={provided.innerRef}>
@@ -47,10 +62,22 @@ export const OrderableList = ({ id, children, onMoved, onDragStart }) => {
                     index={index}
                   >
                     {(provided, snapshot) => {
-                      // Block horizontal movement
-                      const style = provided.draggableProps.style;
-                      if (style.transform) {
-                        style.transform = style.transform.replace(/\d+/, "0");
+                      // Clone style — rbd's object is frozen.
+                      const style = provided.draggableProps.style
+                        ? { ...provided.draggableProps.style }
+                        : provided.draggableProps.style;
+                      if (style?.transform) {
+                        // rbd transforms look like `translate(Xpx, Ypx)`.
+                        // Block horizontal motion, then optionally indent
+                        // when landing in a folder.
+                        const shiftX =
+                          snapshot.isDragging && intoFolder
+                            ? INTO_FOLDER_OFFSET_PX
+                            : 0;
+                        style.transform = style.transform.replace(
+                          /translate\(\s*-?\d+px/,
+                          `translate(${shiftX}px`,
+                        );
                       }
 
                       return React.cloneElement(child, {
@@ -60,6 +87,7 @@ export const OrderableList = ({ id, children, onMoved, onDragStart }) => {
                           : {}),
                         ref: provided.innerRef,
                         ...provided.draggableProps,
+                        style,
                         ...provided.dragHandleProps,
                       });
                     }}

--- a/src/pages/duplicate-list/DuplicateList.jsx
+++ b/src/pages/duplicate-list/DuplicateList.jsx
@@ -9,6 +9,7 @@ import { Header, Main } from "../../components/page";
 import { NumberInput } from "../../components/number-input";
 import { getRandomId } from "../../utils/id";
 import { setLists } from "../../state/lists";
+import { rankAfter } from "../../utils/list-ordering";
 
 import "./DuplicateList.css";
 
@@ -37,19 +38,19 @@ export const DuplicateList = ({ isMobile }) => {
     setDescription(event.target.value);
   };
   const handleSubmit = (event) => {
+    event.preventDefault();
     const newId = getRandomId();
     const newLists = [
+      ...lists,
       {
         ...list,
         name,
         points,
         description,
         id: newId,
+        rank: rankAfter(lists, list),
       },
-      ...lists,
     ];
-
-    event.preventDefault();
 
     localStorage.setItem("owb.lists", JSON.stringify(newLists));
     dispatch(setLists(newLists));

--- a/src/pages/home/Home.css
+++ b/src/pages/home/Home.css
@@ -92,11 +92,25 @@
   z-index: 2;
 }
 
+/* Empty folders that are open get a small breather below so you can see they
+   really do have nothing in them. */
+.home__folder--empty-open {
+  margin-bottom: 0.5rem;
+}
+
 .home__folder-name {
   flex-grow: 1;
   text-overflow: ellipsis;
   overflow-x: hidden;
   white-space: nowrap;
+}
+
+.home__folder-count {
+  font-size: 0.75em;
+  font-weight: normal;
+  opacity: 0.55;
+  margin-left: 0.25em;
+  vertical-align: 0.15em;
 }
 
 .folder__more {
@@ -113,6 +127,12 @@
 
 .home__folder-icon {
   margin-right: 0.5rem;
+}
+
+/* Hide the in-folder indicator while the item is being dragged — its real
+   destination is unknown until drop. */
+[dragging] .home__folder-icon {
+  display: none;
 }
 
 .home__header {

--- a/src/pages/home/Home.css
+++ b/src/pages/home/Home.css
@@ -148,6 +148,21 @@
   opacity: 0.5;
 }
 
+.home__phantom-drop {
+  list-style: none;
+  height: 0;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  transition: height 120ms ease, margin 120ms ease;
+  pointer-events: none;
+}
+
+.home__phantom-drop--active {
+  height: 1.5rem;
+  pointer-events: auto;
+}
+
 .home__delete-text {
   margin-bottom: 1rem;
 }

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
 import { useDispatch } from "react-redux";
@@ -38,9 +38,10 @@ import forg3dBanner from "../../assets/forg3d.jpg";
 import fantasyweltDe from "../../assets/fantasywelt_de.jpg";
 import fantasyweltEn from "../../assets/fantasywelt_en.jpg";
 import mwgForge from "../../assets/mwg-forge.gif";
-import { swap } from "../../utils/collection";
 import { useLanguage } from "../../utils/useLanguage";
-import { updateLocalList, updateListsFolder } from "../../utils/list";
+import { updateLocalList } from "../../utils/list";
+import { sortByRank, ensureRanks, reorderList, reorderFolder } from "../../utils/list-ordering";
+import { generateRank } from "../../utils/lexorank";
 import { setLists, toggleFolder, updateList } from "../../state/lists";
 import { updateSetting } from "../../state/settings";
 import { getRandomId } from "../../utils/id";
@@ -74,9 +75,39 @@ const armyIconMap = {
 export const Home = ({ isMobile }) => {
   const MainComponent = isMobile ? Main : Fragment;
   const settings = useSelector((state) => state.settings);
-  let lists = updateListsFolder(useSelector((state) => state.lists));
+  const dispatch = useDispatch();
+  const rawLists = useSelector((state) => state.lists);
 
-  // Sort lists based on the current sorting setting
+  const { lists: rankedLists, needsUpdate } = useMemo(
+    () => ensureRanks(rawLists),
+    [rawLists],
+  );
+
+  useEffect(() => {
+    if (!rawLists || rawLists.length === 0) return;
+    if (needsUpdate) {
+      localStorage.setItem("owb.lists", JSON.stringify(rankedLists));
+      dispatch(setLists(rankedLists));
+    }
+  }, [rawLists, needsUpdate, rankedLists, dispatch]);
+
+  const sortedLists = useMemo(() => sortByRank(rankedLists), [rankedLists]);
+  let lists = sortedLists;
+
+  const folderIndex = useMemo(() => {
+    const byId = new Map();
+    const childCounts = new Map();
+    for (const item of rankedLists) {
+      if (item.type === "folder") {
+        byId.set(item.id, item);
+        if (!childCounts.has(item.id)) childCounts.set(item.id, 0);
+      } else if (item.folder) {
+        childCounts.set(item.folder, (childCounts.get(item.folder) || 0) + 1);
+      }
+    }
+    return { byId, childCounts };
+  }, [rankedLists]);
+
   switch (settings.listSorting) {
     case "nameAsc":
       lists = [...lists].sort((a, b) => {
@@ -158,7 +189,6 @@ export const Home = ({ isMobile }) => {
   const location = useLocation();
   const { language } = useLanguage();
   const { timezone } = useTimezone();
-  const dispatch = useDispatch();
   const intl = useIntl();
   const [listsInFolder, setListsInFolder] = useState([]);
   const [dialogOpen, setDialogOpen] = useState(null);
@@ -166,6 +196,7 @@ export const Home = ({ isMobile }) => {
   const [sortMenuOpen, setSortMenuOpen] = useState(false);
   const [folderName, setFolderName] = useState("");
   const [activeDeleteOption, setActiveDeleteOption] = useState("delete");
+  const [dragIntoFolder, setDragIntoFolder] = useState(false);
   const resetState = () => {
     dispatch(setArmy(null));
     dispatch(setItems(null));
@@ -174,65 +205,23 @@ export const Home = ({ isMobile }) => {
     localStorage.setItem("owb.settings", JSON.stringify(newSettings));
   };
   const handleListMoved = ({ sourceIndex, destinationIndex }) => {
-    const draggedItem = lists.find((list, index) => index === sourceIndex);
-    const difference = sourceIndex - destinationIndex;
-
     setListsInFolder([]);
 
-    if (difference === 0) {
+    if (sourceIndex === destinationIndex) {
       return;
     }
 
-    if (draggedItem.type === "folder") {
-      const listBeforeDestination = lists.find(
-        (_, index) => index === destinationIndex - 1,
-      );
-      const listAtDestination = lists.find(
-        (_, index) => index === destinationIndex,
-      );
-      const listAfterDestination = lists.find(
-        (_, index) => index === destinationIndex + 1,
-      );
+    const draggedItem = lists[sourceIndex];
+    const newLists = draggedItem.type === "folder"
+      ? reorderFolder(lists, sourceIndex, destinationIndex)
+      : reorderList(lists, sourceIndex, destinationIndex);
 
-      if (
-        !listBeforeDestination ||
-        !listAfterDestination ||
-        (difference > 0 && listAtDestination.type === "folder") || // Moving up
-        (difference < 0 && listAfterDestination.type === "folder") // Moving down
-      ) {
-        let newLists = swap(lists, sourceIndex, destinationIndex);
-        const listsInFolder = lists.filter(
-          (list) => list.folder === draggedItem.id,
-        );
+    localStorage.setItem("owb.lists", JSON.stringify(newLists));
+    dispatch(setLists(newLists));
 
-        listsInFolder.forEach((_, index) => {
-          newLists = swap(
-            newLists,
-            sourceIndex + (destinationIndex < sourceIndex ? 1 + index : 0),
-            destinationIndex + (destinationIndex < sourceIndex ? 1 + index : 0),
-          );
-        });
-        newLists = updateListsFolder(newLists);
-
-        localStorage.setItem("owb.lists", JSON.stringify(newLists));
-        dispatch(setLists(newLists));
-
-        const newSettings = { ...settings, lastChanged: new Date().toString() };
-        dispatch(updateSetting({ lastChanged: newSettings.lastChanged }));
-        localStorage.setItem("owb.settings", JSON.stringify(newSettings));
-      }
-    } else {
-      let newLists = updateListsFolder(
-        swap(lists, sourceIndex, destinationIndex),
-      );
-
-      localStorage.setItem("owb.lists", JSON.stringify(newLists));
-      dispatch(setLists(newLists));
-
-      const newSettings = { ...settings, lastChanged: new Date().toString() };
-      dispatch(updateSetting({ lastChanged: newSettings.lastChanged }));
-      localStorage.setItem("owb.settings", JSON.stringify(newSettings));
-    }
+    const newSettings = { ...settings, lastChanged: new Date().toString() };
+    dispatch(updateSetting({ lastChanged: newSettings.lastChanged }));
+    localStorage.setItem("owb.settings", JSON.stringify(newSettings));
   };
   const folders = lists.filter((list) => list.type === "folder");
   const listsWithoutFolders = lists.filter((list) => list.type !== "folder");
@@ -350,9 +339,11 @@ export const Home = ({ isMobile }) => {
       newLists = newLists.filter(
         (list) => list.folder !== activeMenu || !list.folder,
       );
+    } else {
+      newLists = newLists.map((list) =>
+        list.folder === activeMenu ? { ...list, folder: null } : list,
+      );
     }
-
-    newLists = updateListsFolder(newLists);
 
     setDialogOpen(null);
     setActiveMenu(null);
@@ -379,15 +370,18 @@ export const Home = ({ isMobile }) => {
     localStorage.setItem("owb.settings", JSON.stringify(newSettings));
   };
   const handleNewConfirm = () => {
-    const newLists = updateListsFolder([
+    const firstRank = lists.length > 0 ? lists[0].rank : null;
+    const newLists = [
       {
         id: `folder-${getRandomId()}`,
         name: folderName || intl.formatMessage({ id: "home.newFolder" }),
         type: "folder",
         open: true,
+        folder: null,
+        rank: generateRank(null, firstRank),
       },
       ...lists,
-    ]);
+    ];
 
     localStorage.setItem("owb.lists", JSON.stringify(newLists));
     dispatch(setLists(newLists));
@@ -405,13 +399,40 @@ export const Home = ({ isMobile }) => {
       (list) =>
         list.id === start.draggableId || list.folder === start.draggableId,
     );
-    const listsInFolder = lists
-      .map((list, index) => ({ folder: list.folder, index: index }))
-      .filter((list) => list.folder);
-
-    if (draggedItem.type === "folder") {
-      setListsInFolder(listsInFolder);
+    if (draggedItem?.type === "folder") {
+      setListsInFolder(
+        lists
+          .map((list, index) => ({ folder: list.folder, index }))
+          .filter((list) => list.folder),
+      );
     }
+  };
+  const handleDragUpdate = (update) => {
+    if (!update.destination) {
+      setDragIntoFolder(false);
+      return;
+    }
+    const sourceItem = lists[update.source.index];
+    // Folders never go INTO folders
+    if (sourceItem?.type === "folder") {
+      setDragIntoFolder(false);
+      return;
+    }
+    // Mirror reorderList: walk back past contents until we hit a folder
+    // header, then it's "into folder" only if that folder is open. (Drops
+    // after a closed folder land at top-level.)
+    const withoutItem = lists.filter((_, i) => i !== update.source.index);
+    let intoFolder = false;
+    for (let i = update.destination.index - 1; i >= 0; i--) {
+      const item = withoutItem[i];
+      if (item?.type === "folder") {
+        intoFolder = item.open !== false;
+        break;
+      }
+      // contents (non-folder with folder ref) — skip past them to find the
+      // folder header above
+    }
+    setDragIntoFolder(intoFolder);
   };
   const handleDeleteOptionChange = (option) => {
     setActiveDeleteOption(option);
@@ -641,6 +662,8 @@ export const Home = ({ isMobile }) => {
           id="armies"
           onMoved={handleListMoved}
           onDragStart={handleDragStart}
+          onDragUpdate={handleDragUpdate}
+          intoFolder={dragIntoFolder}
         >
           {lists.map(
             ({
@@ -662,7 +685,15 @@ export const Home = ({ isMobile }) => {
                   className={classNames(
                     "home__folder",
                     activeMenu === id && "home__folder--active",
+                    open &&
+                      (folderIndex.childCounts.get(id) || 0) === 0 &&
+                      "home__folder--empty-open",
                   )}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    updateLocalList({ id, name, type, open: !open });
+                    dispatch(toggleFolder({ folderId: id }));
+                  }}
                 >
                   <span className="home__list-item">
                     <h2 className="home__headline home__headline--folder">
@@ -673,7 +704,9 @@ export const Home = ({ isMobile }) => {
                         })}
                         color="dark"
                         icon="more"
-                        onClick={() => {
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          event.preventDefault();
                           if (activeMenu === id) {
                             setActiveMenu(null);
                           } else {
@@ -684,7 +717,13 @@ export const Home = ({ isMobile }) => {
                           activeMenu === id && "header__more-button",
                         )}
                       />
-                      <span className="home__folder-name">{name}</span>
+                      <span className="home__folder-name">
+                        {name}
+                        {" "}
+                        <span className="home__folder-count">
+                          ({folderIndex.childCounts.get(id) || 0})
+                        </span>
+                      </span>
                       <Button
                         type="text"
                         label={
@@ -694,15 +733,6 @@ export const Home = ({ isMobile }) => {
                         }
                         color="dark"
                         icon={open ? "collapse" : "expand"}
-                        onClick={() => {
-                          updateLocalList({
-                            id,
-                            name,
-                            type,
-                            open: !open,
-                          });
-                          dispatch(toggleFolder({ folderId: id }));
-                        }}
                       />
                     </h2>
                   </span>
@@ -718,7 +748,11 @@ export const Home = ({ isMobile }) => {
                           <li key={buttonName}>
                             <Button
                               type="text"
-                              onClick={() => callback({ name })}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                event.preventDefault();
+                                callback({ name });
+                              }}
                               to={moreButtonTo}
                               icon={icon}
                             >
@@ -736,10 +770,7 @@ export const Home = ({ isMobile }) => {
                   to={`/editor/${id}`}
                   active={location.pathname.includes(id)}
                   onClick={resetState}
-                  hide={
-                    folders.find((folderData) => folderData.id === folder)
-                      ?.open === false
-                  }
+                  hide={folderIndex.byId.get(folder)?.open === false}
                   className={classNames(
                     listsInFolder.length > 0 && "home__list--dragging",
                   )}

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -40,7 +40,7 @@ import fantasyweltEn from "../../assets/fantasywelt_en.jpg";
 import mwgForge from "../../assets/mwg-forge.gif";
 import { useLanguage } from "../../utils/useLanguage";
 import { updateLocalList } from "../../utils/list";
-import { sortByRank, ensureRanks, reorderList, reorderFolder } from "../../utils/list-ordering";
+import { sortByRank, ensureRanks, reorderList, reorderFolder, dropFolderFor } from "../../utils/list-ordering";
 import { generateRank } from "../../utils/lexorank";
 import { setLists, toggleFolder, updateList } from "../../state/lists";
 import { updateSetting } from "../../state/settings";
@@ -197,6 +197,30 @@ export const Home = ({ isMobile }) => {
   const [folderName, setFolderName] = useState("");
   const [activeDeleteOption, setActiveDeleteOption] = useState("delete");
   const [dragIntoFolder, setDragIntoFolder] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const listsWithPhantoms = useMemo(() => {
+    const result = [];
+    let i = 0;
+    while (i < lists.length) {
+      const item = lists[i];
+      result.push(item);
+      i++;
+      if (item.type === "folder" && item.open !== false) {
+        while (i < lists.length && lists[i].folder === item.id) {
+          result.push(lists[i]);
+          i++;
+        }
+        result.push({
+          id: `phantom-${item.id}`,
+          _phantom: true,
+          folder: item.id,
+        });
+      }
+    }
+    return result;
+  }, [lists]);
+
   const resetState = () => {
     dispatch(setArmy(null));
     dispatch(setItems(null));
@@ -206,15 +230,26 @@ export const Home = ({ isMobile }) => {
   };
   const handleListMoved = ({ sourceIndex, destinationIndex }) => {
     setListsInFolder([]);
+    setIsDragging(false);
+    setDragIntoFolder(false);
 
     if (sourceIndex === destinationIndex) {
       return;
     }
 
-    const draggedItem = lists[sourceIndex];
-    const newLists = draggedItem.type === "folder"
-      ? reorderFolder(lists, sourceIndex, destinationIndex)
-      : reorderList(lists, sourceIndex, destinationIndex);
+    const draggedItem = listsWithPhantoms[sourceIndex];
+    if (!draggedItem || draggedItem._phantom) {
+      return;
+    }
+
+    const newLists =
+      draggedItem.type === "folder"
+        ? reorderFolder(listsWithPhantoms, sourceIndex, destinationIndex).filter(
+            (l) => !l._phantom,
+          )
+        : reorderList(listsWithPhantoms, sourceIndex, destinationIndex).filter(
+            (l) => !l._phantom,
+          );
 
     localStorage.setItem("owb.lists", JSON.stringify(newLists));
     dispatch(setLists(newLists));
@@ -395,6 +430,7 @@ export const Home = ({ isMobile }) => {
     window.scrollTo(0, 0);
   };
   const handleDragStart = (start) => {
+    setIsDragging(true);
     const draggedItem = lists.find(
       (list) =>
         list.id === start.draggableId || list.folder === start.draggableId,
@@ -412,27 +448,17 @@ export const Home = ({ isMobile }) => {
       setDragIntoFolder(false);
       return;
     }
-    const sourceItem = lists[update.source.index];
-    // Folders never go INTO folders
+    const sourceItem = listsWithPhantoms[update.source.index];
     if (sourceItem?.type === "folder") {
       setDragIntoFolder(false);
       return;
     }
-    // Mirror reorderList: walk back past contents until we hit a folder
-    // header, then it's "into folder" only if that folder is open. (Drops
-    // after a closed folder land at top-level.)
-    const withoutItem = lists.filter((_, i) => i !== update.source.index);
-    let intoFolder = false;
-    for (let i = update.destination.index - 1; i >= 0; i--) {
-      const item = withoutItem[i];
-      if (item?.type === "folder") {
-        intoFolder = item.open !== false;
-        break;
-      }
-      // contents (non-folder with folder ref) — skip past them to find the
-      // folder header above
-    }
-    setDragIntoFolder(intoFolder);
+    const withoutItem = listsWithPhantoms.filter(
+      (_, i) => i !== update.source.index,
+    );
+    setDragIntoFolder(
+      dropFolderFor(withoutItem, update.destination.index) !== null,
+    );
   };
   const handleDeleteOptionChange = (option) => {
     setActiveDeleteOption(option);
@@ -665,7 +691,7 @@ export const Home = ({ isMobile }) => {
           onDragUpdate={handleDragUpdate}
           intoFolder={dragIntoFolder}
         >
-          {lists.map(
+          {listsWithPhantoms.map(
             ({
               id,
               name,
@@ -676,9 +702,20 @@ export const Home = ({ isMobile }) => {
               type,
               folder,
               open,
+              _phantom,
               ...list
             }) =>
-              type === "folder" ? (
+              _phantom ? (
+                <li
+                  key={id}
+                  className={classNames(
+                    "home__phantom-drop",
+                    isDragging && "home__phantom-drop--active",
+                  )}
+                  data-folder={folder}
+                  dragDisabled
+                />
+              ) : type === "folder" ? (
                 <ListItem
                   key={id}
                   to="#"

--- a/src/pages/import/Import.jsx
+++ b/src/pages/import/Import.jsx
@@ -7,6 +7,7 @@ import { Button } from "../../components/button";
 import { Header, Main } from "../../components/page";
 import { getRandomId } from "../../utils/id";
 import { setLists } from "../../state/lists";
+import { rankAtTop } from "../../utils/list-ordering";
 
 import "./Import.css";
 
@@ -40,7 +41,12 @@ export const Import = ({ isMobile }) => {
     reader.readAsText(list, "UTF-8");
     reader.onload = (event) => {
       const newId = getRandomId();
-      const importedList = { ...JSON.parse(event.target.result), id: newId };
+      const importedList = {
+        ...JSON.parse(event.target.result),
+        id: newId,
+        rank: rankAtTop(lists),
+        folder: null,
+      };
       const newLists = [importedList, ...lists];
 
       localStorage.setItem("owb.lists", JSON.stringify(newLists));

--- a/src/pages/new-list/NewList.jsx
+++ b/src/pages/new-list/NewList.jsx
@@ -13,6 +13,7 @@ import { getGameSystems } from "../../utils/game-systems";
 import { getRandomId } from "../../utils/id";
 import { useLanguage } from "../../utils/useLanguage";
 import { setLists } from "../../state/lists";
+import { rankAtTop } from "../../utils/list-ordering";
 import { updateSetting } from "../../state/settings";
 import { RulesIndex, RuleWithIcon } from "../../components/rules-index";
 
@@ -99,6 +100,8 @@ export const NewList = ({ isMobile }) => {
       url: armyData?.url,
       armyComposition,
       compositionRule,
+      rank: rankAtTop(lists),
+      folder: null,
     };
     const newLists = [newList, ...lists];
     const newSettings = { ...settings, lastChanged: new Date().toString() };

--- a/src/utils/lexorank.js
+++ b/src/utils/lexorank.js
@@ -1,0 +1,47 @@
+// 62-char alphabet in ASCII order so index comparison and string comparison
+// agree. Midpoints can only land on alphanumeric chars (no `[ \ ] ^ _ \``
+// from the gaps between digits/uppercase/lowercase).
+const ALPHABET =
+  "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+const MIN_RANK = "000000";
+const MAX_RANK = "zzzzzz";
+
+const VALID_RANK = /^[0-9A-Za-z]+$/;
+export const isValidRank = (rank) =>
+  typeof rank === "string" && VALID_RANK.test(rank);
+
+export function generateRank(prev, next) {
+  const lower = prev || MIN_RANK;
+  const upper = next || MAX_RANK;
+  return midpoint(lower, upper);
+}
+
+function charToIndex(c) {
+  const idx = ALPHABET.indexOf(c);
+  return idx >= 0 ? idx : 0;
+}
+
+function midpoint(a, b) {
+  let result = "";
+  let i = 0;
+
+  while (true) {
+    const idxA = i < a.length ? charToIndex(a[i]) : 0;
+    const idxB = i < b.length ? charToIndex(b[i]) : ALPHABET.length - 1;
+
+    if (idxA === idxB) {
+      result += ALPHABET[idxA];
+      i++;
+      continue;
+    }
+
+    const mid = Math.floor((idxA + idxB) / 2);
+    if (mid === idxA) {
+      result += ALPHABET[idxA];
+      i++;
+      continue;
+    }
+
+    return result + ALPHABET[mid];
+  }
+}

--- a/src/utils/lexorank.test.js
+++ b/src/utils/lexorank.test.js
@@ -1,0 +1,192 @@
+import { describe, test, expect } from "vitest";
+import { generateRank } from "./lexorank";
+
+describe("generateRank", () => {
+  describe("basic cases", () => {
+    test("returns midpoint between boundaries when no neighbors exist", () => {
+      // First item gets midpoint between "000000" and "zzzzzz"
+      const first = generateRank(null, null);
+      expect(first > "000000").toBe(true);
+      expect(first < "zzzzzz").toBe(true);
+    });
+
+    test("finds midpoint before next when prev is null", () => {
+      const beforeN = generateRank(null, "n");
+      expect(beforeN < "n").toBe(true);
+      expect(beforeN > "000000").toBe(true);
+      // Works even for 'a' - should produce something that sorts before 'a'
+      expect(generateRank(null, "a") < "a").toBe(true);
+    });
+
+    test("finds midpoint after prev when next is null", () => {
+      const afterN = generateRank("n", null);
+      expect(afterN > "n").toBe(true);
+      expect(afterN < "zzzzzz").toBe(true);
+    });
+  });
+
+  describe("midpoint calculation", () => {
+    test("finds midpoint between two single characters", () => {
+      const result = generateRank("a", "z");
+      expect(result > "a").toBe(true);
+      expect(result < "z").toBe(true);
+    });
+
+    test("finds midpoint between adjacent characters by extending", () => {
+      // Between 'a' and 'b', need to extend since no char between them
+      const result = generateRank("a", "b");
+      expect(result > "a").toBe(true);
+      expect(result < "b").toBe(true);
+    });
+
+    test("finds midpoint between multi-character strings", () => {
+      const result = generateRank("abc", "xyz");
+      expect(result > "abc").toBe(true);
+      expect(result < "xyz").toBe(true);
+    });
+
+    test("handles strings with shared prefix", () => {
+      const result = generateRank("na", "nz");
+      expect(result > "na").toBe(true);
+      expect(result < "nz").toBe(true);
+    });
+  });
+
+  describe("ordering property - results always sort correctly", () => {
+    test("sequential insertions at end maintain order", () => {
+      let ranks = [];
+      let lastRank = null;
+
+      // Simulate adding 10 items to the end
+      for (let i = 0; i < 10; i++) {
+        const newRank = generateRank(lastRank, null);
+        ranks.push(newRank);
+        lastRank = newRank;
+      }
+
+      // Verify all ranks sort in order
+      const sorted = [...ranks].sort();
+      expect(sorted).toEqual(ranks);
+    });
+
+    test("sequential insertions at beginning maintain order", () => {
+      let ranks = [];
+      let firstRank = null;
+
+      // Simulate adding 10 items to the beginning
+      for (let i = 0; i < 10; i++) {
+        const newRank = generateRank(null, firstRank);
+        ranks.unshift(newRank);
+        firstRank = newRank;
+      }
+
+      // Verify all ranks sort in order
+      const sorted = [...ranks].sort();
+      expect(sorted).toEqual(ranks);
+    });
+
+    test("insertions between items maintain order", () => {
+      // Start with two items
+      const first = generateRank(null, null);
+      const last = generateRank(first, null);
+
+      // Insert between them
+      const middle = generateRank(first, last);
+
+      const ranks = [first, middle, last];
+      const sorted = [...ranks].sort();
+      expect(sorted).toEqual(ranks);
+    });
+
+    test("multiple insertions between same neighbors", () => {
+      // This tests the case where we repeatedly insert between two items
+      const first = "a";
+      const last = "z";
+
+      let prev = first;
+      let ranks = [first];
+
+      // Insert 5 items between first and last
+      for (let i = 0; i < 5; i++) {
+        const newRank = generateRank(prev, last);
+        ranks.push(newRank);
+        prev = newRank;
+      }
+      ranks.push(last);
+
+      // Verify all ranks sort in order
+      const sorted = [...ranks].sort();
+      expect(sorted).toEqual(ranks);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("handles empty string prev", () => {
+      const result = generateRank("", "z");
+      expect(result < "z").toBe(true);
+    });
+
+    test("handles empty string next", () => {
+      const result = generateRank("a", "");
+      // Empty string sorts before everything, so result should be after 'a'
+      expect(result > "a").toBe(true);
+    });
+
+    test("handles very long strings", () => {
+      const longPrev = "a".repeat(50);
+      const longNext = "z".repeat(50);
+      const result = generateRank(longPrev, longNext);
+      expect(result > longPrev).toBe(true);
+      expect(result < longNext).toBe(true);
+    });
+
+    test("handles strings of different lengths", () => {
+      const result = generateRank("nz", "nzz");
+      expect(result > "nz").toBe(true);
+      expect(result < "nzz").toBe(true);
+    });
+  });
+
+  describe("realistic usage patterns", () => {
+    test("simulates creating a list of 5 items", () => {
+      // Create 5 items one after another
+      const r1 = generateRank(null, null); // First item
+      const r2 = generateRank(r1, null); // Second at end
+      const r3 = generateRank(r2, null); // Third at end
+      const r4 = generateRank(r3, null); // Fourth at end
+      const r5 = generateRank(r4, null); // Fifth at end
+
+      const ranks = [r1, r2, r3, r4, r5];
+      const sorted = [...ranks].sort();
+      expect(sorted).toEqual(ranks);
+    });
+
+    test("simulates reordering - move last to first", () => {
+      // Create 3 items
+      const r1 = generateRank(null, null);
+      const r2 = generateRank(r1, null);
+      const r3 = generateRank(r2, null);
+
+      // Move r3 to before r1
+      const r3New = generateRank(null, r1);
+
+      const ranks = [r3New, r1, r2];
+      const sorted = [...ranks].sort();
+      expect(sorted).toEqual(ranks);
+    });
+
+    test("simulates reordering - move first to middle", () => {
+      // Create 3 items
+      const r1 = generateRank(null, null);
+      const r2 = generateRank(r1, null);
+      const r3 = generateRank(r2, null);
+
+      // Move r1 to between r2 and r3
+      const r1New = generateRank(r2, r3);
+
+      const ranks = [r2, r1New, r3];
+      const sorted = [...ranks].sort();
+      expect(sorted).toEqual(ranks);
+    });
+  });
+});

--- a/src/utils/list-ordering.js
+++ b/src/utils/list-ordering.js
@@ -110,6 +110,92 @@ export const ensureRanks = (lists) => {
   return { lists: result, needsUpdate };
 };
 
+// Float pinned items.
+//   - Top-level pinned (no folder): hoisted to the very top, ABOVE any folder,
+//     in pinned_at ascending order. Folders never push above pinned lists.
+//   - Folder-content pinned: hoisted to the top of that folder's contents.
+// Runs after sortByRank.
+export const sortWithPins = (lists) => {
+  const topLevelPinned = [];
+  const remaining = [];
+  for (const item of lists) {
+    if (item.type !== "folder" && !item.folder && item.pinned_at) {
+      topLevelPinned.push(item);
+    } else {
+      remaining.push(item);
+    }
+  }
+  topLevelPinned.sort((a, b) => new Date(a.pinned_at) - new Date(b.pinned_at));
+
+  const result = [...topLevelPinned];
+  let i = 0;
+  while (i < remaining.length) {
+    const item = remaining[i];
+    if (item.type === "folder") {
+      result.push(item);
+      i++;
+      const contents = [];
+      while (i < remaining.length && remaining[i].folder === item.id) {
+        contents.push(remaining[i]);
+        i++;
+      }
+      const pinned = contents
+        .filter((c) => c.pinned_at)
+        .sort((a, b) => new Date(a.pinned_at) - new Date(b.pinned_at));
+      const unpinned = contents.filter((c) => !c.pinned_at);
+      result.push(...pinned, ...unpinned);
+    } else {
+      result.push(item);
+      i++;
+    }
+  }
+  return result;
+};
+
+// Decide which folder a drop position falls into. Shared by reorderList
+// (commits the rank) and handleDragUpdate (shows the visual indent cue) so
+// they agree.
+//
+// To make "drop into the last position of an open folder" reachable, Home.jsx
+// inserts a phantom drop-zone item after each open folder's last child (or
+// right after the header for empty open folders). Phantoms have folder=X so
+// they match the same-folder branches below; dropping past the phantom lands
+// on top-level naturally.
+export const dropFolderFor = (withoutItem, insertAt) => {
+  const prev = withoutItem[insertAt - 1] || null;
+  const next = withoutItem[insertAt] || null;
+
+  if (prev?.type === "folder") {
+    return prev.open === false ? null : prev.id;
+  }
+  if (prev?.folder) {
+    if (!next) return prev.folder;
+    if (next.folder === prev.folder) return prev.folder;
+    if (next.type === "folder") return prev.folder;
+    if (next.folder) return prev.folder;
+    return null;
+  }
+  if (next?.folder && next.type !== "folder") {
+    return next.folder;
+  }
+  return null;
+};
+
+// Choose a rank that doesn't collide with any existing rank in `lists`.
+// generateRank is unaware of in-use ranks — when it picks one that's already
+// taken, ensureRanks would later see a duplicate and reassign by JSON array
+// position, often back to the very rank we wanted to replace. Tighten the
+// lower bound iteratively until we land on a free slot.
+const uniqueRankBetween = (prevRank, nextRank, used) => {
+  let candidate = generateRank(prevRank, nextRank);
+  let lower = prevRank;
+  while (used.has(candidate)) {
+    lower = candidate;
+    candidate = generateRank(lower, nextRank);
+  }
+  return candidate;
+};
+
 export const reorderList = (lists, sourceIndex, destIndex) => {
   const item = lists[sourceIndex];
 
@@ -119,36 +205,52 @@ export const reorderList = (lists, sourceIndex, destIndex) => {
   const prev = withoutItem[insertAt - 1] || null;
   let next = withoutItem[insertAt] || null;
 
-  let newFolder = null;
+  const newFolder = dropFolderFor(withoutItem, insertAt);
+
+  // If dropping after a collapsed folder, advance both bounds past its
+  // hidden children so the new rank lands cleanly after the whole group.
+  // (Hidden children have height:0 but still occupy rbd flat indices.)
+  // Rank-prev / rank-next must come from the SAME context as the new
+  // folder placement, otherwise we'd anchor against an unrelated rank
+  // space. E.g. dropping a top-level item just past a folder's children
+  // would anchor on those children's rank (high in lex), which then
+  // sorts the new item way down the top-level run. Walk to find anchors
+  // that share context (top-level + folder headers, OR same-folder
+  // children), skipping pinned floaters at the top level.
+  const sameContext = (c) => {
+    if (!c) return false;
+    // Phantom drop-slots have no real rank — they exist only to give the
+    // user a target for "drop into folder, last position". Anchoring rank
+    // against them would push generateRank into a (null, null) call and
+    // place the item arbitrarily within the folder.
+    if (c._phantom) return false;
+    if (newFolder === null) {
+      // Pinned top-level items float to the visual top — they don't sit
+      // at their rank position, so they're invalid rank anchors.
+      if (c.pinned_at && !c.folder && c.type !== "folder") return false;
+      return c.type === "folder" || !c.folder;
+    }
+    return c.folder === newFolder;
+  };
+  let prevRank = null;
   for (let i = insertAt - 1; i >= 0; i--) {
-    if (withoutItem[i]?.type === "folder") {
-      if (withoutItem[i].open === false) break;
-      newFolder = withoutItem[i].id;
+    if (sameContext(withoutItem[i])) {
+      prevRank = withoutItem[i].rank || null;
+      break;
+    }
+  }
+  let nextRank = null;
+  for (let i = insertAt; i < withoutItem.length; i++) {
+    if (sameContext(withoutItem[i])) {
+      nextRank = withoutItem[i].rank || null;
       break;
     }
   }
 
-  // If dropping after a collapsed folder, advance BOTH bounds past its
-  // hidden children so the new rank lands cleanly after the whole group.
-  // (Hidden children have height:0 but still occupy rbd flat indices, so
-  // `next` could otherwise be a hidden child, producing a degenerate range.)
-  let prevRank = prev?.rank || null;
-  if (prev?.type === "folder" && prev.open === false) {
-    const contents = lists.filter((l) => l.folder === prev.id);
-    if (contents.length > 0) {
-      const last = contents.reduce((a, b) =>
-        (b.rank || "") > (a.rank || "") ? b : a,
-      );
-      prevRank = last.rank;
-    }
-    let i = insertAt;
-    while (i < withoutItem.length && withoutItem[i]?.folder === prev.id) {
-      i++;
-    }
-    next = withoutItem[i] || null;
-  }
-
-  const newRank = generateRank(prevRank, next?.rank || null);
+  const usedRanks = new Set(
+    lists.filter((l) => l.id !== item.id && l.rank).map((l) => l.rank),
+  );
+  const newRank = uniqueRankBetween(prevRank, nextRank, usedRanks);
 
   return lists.map((l) =>
     l.id === item.id
@@ -211,7 +313,10 @@ export const reorderFolder = (lists, sourceIndex, destIndex) => {
     if (next?.folder === prev.id) next = null;
   }
 
-  const newRank = generateRank(prevRank, next?.rank || null);
+  const usedRanks = new Set(
+    lists.filter((l) => l.id !== folder.id && l.rank).map((l) => l.rank),
+  );
+  const newRank = uniqueRankBetween(prevRank, next?.rank || null, usedRanks);
 
   return lists.map((l) =>
     l.id === folder.id

--- a/src/utils/list-ordering.js
+++ b/src/utils/list-ordering.js
@@ -1,0 +1,218 @@
+import { generateRank, isValidRank } from "./lexorank";
+
+const byRank = (a, b) => {
+  if (!a.rank && !b.rank) return 0;
+  if (!a.rank) return 1;
+  if (!b.rank) return -1;
+  if (a.rank < b.rank) return -1;
+  if (a.rank > b.rank) return 1;
+  return 0;
+};
+
+export const sortByRank = (lists) => {
+  const topLevel = lists.filter(
+    (l) => l.folder === null || l.folder === undefined || l.type === "folder"
+  );
+
+  const sortedTopLevel = [...topLevel].sort(byRank);
+
+  const result = [];
+  for (const item of sortedTopLevel) {
+    result.push(item);
+
+    if (item.type === "folder") {
+      const contents = lists
+        .filter((l) => l.folder === item.id)
+        .sort(byRank);
+      result.push(...contents);
+    }
+  }
+
+  return result;
+};
+
+export const rankAtTop = (lists) => {
+  const sorted = sortByRank(lists);
+  return generateRank(null, sorted[0]?.rank || null);
+};
+
+// Ranks within `source`'s folder context — siblings outside the folder
+// don't constrain the position.
+export const rankAfter = (lists, source) => {
+  const siblingFolder = source?.folder || null;
+  const siblings = lists
+    .filter((l) => (l.folder || null) === siblingFolder)
+    .slice()
+    .sort(byRank);
+  const idx = siblings.findIndex((l) => l.id === source?.id);
+  const next = idx >= 0 ? siblings[idx + 1] : null;
+  return generateRank(source?.rank || null, next?.rank || null);
+};
+
+export const ensureRanks = (lists) => {
+  let lastRank = null;
+  let needsUpdate = false;
+  let currentFolder = null;
+  const seenRanks = new Set();
+
+  const firstFolderRank =
+    lists.find((l) => l.type === "folder" && isValidRank(l.rank))?.rank || null;
+
+  const result = lists.map((list, index) => {
+    if (list.type === "folder") {
+      currentFolder = list.id;
+    }
+
+    if (isValidRank(list.rank) && !seenRanks.has(list.rank)) {
+      seenRanks.add(list.rank);
+      lastRank = list.rank;
+      return list;
+    }
+
+    // Legacy migration: items without an explicit folder field inherit
+    // currentFolder from their array position (pre-rank lists relied on
+    // position to convey containment).
+    const newFolder = list.type === "folder"
+      ? list.folder
+      : (list.folder !== undefined ? list.folder : currentFolder);
+
+    // Top-level items rank before the first folder regardless of array
+    // position. Use lastRank as the lower bound so multiple top-level items
+    // each get a distinct rank instead of collapsing to the same midpoint.
+    let newRank;
+    if (newFolder === null && list.type !== "folder" && firstFolderRank) {
+      const lower = lastRank && lastRank < firstFolderRank ? lastRank : null;
+      newRank = generateRank(lower, firstFolderRank);
+    } else {
+      const nextWithRank = lists.slice(index + 1).find((l) => l.rank);
+      newRank = generateRank(lastRank, nextWithRank?.rank);
+    }
+
+    // Guarantee uniqueness even if midpoint lands on an existing rank
+    // (corrupted data or unfortunate spacing). Appending "h" extends the
+    // string to a strictly-greater value that no prior rank can match.
+    while (seenRanks.has(newRank)) {
+      newRank = newRank + "h";
+    }
+
+    needsUpdate = true;
+    lastRank = newRank;
+    seenRanks.add(newRank);
+
+    return {
+      ...list,
+      rank: newRank,
+      folder: newFolder,
+    };
+  });
+
+  return { lists: result, needsUpdate };
+};
+
+export const reorderList = (lists, sourceIndex, destIndex) => {
+  const item = lists[sourceIndex];
+
+  const withoutItem = lists.filter((_, i) => i !== sourceIndex);
+  const insertAt = destIndex;
+
+  const prev = withoutItem[insertAt - 1] || null;
+  let next = withoutItem[insertAt] || null;
+
+  let newFolder = null;
+  for (let i = insertAt - 1; i >= 0; i--) {
+    if (withoutItem[i]?.type === "folder") {
+      if (withoutItem[i].open === false) break;
+      newFolder = withoutItem[i].id;
+      break;
+    }
+  }
+
+  // If dropping after a collapsed folder, advance BOTH bounds past its
+  // hidden children so the new rank lands cleanly after the whole group.
+  // (Hidden children have height:0 but still occupy rbd flat indices, so
+  // `next` could otherwise be a hidden child, producing a degenerate range.)
+  let prevRank = prev?.rank || null;
+  if (prev?.type === "folder" && prev.open === false) {
+    const contents = lists.filter((l) => l.folder === prev.id);
+    if (contents.length > 0) {
+      const last = contents.reduce((a, b) =>
+        (b.rank || "") > (a.rank || "") ? b : a,
+      );
+      prevRank = last.rank;
+    }
+    let i = insertAt;
+    while (i < withoutItem.length && withoutItem[i]?.folder === prev.id) {
+      i++;
+    }
+    next = withoutItem[i] || null;
+  }
+
+  const newRank = generateRank(prevRank, next?.rank || null);
+
+  return lists.map((l) =>
+    l.id === item.id
+      ? { ...l, rank: newRank, folder: newFolder }
+      : l
+  );
+};
+
+export const reorderFolder = (lists, sourceIndex, destIndex) => {
+  const folder = lists[sourceIndex];
+
+  if (folder?.type !== "folder") {
+    return reorderList(lists, sourceIndex, destIndex);
+  }
+
+  // rbd's destIndex is the position in the NEW array (after removing source).
+  // Operate on the post-removal array so destIndex maps correctly regardless
+  // of whether source < dest or source > dest.
+  const contentIds = new Set(
+    lists.filter((l) => l.folder === folder.id).map((l) => l.id),
+  );
+  const withoutFolder = lists.filter((_, i) => i !== sourceIndex);
+
+  // Find the nearest neighbor on each side, skipping the folder's own
+  // contents (they'll follow the folder visually after sortByRank groups
+  // them again).
+  let prev = null;
+  for (let i = destIndex - 1; i >= 0; i--) {
+    if (!contentIds.has(withoutFolder[i].id)) {
+      prev = withoutFolder[i];
+      break;
+    }
+  }
+  let next = null;
+  for (let i = destIndex; i < withoutFolder.length; i++) {
+    if (!contentIds.has(withoutFolder[i].id)) {
+      next = withoutFolder[i];
+      break;
+    }
+  }
+
+  // If prev is a collapsed folder, advance both bounds past its hidden
+  // contents so the moved folder lands cleanly after the whole group.
+  let prevRank = prev?.rank || null;
+  if (prev?.type === "folder" && prev.open === false) {
+    const contents = lists.filter((l) => l.folder === prev.id);
+    if (contents.length > 0) {
+      const last = contents.reduce((a, b) =>
+        (b.rank || "") > (a.rank || "") ? b : a,
+      );
+      prevRank = last.rank;
+    }
+    for (let i = destIndex; i < withoutFolder.length; i++) {
+      const item = withoutFolder[i];
+      if (contentIds.has(item.id)) continue;
+      if (item.folder === prev.id) continue;
+      next = item;
+      break;
+    }
+    if (next?.folder === prev.id) next = null;
+  }
+
+  const newRank = generateRank(prevRank, next?.rank || null);
+
+  return lists.map((l) =>
+    l.id === folder.id ? { ...l, rank: newRank } : l,
+  );
+};

--- a/src/utils/list-ordering.js
+++ b/src/utils/list-ordering.js
@@ -103,6 +103,7 @@ export const ensureRanks = (lists) => {
       ...list,
       rank: newRank,
       folder: newFolder,
+      updated_at: new Date().toISOString(),
     };
   });
 
@@ -151,7 +152,7 @@ export const reorderList = (lists, sourceIndex, destIndex) => {
 
   return lists.map((l) =>
     l.id === item.id
-      ? { ...l, rank: newRank, folder: newFolder }
+      ? { ...l, rank: newRank, folder: newFolder, updated_at: new Date().toISOString() }
       : l
   );
 };
@@ -213,6 +214,8 @@ export const reorderFolder = (lists, sourceIndex, destIndex) => {
   const newRank = generateRank(prevRank, next?.rank || null);
 
   return lists.map((l) =>
-    l.id === folder.id ? { ...l, rank: newRank } : l,
+    l.id === folder.id
+      ? { ...l, rank: newRank, updated_at: new Date().toISOString() }
+      : l,
   );
 };

--- a/src/utils/list-ordering.test.js
+++ b/src/utils/list-ordering.test.js
@@ -324,6 +324,28 @@ describe("ensureRanks", () => {
     expect(ranked.rank < "D").toBe(true);
     expect(ranked.folder).toBeNull();
   });
+
+  test("stamps updated_at on items it migrates so the new rank syncs", () => {
+    // Two clients running ensureRanks independently on the same legacy data
+    // would otherwise generate different ranks AND keep identical (legacy)
+    // updated_at values, leaving sync unable to converge.
+    const lists = [
+      { id: "1", name: "Has rank", rank: "h", updated_at: "2026-01-01T00:00:00.000Z" },
+      { id: "2", name: "No rank yet", updated_at: "2026-01-01T00:00:00.000Z" },
+    ];
+
+    const before = new Date().toISOString();
+    const { lists: result } = ensureRanks(lists);
+    const after = new Date().toISOString();
+
+    // Untouched item keeps its original updated_at.
+    expect(result.find((l) => l.id === "1").updated_at).toBe("2026-01-01T00:00:00.000Z");
+
+    // Migrated item gets a fresh updated_at so sync recognises it as dirty.
+    const migrated = result.find((l) => l.id === "2");
+    expect(migrated.updated_at >= before).toBe(true);
+    expect(migrated.updated_at <= after).toBe(true);
+  });
 });
 
 describe("reorderList", () => {
@@ -592,6 +614,34 @@ describe("reorderList", () => {
       expect(unchanged.rank).toBe("b");
     });
   });
+
+  describe("updated_at stamping", () => {
+    test("stamps updated_at on the moved item so sync sees it as dirty", () => {
+      const lists = [
+        { ...makeList("1", "First", "d"), updated_at: "2026-01-01T00:00:00.000Z" },
+        { ...makeList("2", "Second", "m"), updated_at: "2026-01-01T00:00:00.000Z" },
+      ];
+
+      const before = new Date().toISOString();
+      const result = reorderList(lists, 0, 1);
+      const after = new Date().toISOString();
+
+      const moved = result.find((l) => l.id === "1");
+      expect(moved.updated_at >= before).toBe(true);
+      expect(moved.updated_at <= after).toBe(true);
+    });
+
+    test("does not stamp updated_at on untouched items", () => {
+      const lists = [
+        { ...makeList("1", "First", "d"), updated_at: "2026-01-01T00:00:00.000Z" },
+        { ...makeList("2", "Second", "m"), updated_at: "2026-01-01T00:00:00.000Z" },
+      ];
+
+      const result = reorderList(lists, 0, 1);
+      const unchanged = result.find((l) => l.id === "2");
+      expect(unchanged.updated_at).toBe("2026-01-01T00:00:00.000Z");
+    });
+  });
 });
 
 describe("reorderFolder", () => {
@@ -730,6 +780,25 @@ describe("reorderFolder", () => {
       // Must sort AFTER all current top-level ranks (max is "004")
       expect(movedFolder.rank > "004").toBe(true);
       expect(movedFolder.rank).not.toBe("001");
+    });
+  });
+
+  describe("updated_at stamping", () => {
+    test("stamps updated_at on the moved folder so sync sees it as dirty", () => {
+      const folder = { ...makeFolder("folder1", "My Folder", "b"), updated_at: "2026-01-01T00:00:00.000Z" };
+      const lists = [
+        { ...makeList("1", "First", "a"), updated_at: "2026-01-01T00:00:00.000Z" },
+        folder,
+        { ...makeList("2", "Second", "c"), updated_at: "2026-01-01T00:00:00.000Z" },
+      ];
+
+      const before = new Date().toISOString();
+      const result = reorderFolder(lists, 1, 2);
+      const after = new Date().toISOString();
+
+      const moved = result.find((l) => l.id === "folder1");
+      expect(moved.updated_at >= before).toBe(true);
+      expect(moved.updated_at <= after).toBe(true);
     });
   });
 });

--- a/src/utils/list-ordering.test.js
+++ b/src/utils/list-ordering.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { sortByRank, ensureRanks, reorderList, reorderFolder } from "./list-ordering";
+import { sortByRank, ensureRanks, reorderList, reorderFolder, sortWithPins } from "./list-ordering";
 
 // Helper to create a list item
 const makeList = (id, name, rank = null, folder = null) => ({
@@ -184,6 +184,13 @@ describe("ensureRanks", () => {
     expect(result[1].rank < "z").toBe(true);
   });
 
+  test("sets updated_at on newly ranked items", () => {
+    const lists = [makeList("1", "First")];
+
+    const { lists: result } = ensureRanks(lists);
+    expect(result[0].updated_at).toBeTruthy();
+  });
+
   test("assigns folder from position for legacy items", () => {
     const folder = makeFolder("folder1", "My Folder", "a");
     // Truly legacy item: no folder property at all (undefined, not null)
@@ -323,28 +330,6 @@ describe("ensureRanks", () => {
     const ranked = result.find((l) => l.id === "1");
     expect(ranked.rank < "D").toBe(true);
     expect(ranked.folder).toBeNull();
-  });
-
-  test("stamps updated_at on items it migrates so the new rank syncs", () => {
-    // Two clients running ensureRanks independently on the same legacy data
-    // would otherwise generate different ranks AND keep identical (legacy)
-    // updated_at values, leaving sync unable to converge.
-    const lists = [
-      { id: "1", name: "Has rank", rank: "h", updated_at: "2026-01-01T00:00:00.000Z" },
-      { id: "2", name: "No rank yet", updated_at: "2026-01-01T00:00:00.000Z" },
-    ];
-
-    const before = new Date().toISOString();
-    const { lists: result } = ensureRanks(lists);
-    const after = new Date().toISOString();
-
-    // Untouched item keeps its original updated_at.
-    expect(result.find((l) => l.id === "1").updated_at).toBe("2026-01-01T00:00:00.000Z");
-
-    // Migrated item gets a fresh updated_at so sync recognises it as dirty.
-    const migrated = result.find((l) => l.id === "2");
-    expect(migrated.updated_at >= before).toBe(true);
-    expect(migrated.updated_at <= after).toBe(true);
   });
 });
 
@@ -560,8 +545,10 @@ describe("reorderList", () => {
       const moved = result.find((l) => l.id === "2");
 
       expect(moved.folder).toBe("folder1");
-      expect(moved.rank < "b").toBe(true);
-      expect(moved.rank > "a").toBe(true);
+      // Second now sorts FIRST among folder1's children.
+      const sorted = sortByRank(result);
+      const childIds = sorted.filter((l) => l.folder === "folder1").map((l) => l.id);
+      expect(childIds).toEqual(["2", "1"]);
     });
 
     test("dropping below an open folder DOES add to folder", () => {
@@ -603,6 +590,17 @@ describe("reorderList", () => {
       expect(moved.rank > "m").toBe(true);
     });
 
+    test("sets updated_at on moved item", () => {
+      const lists = [
+        makeList("1", "First", "a"),
+        makeList("2", "Second", "b"),
+      ];
+
+      const result = reorderList(lists, 0, 2);
+      const moved = result.find((l) => l.id === "1");
+      expect(moved.updated_at).toBeTruthy();
+    });
+
     test("does not modify other items", () => {
       const lists = [
         makeList("1", "First", "a"),
@@ -612,34 +610,7 @@ describe("reorderList", () => {
       const result = reorderList(lists, 0, 2);
       const unchanged = result.find((l) => l.id === "2");
       expect(unchanged.rank).toBe("b");
-    });
-  });
-
-  describe("updated_at stamping", () => {
-    test("stamps updated_at on the moved item so sync sees it as dirty", () => {
-      const lists = [
-        { ...makeList("1", "First", "d"), updated_at: "2026-01-01T00:00:00.000Z" },
-        { ...makeList("2", "Second", "m"), updated_at: "2026-01-01T00:00:00.000Z" },
-      ];
-
-      const before = new Date().toISOString();
-      const result = reorderList(lists, 0, 1);
-      const after = new Date().toISOString();
-
-      const moved = result.find((l) => l.id === "1");
-      expect(moved.updated_at >= before).toBe(true);
-      expect(moved.updated_at <= after).toBe(true);
-    });
-
-    test("does not stamp updated_at on untouched items", () => {
-      const lists = [
-        { ...makeList("1", "First", "d"), updated_at: "2026-01-01T00:00:00.000Z" },
-        { ...makeList("2", "Second", "m"), updated_at: "2026-01-01T00:00:00.000Z" },
-      ];
-
-      const result = reorderList(lists, 0, 1);
-      const unchanged = result.find((l) => l.id === "2");
-      expect(unchanged.updated_at).toBe("2026-01-01T00:00:00.000Z");
+      expect(unchanged.updated_at).toBeUndefined();
     });
   });
 });
@@ -781,24 +752,18 @@ describe("reorderFolder", () => {
       expect(movedFolder.rank > "004").toBe(true);
       expect(movedFolder.rank).not.toBe("001");
     });
-  });
 
-  describe("updated_at stamping", () => {
-    test("stamps updated_at on the moved folder so sync sees it as dirty", () => {
-      const folder = { ...makeFolder("folder1", "My Folder", "b"), updated_at: "2026-01-01T00:00:00.000Z" };
+    test("sets updated_at on moved folder", () => {
+      const folder = makeFolder("folder1", "My Folder", "a");
       const lists = [
-        { ...makeList("1", "First", "a"), updated_at: "2026-01-01T00:00:00.000Z" },
         folder,
-        { ...makeList("2", "Second", "c"), updated_at: "2026-01-01T00:00:00.000Z" },
+        makeList("1", "Outside", "b"),
       ];
 
-      const before = new Date().toISOString();
-      const result = reorderFolder(lists, 1, 2);
-      const after = new Date().toISOString();
-
-      const moved = result.find((l) => l.id === "folder1");
-      expect(moved.updated_at >= before).toBe(true);
-      expect(moved.updated_at <= after).toBe(true);
+      // rbd dest = new-array index. Last position in 2-item new array = 1.
+      const result = reorderFolder(lists, 0, 1);
+      const movedFolder = result.find((l) => l.id === "folder1");
+      expect(movedFolder.updated_at).toBeTruthy();
     });
   });
 });
@@ -1001,10 +966,13 @@ describe("newly created folders", () => {
 
     // Now reordering should work
     const reSorted = sortByRank(ranked);
-    const folderIdx = reSorted.findIndex((l) => l.id === "folder1");
-    // Drop List A below the folder
     const listAIdx = reSorted.findIndex((l) => l.id === "1");
-    const reordered = reorderList(reSorted, listAIdx, folderIdx + 1);
+    // Drop List A right after the folder header. reorderList takes the
+    // POST-removal index (matching rbd's destination.index), so when listA
+    // sits before the folder, "right after folder header" maps to the
+    // folder's post-removal index + 1.
+    const folderIdxPost = reSorted.findIndex((l) => l.id === "folder1") - (listAIdx < reSorted.findIndex((l) => l.id === "folder1") ? 1 : 0);
+    const reordered = reorderList(reSorted, listAIdx, folderIdxPost + 1);
     const finalSorted = sortByRank(reordered);
 
     const moved = finalSorted.find((l) => l.id === "1");
@@ -1022,8 +990,9 @@ describe("integration: reorder then sort", () => {
       makeList("3", "Last", "d"),
     ];
 
-    // Move "First" into the folder (after folder header)
-    const reordered = reorderList(lists, 0, 2);
+    // Move "First" into the folder. Post-removal layout is
+    // [folder, Inside, Last]; drop right after folder header = idx 1.
+    const reordered = reorderList(lists, 0, 1);
     const sorted = sortByRank(reordered);
 
     // First should now be inside folder
@@ -1053,5 +1022,499 @@ describe("integration: reorder then sort", () => {
     expect(sorted[0].name).toBe("Third");
     expect(sorted[1].name).toBe("First");
     expect(sorted[2].name).toBe("Second");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sortWithPins
+// ---------------------------------------------------------------------------
+describe("sortWithPins", () => {
+  const list = (id, opts = {}) => ({ id, name: id, type: opts.type, folder: opts.folder, pinned_at: opts.pinned_at });
+
+  test("top-level pinned floats above all folders", () => {
+    const lists = [
+      list("L1"),
+      list("F1", { type: "folder" }),
+      list("L2", { folder: "F1" }),
+      list("L3", { pinned_at: "2026-01-01T00:00:00Z" }),
+    ];
+    const sorted = sortWithPins(lists);
+    expect(sorted.map((l) => l.id)).toEqual(["L3", "L1", "F1", "L2"]);
+  });
+
+  test("multiple top-level pinned ordered by pinned_at ascending", () => {
+    const lists = [
+      list("F1", { type: "folder" }),
+      list("L1", { pinned_at: "2026-02-01T00:00:00Z" }),
+      list("L2", { pinned_at: "2026-01-01T00:00:00Z" }),
+    ];
+    const sorted = sortWithPins(lists);
+    expect(sorted.map((l) => l.id)).toEqual(["L2", "L1", "F1"]);
+  });
+
+  test("folder-content pinned floats to top of its folder, not to global top", () => {
+    const lists = [
+      list("L1"),
+      list("F1", { type: "folder" }),
+      list("L2", { folder: "F1" }),
+      list("L3", { folder: "F1", pinned_at: "2026-01-01T00:00:00Z" }),
+    ];
+    const sorted = sortWithPins(lists);
+    expect(sorted.map((l) => l.id)).toEqual(["L1", "F1", "L3", "L2"]);
+  });
+
+  test("top-level pinned + folder-content pinned coexist correctly", () => {
+    const lists = [
+      list("L_top"),
+      list("F1", { type: "folder" }),
+      list("L_in", { folder: "F1" }),
+      list("L_in_pin", { folder: "F1", pinned_at: "2026-01-01T00:00:00Z" }),
+      list("L_top_pin", { pinned_at: "2026-01-02T00:00:00Z" }),
+    ];
+    const sorted = sortWithPins(lists);
+    expect(sorted.map((l) => l.id)).toEqual([
+      "L_top_pin", // top-level pin → very top
+      "L_top",     // unpinned top-level keeps rank position
+      "F1",
+      "L_in_pin", // pin within folder → top of folder
+      "L_in",
+    ]);
+  });
+
+  test("folders never push above top-level pinned even when folder rank is first", () => {
+    const lists = [
+      list("F1", { type: "folder" }),
+      list("L1", { pinned_at: "2026-01-01T00:00:00Z" }),
+    ];
+    const sorted = sortWithPins(lists);
+    expect(sorted[0].id).toBe("L1");
+    expect(sorted[1].id).toBe("F1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reorderList — drag bugs from real-user snapshots (TDD)
+// ---------------------------------------------------------------------------
+describe("reorderList — real-snapshot scenarios", () => {
+  // Build a stripped-down post-sortByRank visual layout matching snap-1.
+  // sourceIndex 2 = Mark Long, the user dragged him to "first place inside
+  // Tournament Submits". TS is at idx 3, BB-Summer (TS child) at 4, Liam
+  // (TS child) at 5. Post-removal drop position between TS and BB-Summer
+  // is destinationIndex 3.
+  const snap1Lists = () => [
+    { id: "liam-top", name: "Liam top", rank: "Hhhh", folder: null, type: undefined },
+    { id: "cory", name: "Cory", rank: "Yyv", folder: null, type: undefined },
+    { id: "mark", name: "Mark", rank: "Yyx", folder: null, type: undefined },
+    { id: "ts", name: "Tournament Submits", rank: "Z", folder: null, type: "folder", open: true },
+    { id: "bb-summer", name: "BB-Summer", rank: "Yh", folder: "ts", type: undefined },
+    { id: "liam-in-ts", name: "Liam in TS", rank: "h", folder: "ts", type: undefined },
+  ];
+
+  test("dragging top-level item into open folder at first position lands it first inside that folder", () => {
+    const lists = snap1Lists();
+    const result = reorderList(lists, 2, 3); // mark from idx 2, drop between TS and BB-Summer
+
+    const mark = result.find((l) => l.id === "mark");
+    expect(mark.folder).toBe("ts");
+
+    // Sort TS children by rank; mark must be FIRST.
+    const tsChildren = result
+      .filter((l) => l.folder === "ts")
+      .sort((a, b) => (a.rank < b.rank ? -1 : a.rank > b.rank ? 1 : 0));
+    expect(tsChildren[0].id).toBe("mark");
+    expect(tsChildren[0].rank).not.toBe("Yyx"); // rank MUST have changed
+  });
+
+  test("rank assigned in folder must compare LESS than the folder's first existing child", () => {
+    const lists = snap1Lists();
+    const result = reorderList(lists, 2, 3);
+    const mark = result.find((l) => l.id === "mark");
+    const bb = result.find((l) => l.id === "bb-summer");
+    expect(mark.rank < bb.rank).toBe(true);
+  });
+
+  // Snap-2 → snap-3 drag-out scenario. Mark Long is now in TS at rank Yyx,
+  // visual idx 27 of 51. User drags him out and rbd reports a destination
+  // somewhere between top-level items where the nearest preceding folder
+  // header is New Folder (folder-lcvbkbhb), causing him to silently land
+  // in NF instead of top-level.
+  const snap2Lists = () => [
+    { id: "nf", name: "New Folder", rank: "07", folder: null, type: "folder", open: true },
+    { id: "calum-nf", name: "Calum in NF", rank: "Yyy", folder: "nf", type: undefined },
+    { id: "summer-slam", name: "Summer Slam", rank: "YyyU", folder: "nf", type: undefined },
+    { id: "bb-settra", name: "BB-Settra", rank: "2", folder: null, type: undefined },
+    { id: "ts", name: "Tournament Submits", rank: "Z", folder: null, type: "folder", open: true },
+    { id: "bb-summer", name: "BB-Summer", rank: "Yh", folder: "ts", type: undefined },
+    { id: "mark", name: "Mark", rank: "Yyx", folder: "ts", type: undefined },
+    { id: "liam-in-ts", name: "Liam in TS", rank: "h", folder: "ts", type: undefined },
+    { id: "battle", name: "Battle march", rank: "q", folder: null, type: "folder", open: true },
+  ];
+
+  test("dragging item out of folder to position between last child and next folder header — stays in folder (last position)", () => {
+    const lists = snap2Lists();
+    // Mark at idx 6 (in TS). Drop right after Liam (TS's last child), just
+    // before Battle folder header. Post-removal idx 7. prev=Liam (folder=ts),
+    // next=Battle (folder header) → "last position in TS" semantics.
+    const result = reorderList(lists, 6, 7);
+    const mark = result.find((l) => l.id === "mark");
+    expect(mark.folder).toBe("ts");
+  });
+
+  test("dragging item out of folder to between top-level items above its folder — lands at top-level (not in earlier folder)", () => {
+    const lists = snap2Lists();
+    // Mark at idx 6 (in TS). User drags up; rbd reports drop position 4
+    // (between bb-settra and TS header). Walk-back via OLD logic would skip
+    // bb-settra and NF children, landing in NF — the bug. New logic uses
+    // next item's context: next=TS header → top-level.
+    const result = reorderList(lists, 6, 4);
+    const mark = result.find((l) => l.id === "mark");
+    expect(mark.folder).toBeNull();
+  });
+
+  test("dragging item out of folder to between NF child and a top-level item — lands at top-level", () => {
+    const lists = snap2Lists();
+    // Drop position 3 (between summer-slam (last NF child) and bb-settra
+    // (top-level)). prev=summer-slam (folder=nf), next=bb-settra (top-level).
+    // Boundary out of NF — top-level.
+    const result = reorderList(lists, 6, 3);
+    const mark = result.find((l) => l.id === "mark");
+    expect(mark.folder).toBeNull();
+  });
+
+  test("dragging top-level item just below a folder's last child to a position before BB-Settra — anchors against folder header, not the folder child", () => {
+    // Reproduces a follow-on bug: Mark is at top-level (rank 03), NF folder
+    // is open (rank 07) with children Calum/Summer Slam, BB-Settra is the
+    // first top-level after the folder. User drags Mark from his top-level
+    // slot to "just above BB-Settra". The drop position is between
+    // Summer Slam (NF child, rank YyyU) and BB-Settra (rank 2). Old code
+    // anchored on Summer Slam → generateRank(YyyU, 2) = "I", which sorts
+    // Mark below Liam Meikle (rank Hhhh < I < O). Fix walks past folder
+    // children to find NF (the same-context prev) → rank between 07 and 2.
+    const lists = [
+      { id: "wed", name: "Wed", rank: "H", pinned_at: "2026-01-01T00:00:00Z" },
+      { id: "mark", name: "Mark", rank: "03" },
+      { id: "nf", name: "NF", rank: "07", type: "folder", open: true },
+      { id: "calum", name: "Calum", rank: "Yyy", folder: "nf" },
+      { id: "summer", name: "Summer", rank: "YyyU", folder: "nf" },
+      { id: "bb-settra", name: "BB-Settra", rank: "2" },
+      { id: "chorfs", name: "Chorfs", rank: "5g" },
+      { id: "liam", name: "Liam", rank: "Hhhh" },
+      { id: "keith", name: "Keith", rank: "O" },
+    ];
+    const visual = sortWithPins(sortByRank(lists));
+    // visual: [wed (pinned), mark, nf, calum, summer, bb-settra, chorfs, liam, keith]
+    const markIdx = visual.findIndex((l) => l.id === "mark");
+    const bbIdx = visual.findIndex((l) => l.id === "bb-settra");
+    // Drop just before BB-Settra. markIdx < bbIdx → post-removal BB at bbIdx-1.
+    const dest = bbIdx - 1;
+
+    const result = reorderList(visual, markIdx, dest);
+    const mark = result.find((l) => l.id === "mark");
+
+    expect(mark.folder).toBeNull();
+    // Sort against top-level rank space: between NF (07) and BB-Settra (2).
+    expect(mark.rank > "07").toBe(true);
+    expect(mark.rank < "2").toBe(true);
+    // Specifically NOT in the H..O range where Liam/Keith live.
+    expect(mark.rank < "5g").toBe(true);
+  });
+
+  test("dragging from inside folder to top-level position immediately above the folder header (when prev is pinned)", () => {
+    // Reproduces the production bug: pinned 'Wed night orcs' (rank H) floats
+    // to the top, New Folder (rank 07) is the first non-pinned item, with
+    // Mark inside NF. Dropping Mark just above NF and below Wed should land
+    // him as the first top-level item. With the old code, generateRank('H',
+    // '07') produced rank '8', placing Mark below BB-Settra (rank '2') —
+    // way below where the user intended.
+    const lists = [
+      { id: "wed", name: "Wed night orcs", rank: "H", pinned_at: "2026-01-01T00:00:00Z" },
+      { id: "nf", name: "New Folder", rank: "07", type: "folder", open: true },
+      { id: "mark", name: "Mark", rank: "Yyx", folder: "nf" },
+      { id: "calum", name: "Calum", rank: "Yyy", folder: "nf" },
+      { id: "summer", name: "Summer Slam", rank: "YyyU", folder: "nf" },
+      { id: "bb-settra", name: "BB-Settra", rank: "2" },
+      { id: "chorfs", name: "Chorfs", rank: "5g" },
+      { id: "cold", name: "Cold WSWG", rank: "8" },
+    ];
+
+    // Visual layout post-sortWithPins is: [wed (pinned), nf, mark, calum,
+    // summer, bb-settra, chorfs, cold]. Mark is at idx 2; user drops him
+    // between wed (idx 0) and nf (idx 1). Post-removal layout:
+    // [wed, nf, calum, summer, bb-settra, chorfs, cold]; drop at idx 1.
+    const visual = sortWithPins(sortByRank(lists));
+    const markIdx = visual.findIndex((l) => l.id === "mark");
+    const result = reorderList(visual, markIdx, 1);
+    const mark = result.find((l) => l.id === "mark");
+
+    // Top-level (out of folder).
+    expect(mark.folder).toBeNull();
+    // And rank should sort BEFORE NF so visually first non-pinned.
+    expect(mark.rank < "07").toBe(true);
+    // And NOT below BB-Settra (the original bug).
+    expect(mark.rank < "2").toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dropFolderFor — direct unit tests for the placement rule
+// ---------------------------------------------------------------------------
+import { dropFolderFor } from "./list-ordering";
+
+describe("dropFolderFor", () => {
+  test("right after open folder header → inside folder", () => {
+    const list = [
+      { id: "f", type: "folder", open: true },
+      { id: "a", folder: "f" },
+    ];
+    expect(dropFolderFor(list, 1)).toBe("f");
+  });
+
+  test("right after closed folder header → top-level", () => {
+    const list = [
+      { id: "f", type: "folder", open: false },
+      { id: "a", folder: "f" },
+    ];
+    expect(dropFolderFor(list, 1)).toBe(null);
+  });
+
+  test("between two children of same folder → that folder", () => {
+    const list = [
+      { id: "a", folder: "f" },
+      { id: "b", folder: "f" },
+    ];
+    expect(dropFolderFor(list, 1)).toBe("f");
+  });
+
+  test("between folder X's last child and a top-level item → top-level (drag-out boundary; phantom slot serves drag-in)", () => {
+    const list = [
+      { id: "a", folder: "f" },
+      { id: "b", folder: null },
+    ];
+    expect(dropFolderFor(list, 1)).toBe(null);
+  });
+
+  test("between folder X's last child and another folder header → stays in X (last)", () => {
+    const list = [
+      { id: "a", folder: "f" },
+      { id: "g", type: "folder", open: true },
+    ];
+    expect(dropFolderFor(list, 1)).toBe("f");
+  });
+
+  test("right after an empty open folder header (next is anything) → INSIDE that folder", () => {
+    const list = [
+      { id: "f", type: "folder", open: true },
+      { id: "after", folder: null },
+    ];
+    expect(dropFolderFor(list, 1)).toBe("f");
+  });
+
+  test("right after an empty open folder header at end of list → INSIDE that folder", () => {
+    const list = [{ id: "f", type: "folder", open: true }];
+    expect(dropFolderFor(list, 1)).toBe("f");
+  });
+
+  test("phantom rows are skipped as rank anchors so reorderList uses the previous real sibling", () => {
+    // The folder-X last child (rank "c") is being dropped onto the phantom
+    // slot. Without skipping the phantom, prev becomes the rankless phantom
+    // → generateRank(null, null) and the item lands arbitrarily within X.
+    const lists = [
+      { id: "f", type: "folder", rank: "a", open: true },
+      { id: "first", folder: "f", rank: "b" },
+      { id: "moved", folder: "f", rank: "c" }, // currently last child of f
+      { id: `phantom-f`, _phantom: true, folder: "f" },
+      { id: "outside", folder: null, rank: "z" },
+    ];
+    // Drop "moved" onto the phantom slot. Visual is already the same; rbd
+    // would report sourceIndex=2, destinationIndex=2 (phantom's post-removal
+    // index). reorderList should anchor against "first" (the real previous
+    // sibling), not the phantom.
+    const result = reorderList(lists, 2, 2);
+    const moved = result.find((l) => l.id === "moved");
+    expect(moved.folder).toBe("f");
+    expect(moved.rank > "b").toBe(true);
+  });
+
+  test("phantom-as-next anchors the drop INTO the phantom's folder", () => {
+    // Home.jsx inserts a phantom after each open folder's last child to
+    // make "drop into folder, last position" reachable. Phantoms have
+    // folder=X and no rank.
+    const list = [
+      { id: "child", folder: "f" },
+      { id: "phantom-f", _phantom: true, folder: "f" },
+      { id: "next", folder: null },
+    ];
+    // Drop AT the phantom slot (between child and phantom): both have
+    // folder=f → in f.
+    expect(dropFolderFor(list, 1)).toBe("f");
+    // Drop AFTER the phantom (between phantom and next top-level item):
+    // boundary out → top-level.
+    expect(dropFolderFor(list, 2)).toBe(null);
+  });
+
+  test("at end of list when prev is folder child → stays in that folder (last)", () => {
+    const list = [{ id: "a", folder: "f" }];
+    expect(dropFolderFor(list, 1)).toBe("f");
+  });
+
+  test("between two top-level items → top-level", () => {
+    const list = [{ id: "a" }, { id: "b" }];
+    expect(dropFolderFor(list, 1)).toBe(null);
+  });
+
+  test("dropping above a folder header (next is folder) when prev is top-level → top-level", () => {
+    const list = [
+      { id: "a", folder: null },
+      { id: "f", type: "folder", open: true },
+    ];
+    expect(dropFolderFor(list, 1)).toBe(null);
+  });
+
+  test("dropping above a folder child when prev is top-level → into that folder", () => {
+    const list = [
+      { id: "top", folder: null },
+      { id: "child", folder: "f" },
+    ];
+    expect(dropFolderFor(list, 1)).toBe("f");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stress: random drag-drop combinations on a realistic fixture
+// (Inspired by an exhaustive scan of a real-user 51-list snapshot — covers
+// inverted-bounds folders, prefix-pair ranks, near-MIN ranks, closed folders,
+// and pinned items. Deterministic via mulberry32 seeded RNG so failures are
+// reproducible.)
+// ---------------------------------------------------------------------------
+describe("reorderList — randomised stress on realistic fixture", () => {
+  const FIXTURE = [
+    // Pinned tops
+    { id: "p1", name: "Pinned A", rank: "0F", pinned_at: "2026-03-22T23:42:36.133Z" },
+    { id: "p2", name: "Pinned B", rank: "7", pinned_at: "2026-03-22T23:42:42.561Z" },
+    // Folder rank '07' (near-MIN) with children spanning ranks
+    { id: "f-near-min", name: "Near Min", type: "folder", rank: "07", open: true },
+    { id: "fc1", name: "Yyy", rank: "Yyy", folder: "f-near-min" },
+    { id: "fc2", name: "YyyU", rank: "YyyU", folder: "f-near-min" },
+    // Top-level run including prefix pairs
+    { id: "t1", name: "BB-Settra", rank: "2" },
+    { id: "t2", name: "Cold WSWG", rank: "8" },
+    { id: "t3", name: "Calum top", rank: "9" },
+    { id: "t4", name: "Liam-top long", rank: "Hhhh" },
+    { id: "t5", name: "Cameron", rank: "Y" },
+    { id: "t6", name: "Wed waaaagh", rank: "YU" },
+    { id: "t7", name: "Jabe", rank: "Yy" },
+    { id: "t8", name: "Morgan", rank: "YyU" },
+    { id: "t9", name: "Adam Southwell", rank: "Yyr" },
+    { id: "t10", name: "Cory Mathis", rank: "Yyv" },
+    { id: "t11", name: "Mark Long", rank: "Yyx" },
+    // INVERTED-BOUNDS folder: rank "Z" but children "Yh" and "h"
+    { id: "f-inverted", name: "TS", type: "folder", rank: "Z", open: true },
+    { id: "ic1", name: "BB-Summer", rank: "Yh", folder: "f-inverted" },
+    { id: "ic2", name: "Liam-in-TS", rank: "h", folder: "f-inverted" },
+    // Closed folder
+    { id: "f-closed", name: "Battle", type: "folder", rank: "q", open: false },
+    { id: "cc1", name: "War", rank: "r", folder: "f-closed", pinned_at: "2026-05-01T00:00:00Z" },
+    { id: "cc2", name: "Hallowed", rank: "tzmzK", folder: "f-closed" },
+    // Open folder with many lowercase children
+    { id: "f-many", name: "Sync", type: "folder", rank: "u", open: true },
+    { id: "mc1", name: "Double Shag", rank: "w", folder: "f-many" },
+    { id: "mc2", name: "Summer Sling", rank: "x", folder: "f-many" },
+    { id: "mc3", name: "Where Ogre", rank: "y", folder: "f-many" },
+    { id: "mc4", name: "Michel Jago", rank: "yU", folder: "f-many" },
+    { id: "mc5", name: "Colin G WH", rank: "yg", folder: "f-many" },
+  ];
+
+  // Deterministic PRNG so any failure is reproducible.
+  const mulberry32 = (seed) => () => {
+    let t = (seed += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+
+  const baseLists = (() => {
+    const ensured = ensureRanks(FIXTURE).lists;
+    return sortWithPins(sortByRank(ensured));
+  })();
+
+  test("50 random drag-drops: no rank collisions, no invalid folders, ensureRanks preserves", () => {
+    const rng = mulberry32(0xbb_50);
+    const N = 50;
+    const failures = [];
+
+    for (let i = 0; i < N; i++) {
+      let src;
+      do {
+        src = Math.floor(rng() * baseLists.length);
+      } while (baseLists[src].type === "folder");
+      let dest;
+      do {
+        dest = Math.floor(rng() * baseLists.length);
+      } while (dest === src);
+
+      const result = reorderList(baseLists, src, dest);
+      const moved = result.find((l) => l.id === baseLists[src].id);
+
+      const ranks = result.map((l) => l.rank).filter(Boolean);
+      const seen = new Set();
+      for (const r of ranks) {
+        if (seen.has(r)) {
+          failures.push({ i, src, dest, kind: "collision", dup: r });
+          break;
+        }
+        seen.add(r);
+      }
+
+      if (moved.folder && !result.some((l) => l.id === moved.folder && l.type === "folder")) {
+        failures.push({ i, src, dest, kind: "invalid-folder", folder: moved.folder });
+      }
+
+      const { lists: ensuredAgain } = ensureRanks(result);
+      const after = ensuredAgain.find((l) => l.id === moved.id).rank;
+      if (after !== moved.rank) {
+        failures.push({ i, src, dest, kind: "ensureRanks-regressed", before: moved.rank, after });
+      }
+    }
+
+    if (failures.length) {
+      // Surface first 5 failures inline; full list goes to the assertion message.
+      console.log("Stress failures:", failures.slice(0, 5));
+    }
+    expect(failures).toEqual([]);
+  });
+
+  test("50 random folder reorders: no rank collisions, child counts preserved", () => {
+    const rng = mulberry32(0xbb_5f);
+    const N = 50;
+    const folderSrcs = baseLists
+      .map((l, i) => (l.type === "folder" ? i : -1))
+      .filter((i) => i >= 0);
+    const failures = [];
+
+    for (let i = 0; i < N; i++) {
+      const src = folderSrcs[Math.floor(rng() * folderSrcs.length)];
+      let dest;
+      do {
+        dest = Math.floor(rng() * baseLists.length);
+      } while (dest === src);
+
+      const result = reorderFolder(baseLists, src, dest);
+      const ranks = result.map((l) => l.rank).filter(Boolean);
+      const seen = new Set();
+      for (const r of ranks) {
+        if (seen.has(r)) {
+          failures.push({ i, src, dest, kind: "collision", dup: r });
+          break;
+        }
+        seen.add(r);
+      }
+      const folderId = baseLists[src].id;
+      const before = baseLists.filter((l) => l.folder === folderId).length;
+      const after = result.filter((l) => l.folder === folderId).length;
+      if (before !== after) failures.push({ i, src, dest, kind: "child-count", before, after });
+    }
+
+    if (failures.length) console.log("Folder stress failures:", failures.slice(0, 5));
+    expect(failures).toEqual([]);
   });
 });

--- a/src/utils/list-ordering.test.js
+++ b/src/utils/list-ordering.test.js
@@ -1,0 +1,988 @@
+import { describe, test, expect } from "vitest";
+import { sortByRank, ensureRanks, reorderList, reorderFolder } from "./list-ordering";
+
+// Helper to create a list item
+const makeList = (id, name, rank = null, folder = null) => ({
+  id,
+  name,
+  rank,
+  folder,
+  type: "list",
+});
+
+// Helper to create a folder
+const makeFolder = (id, name, rank = null, open = true) => ({
+  id,
+  name,
+  rank,
+  folder: null,
+  type: "folder",
+  open,
+});
+
+describe("sortByRank", () => {
+  describe("basic sorting", () => {
+    test("sorts items by rank alphabetically", () => {
+      const lists = [
+        makeList("3", "Third", "c"),
+        makeList("1", "First", "a"),
+        makeList("2", "Second", "b"),
+      ];
+
+      const result = sortByRank(lists);
+      expect(result.map((l) => l.name)).toEqual(["First", "Second", "Third"]);
+    });
+
+    test("items without rank sort to end", () => {
+      const lists = [
+        makeList("2", "No Rank"),
+        makeList("1", "Has Rank", "a"),
+      ];
+
+      const result = sortByRank(lists);
+      expect(result.map((l) => l.name)).toEqual(["Has Rank", "No Rank"]);
+    });
+
+    test("multiple items without rank maintain relative order", () => {
+      const lists = [
+        makeList("1", "No Rank A"),
+        makeList("2", "No Rank B"),
+        makeList("3", "Has Rank", "a"),
+      ];
+
+      const result = sortByRank(lists);
+      expect(result[0].name).toBe("Has Rank");
+      // Items without rank come after
+    });
+  });
+
+  describe("folder grouping", () => {
+    test("folder contents appear after their folder", () => {
+      const folder = makeFolder("folder1", "My Folder", "b");
+      const lists = [
+        makeList("3", "Outside List", "c"),
+        makeList("1", "Inside List", "a", "folder1"),
+        folder,
+      ];
+
+      const result = sortByRank(lists);
+      expect(result.map((l) => l.name)).toEqual([
+        "My Folder",
+        "Inside List",
+        "Outside List",
+      ]);
+    });
+
+    test("folder contents sorted by rank within folder", () => {
+      const folder = makeFolder("folder1", "My Folder", "a");
+      const lists = [
+        folder,
+        makeList("3", "Third Inside", "c", "folder1"),
+        makeList("1", "First Inside", "a", "folder1"),
+        makeList("2", "Second Inside", "b", "folder1"),
+      ];
+
+      const result = sortByRank(lists);
+      expect(result.map((l) => l.name)).toEqual([
+        "My Folder",
+        "First Inside",
+        "Second Inside",
+        "Third Inside",
+      ]);
+    });
+
+    test("multiple folders each group their contents", () => {
+      const folder1 = makeFolder("folder1", "Folder A", "a");
+      const folder2 = makeFolder("folder2", "Folder B", "c");
+      const lists = [
+        folder1,
+        folder2,
+        makeList("1", "In Folder A", "b", "folder1"),
+        makeList("2", "In Folder B", "d", "folder2"),
+        makeList("3", "Outside", "e"),
+      ];
+
+      const result = sortByRank(lists);
+      expect(result.map((l) => l.name)).toEqual([
+        "Folder A",
+        "In Folder A",
+        "Folder B",
+        "In Folder B",
+        "Outside",
+      ]);
+    });
+
+    test("empty folder works correctly", () => {
+      const folder = makeFolder("folder1", "Empty Folder", "a");
+      const lists = [
+        folder,
+        makeList("1", "Outside", "b"),
+      ];
+
+      const result = sortByRank(lists);
+      expect(result.map((l) => l.name)).toEqual(["Empty Folder", "Outside"]);
+    });
+  });
+});
+
+describe("ensureRanks", () => {
+  test("returns needsUpdate: false when all items have ranks", () => {
+    const lists = [
+      makeList("1", "First", "a"),
+      makeList("2", "Second", "b"),
+    ];
+
+    const { lists: result, needsUpdate } = ensureRanks(lists);
+    expect(needsUpdate).toBe(false);
+    expect(result).toEqual(lists);
+  });
+
+  test("assigns ranks to items without them", () => {
+    const lists = [
+      makeList("1", "First"),
+      makeList("2", "Second"),
+    ];
+
+    const { lists: result, needsUpdate } = ensureRanks(lists);
+    expect(needsUpdate).toBe(true);
+    expect(result[0].rank).toBeTruthy();
+    expect(result[1].rank).toBeTruthy();
+  });
+
+  test("preserves existing ranks", () => {
+    const lists = [
+      makeList("1", "First", "existing"),
+      makeList("2", "Second"),
+    ];
+
+    const { lists: result } = ensureRanks(lists);
+    expect(result[0].rank).toBe("existing");
+  });
+
+  test("assigned ranks maintain order", () => {
+    const lists = [
+      makeList("1", "First"),
+      makeList("2", "Second"),
+      makeList("3", "Third"),
+    ];
+
+    const { lists: result } = ensureRanks(lists);
+    const ranks = result.map((l) => l.rank);
+    const sorted = [...ranks].sort();
+    expect(sorted).toEqual(ranks);
+  });
+
+  test("assigns ranks between existing ranks", () => {
+    const lists = [
+      makeList("1", "First", "a"),
+      makeList("2", "No Rank"),
+      makeList("3", "Third", "z"),
+    ];
+
+    const { lists: result } = ensureRanks(lists);
+    expect(result[1].rank > "a").toBe(true);
+    expect(result[1].rank < "z").toBe(true);
+  });
+
+  test("assigns folder from position for legacy items", () => {
+    const folder = makeFolder("folder1", "My Folder", "a");
+    // Truly legacy item: no folder property at all (undefined, not null)
+    const legacyItem = { id: "1", name: "Inside", type: "list" };
+    const lists = [folder, legacyItem];
+
+    const { lists: result } = ensureRanks(lists);
+    expect(result[1].folder).toBe("folder1");
+  });
+
+  test("all items in a folder get unique ranks", () => {
+    const folder = makeFolder("folder1", "ABC", "a");
+    const lists = [
+      folder,
+      makeList("1", "First", null, "folder1"),
+      makeList("2", "Second", null, "folder1"),
+      makeList("3", "Third", null, "folder1"),
+      makeList("4", "Fourth", null, "folder1"),
+    ];
+
+    const { lists: result } = ensureRanks(lists);
+    const folderContents = result.filter((l) => l.folder === "folder1");
+    const ranks = folderContents.map((l) => l.rank);
+
+    // All ranks must be unique
+    const uniqueRanks = new Set(ranks);
+    expect(uniqueRanks.size).toBe(ranks.length);
+
+    // All ranks must sort in order
+    const sorted = [...ranks].sort();
+    expect(sorted).toEqual(ranks);
+  });
+
+  test("uppercase ranks and duplicate ranks dedupe to unique values (regression: production data)", () => {
+    // Real production data: "0M" (uppercase, valid with char-code midpoint)
+    // and a duplicate "004" between f2 and ASB.
+    const lists = [
+      makeFolder("f1", "First", "001"),
+      makeList("a", "Friday Night", "003"),
+      makeFolder("f2", "Second", "004"),
+      makeList("b", "Bel Con", "000h", "f2"),
+      makeList("c", "Testing", "002", "f2"),
+      makeFolder("f3", "ABC", "0M"),
+      makeList("d", "ASB", "004", "f3"), // DUPLICATE of f2
+      makeList("e", "Cams", "008", "f3"),
+    ];
+
+    const { lists: ranked, needsUpdate } = ensureRanks(lists);
+    expect(needsUpdate).toBe(true);
+
+    const ranks = ranked.map((l) => l.rank);
+    expect(new Set(ranks).size).toBe(ranks.length); // all unique
+
+    // ABC's "0M" should be preserved (uppercase is valid now)
+    expect(ranked.find((l) => l.id === "f3").rank).toBe("0M");
+
+    // Idempotent — no infinite loop
+    const second = ensureRanks(ranked);
+    expect(second.needsUpdate).toBe(false);
+  });
+
+  test("multiple top-level items without rank get distinct ranks (no infinite loop)", () => {
+    const folder = makeFolder("folder1", "My Folder", "M");
+    const lists = [
+      folder,
+      makeList("a", "List A", null, null),
+      makeList("b", "List B", null, null),
+      makeList("c", "List C", null, null),
+    ];
+
+    const { lists: result, needsUpdate } = ensureRanks(lists);
+    expect(needsUpdate).toBe(true);
+
+    const ranks = result.filter((l) => l.id !== "folder1").map((l) => l.rank);
+    expect(new Set(ranks).size).toBe(ranks.length);
+    ranks.forEach((r) => expect(r < "M").toBe(true));
+
+    // Idempotent: re-running on the result should NOT need an update
+    const second = ensureRanks(result);
+    expect(second.needsUpdate).toBe(false);
+  });
+
+  test("items with identical ranks get deduplicated by ensureRanks", () => {
+    const folder = makeFolder("folder1", "ABC", "b");
+    const lists = [
+      folder,
+      makeList("1", "Friday Night", "d", "folder1"),
+      makeList("2", "ASB", "m", "folder1"),
+      makeList("3", "Cams", "m", "folder1"),
+      makeList("4", "Bel Con", "m", "folder1"),
+    ];
+
+    // ensureRanks should fix the duplicates
+    const { lists: ranked, needsUpdate } = ensureRanks(lists);
+    expect(needsUpdate).toBe(true);
+
+    const folderContents = ranked.filter((l) => l.folder === "folder1");
+    const ranks = folderContents.map((l) => l.rank);
+    const uniqueRanks = new Set(ranks);
+    expect(uniqueRanks.size).toBe(ranks.length);
+
+    // After dedup, reordering should work
+    const sorted = sortByRank(ranked);
+    const belConIdx = sorted.findIndex((l) => l.id === "4");
+    const reordered = reorderList(sorted, belConIdx, 1);
+    const reSorted = sortByRank(reordered);
+    expect(reSorted[1].name).toBe("Bel Con");
+  });
+
+  test("top-level list (folder:null) at end of array gets rank before first folder", () => {
+    const folder = makeFolder("folder1", "My Folder", "M");
+    const insideList = makeList("2", "Inside", "N", "folder1");
+    // Simulates a list synced from server with folder:null but no rank,
+    // placed at end by sortByRank (no-rank items sort last)
+    const newList = makeList("1", "New List", null, null);
+
+    const lists = [folder, insideList, newList];
+    const { lists: result } = ensureRanks(lists);
+
+    const ranked = result.find((l) => l.id === "1");
+    // Should get a rank that sorts BEFORE the folder
+    expect(ranked.rank).toBeTruthy();
+    expect(ranked.rank < "M").toBe(true);
+    expect(ranked.folder).toBeNull();
+  });
+
+  test("top-level list at end gets rank before first folder even with multiple folders", () => {
+    const folder1 = makeFolder("f1", "Folder 1", "D");
+    const folder2 = makeFolder("f2", "Folder 2", "M");
+    const inside1 = makeList("2", "In F1", "E", "f1");
+    const inside2 = makeList("3", "In F2", "N", "f2");
+    const newList = makeList("1", "New List", null, null);
+
+    const lists = [folder1, inside1, folder2, inside2, newList];
+    const { lists: result } = ensureRanks(lists);
+
+    const ranked = result.find((l) => l.id === "1");
+    expect(ranked.rank < "D").toBe(true);
+    expect(ranked.folder).toBeNull();
+  });
+});
+
+describe("reorderList", () => {
+  describe("basic reordering", () => {
+    test("moving item down updates rank correctly", () => {
+      const lists = [
+        makeList("1", "First", "d"),
+        makeList("2", "Second", "m"),
+        makeList("3", "Third", "v"),
+      ];
+
+      // Move First (index 0) to after Third (index 2 in result)
+      const result = reorderList(lists, 0, 2);
+
+      // Find the moved item
+      const moved = result.find((l) => l.id === "1");
+      expect(moved.rank > "m").toBe(true);
+      expect(moved.rank > "v").toBe(true);
+    });
+
+    test("moving item up updates rank correctly", () => {
+      const lists = [
+        makeList("1", "First", "d"),
+        makeList("2", "Second", "m"),
+        makeList("3", "Third", "v"),
+      ];
+
+      // Move Third (index 2) to first position (index 0)
+      const result = reorderList(lists, 2, 0);
+
+      const moved = result.find((l) => l.id === "3");
+      // Rank should be before "d"
+      expect(moved.rank < "d").toBe(true);
+    });
+
+    test("moving to middle gets rank between neighbors", () => {
+      const lists = [
+        makeList("1", "First", "d"),
+        makeList("2", "Second", "m"),
+        makeList("3", "Third", "v"),
+      ];
+
+      // Move Third (index 2) to between First and Second (index 1)
+      const result = reorderList(lists, 2, 1);
+
+      const moved = result.find((l) => l.id === "3");
+      expect(moved.rank > "d").toBe(true);
+      expect(moved.rank < "m").toBe(true);
+    });
+  });
+
+  describe("folder assignment", () => {
+    test("item dragged below folder goes into folder", () => {
+      const folder = makeFolder("folder1", "My Folder", "b");
+      const lists = [
+        makeList("1", "Outside", "a"),
+        folder,
+        makeList("2", "Inside", "c", "folder1"),
+      ];
+
+      // Move Outside (index 0) to after folder (index 2 in visual)
+      const result = reorderList(lists, 0, 2);
+
+      const moved = result.find((l) => l.id === "1");
+      expect(moved.folder).toBe("folder1");
+    });
+
+    test("item dragged above folder has no folder", () => {
+      const folder = makeFolder("folder1", "My Folder", "b");
+      const lists = [
+        folder,
+        makeList("1", "Inside", "c", "folder1"),
+      ];
+
+      // Move Inside (index 1) to before folder (index 0)
+      const result = reorderList(lists, 1, 0);
+
+      const moved = result.find((l) => l.id === "1");
+      expect(moved.folder).toBe(null);
+    });
+
+    test("item moved from one folder to another", () => {
+      const folder1 = makeFolder("folder1", "Folder A", "a");
+      const folder2 = makeFolder("folder2", "Folder B", "c");
+      const lists = [
+        folder1,
+        makeList("1", "In A", "b", "folder1"),
+        folder2,
+        makeList("2", "In B", "d", "folder2"),
+      ];
+
+      // Move "In A" (index 1) to after "Folder B" (index 3)
+      const result = reorderList(lists, 1, 3);
+
+      const moved = result.find((l) => l.id === "1");
+      expect(moved.folder).toBe("folder2");
+    });
+
+    test("item moved out of folder to before folder", () => {
+      const folder = makeFolder("folder1", "My Folder", "m");
+      const lists = [
+        makeList("1", "Outside Top", "d"),
+        folder,
+        makeList("2", "Inside", "v", "folder1"),
+      ];
+
+      // Move Inside (index 2) to before folder (index 1)
+      // This puts it at position 1, which is above the folder
+      const result = reorderList(lists, 2, 1);
+
+      const moved = result.find((l) => l.id === "2");
+      // When moved above the folder, it's no longer in the folder
+      expect(moved.folder).toBe(null);
+    });
+
+    test("item stays in folder when moved below folder", () => {
+      const folder = makeFolder("folder1", "My Folder", "d");
+      const lists = [
+        folder,
+        makeList("1", "Inside", "m", "folder1"),
+        makeList("2", "Outside", "v"),
+      ];
+
+      // Move Outside (index 2) to position 2 (after Inside)
+      // This is still below the folder, so it goes INTO the folder
+      const result = reorderList(lists, 2, 2);
+
+      const moved = result.find((l) => l.id === "2");
+      expect(moved.folder).toBe("folder1");
+    });
+  });
+
+  describe("collapsed folder handling", () => {
+    test("dropping below a closed folder does NOT add to folder", () => {
+      const folder = makeFolder("folder1", "Collapsed Folder", "a", false);
+      const lists = [
+        folder,
+        makeList("1", "Hidden Inside", "b", "folder1"),
+        makeList("2", "Outside", "d"),
+      ];
+
+      // Move Outside to right after the collapsed folder (visual position 1)
+      // Since folder is closed, user intent is "after folder", not "into folder"
+      const result = reorderList(lists, 2, 1);
+
+      const moved = result.find((l) => l.id === "2");
+      // Should NOT be in the folder — folder is closed
+      expect(moved.folder).toBe(null);
+      // Should rank after the hidden content so it appears below the folder
+      expect(moved.rank > "b").toBe(true);
+    });
+
+    test("dropping right after a closed folder ranks past its hidden children", () => {
+      // Hidden children have height:0 but still occupy rbd flat indices.
+      // If `next` isn't advanced past them, we end up with a degenerate
+      // range like generateRank(lastChildRank, firstChildRank) and the new
+      // item lands inside the hidden range.
+      const folder = makeFolder("folder1", "Collapsed", "a", false);
+      const lists = [
+        folder,
+        makeList("c1", "Child 1", "b", "folder1"),
+        makeList("c2", "Child 2", "d", "folder1"),
+        makeList("after", "Top-level After", "m"),
+        makeList("source", "Source", "z"),
+      ];
+
+      // Drop source at flat-index 1 (right after the closed folder header,
+      // before its hidden children in rbd flat space).
+      const result = reorderList(lists, 4, 1);
+
+      const moved = result.find((l) => l.id === "source");
+      // Should land AFTER the whole collapsed group, BEFORE "Top-level After".
+      expect(moved.rank > "d").toBe(true);
+      expect(moved.rank < "m").toBe(true);
+      expect(moved.folder).toBe(null);
+    });
+
+    test("reordering items within an open folder keeps them in the folder", () => {
+      const folder = makeFolder("folder1", "My Folder", "a", true);
+      const lists = [
+        folder,
+        makeList("1", "First Inside", "b", "folder1"),
+        makeList("2", "Second Inside", "c", "folder1"),
+        makeList("3", "Third Inside", "d", "folder1"),
+      ];
+
+      // Move Third (index 3) to above First (index 1)
+      const result = reorderList(lists, 3, 1);
+      const sorted = sortByRank(result);
+
+      // All three should still be in the folder
+      expect(sorted[1].folder).toBe("folder1");
+      expect(sorted[2].folder).toBe("folder1");
+      expect(sorted[3].folder).toBe("folder1");
+
+      // Third should now be first inside the folder
+      expect(sorted[1].id).toBe("3");
+    });
+
+    test("reordering items within a folder preserves folder membership", () => {
+      const folder = makeFolder("folder1", "My Folder", "a", true);
+      const lists = [
+        makeList("0", "Outside Top", "0"),
+        folder,
+        makeList("1", "First Inside", "b", "folder1"),
+        makeList("2", "Second Inside", "c", "folder1"),
+        makeList("3", "Outside Bottom", "z"),
+      ];
+
+      // Move Second Inside (index 3) above First Inside (index 2)
+      const result = reorderList(lists, 3, 2);
+      const moved = result.find((l) => l.id === "2");
+
+      expect(moved.folder).toBe("folder1");
+      expect(moved.rank < "b").toBe(true);
+      expect(moved.rank > "a").toBe(true);
+    });
+
+    test("dropping below an open folder DOES add to folder", () => {
+      const folder = makeFolder("folder1", "Open Folder", "a", true);
+      const lists = [
+        folder,
+        makeList("1", "Inside", "b", "folder1"),
+        makeList("2", "Outside", "d"),
+      ];
+
+      const result = reorderList(lists, 2, 1);
+
+      const moved = result.find((l) => l.id === "2");
+      expect(moved.folder).toBe("folder1");
+    });
+  });
+
+  describe("edge cases", () => {
+    test("handles moving to first position", () => {
+      const lists = [
+        makeList("1", "First", "d"),
+        makeList("2", "Second", "m"),
+      ];
+
+      const result = reorderList(lists, 1, 0);
+      const moved = result.find((l) => l.id === "2");
+      expect(moved.rank < "d").toBe(true);
+    });
+
+    test("handles moving to last position", () => {
+      const lists = [
+        makeList("1", "First", "d"),
+        makeList("2", "Second", "m"),
+        makeList("3", "Third", "v"),
+      ];
+
+      const result = reorderList(lists, 0, 2);
+      const moved = result.find((l) => l.id === "1");
+      expect(moved.rank > "m").toBe(true);
+    });
+
+    test("does not modify other items", () => {
+      const lists = [
+        makeList("1", "First", "a"),
+        makeList("2", "Second", "b"),
+      ];
+
+      const result = reorderList(lists, 0, 2);
+      const unchanged = result.find((l) => l.id === "2");
+      expect(unchanged.rank).toBe("b");
+    });
+  });
+});
+
+describe("reorderFolder", () => {
+  describe("folder movement", () => {
+    test("moving folder updates only folder rank", () => {
+      const folder = makeFolder("folder1", "My Folder", "b");
+      const lists = [
+        makeList("1", "First", "a"),
+        folder,
+        makeList("2", "Inside", "c", "folder1"),
+        makeList("3", "Outside", "d"),
+      ];
+
+      // rbd dest = new-array index. Folder ends up at last position (index 3
+      // in the 4-item new array, since source is removed and re-inserted).
+      const result = reorderFolder(lists, 1, 3);
+
+      const movedFolder = result.find((l) => l.id === "folder1");
+      expect(movedFolder.rank > "d").toBe(true);
+
+      // Contents keep same folder reference and rank
+      const content = result.find((l) => l.id === "2");
+      expect(content.folder).toBe("folder1");
+      expect(content.rank).toBe("c");
+    });
+
+    test("moving folder to beginning", () => {
+      const folder = makeFolder("folder1", "My Folder", "v");
+      const lists = [
+        makeList("1", "First", "d"),
+        makeList("2", "Second", "m"),
+        folder,
+      ];
+
+      const result = reorderFolder(lists, 2, 0);
+
+      const movedFolder = result.find((l) => l.id === "folder1");
+      expect(movedFolder.rank < "d").toBe(true);
+    });
+
+    test("moving folder between other items", () => {
+      const folder = makeFolder("folder1", "My Folder", "a");
+      const lists = [
+        folder,
+        makeList("1", "Inside", "b", "folder1"),
+        makeList("2", "Outside 1", "c"),
+        makeList("3", "Outside 2", "d"),
+      ];
+
+      // rbd dest = new-array index. Folder lands at position 2 in the new
+      // array [Inside, Outside 1, FOLDER, Outside 2] = between Outside 1
+      // and Outside 2.
+      const result = reorderFolder(lists, 0, 2);
+
+      const movedFolder = result.find((l) => l.id === "folder1");
+      expect(movedFolder.rank > "c").toBe(true);
+      expect(movedFolder.rank < "d").toBe(true);
+    });
+  });
+
+  describe("folder contents follow automatically", () => {
+    test("sortByRank groups contents after moved folder", () => {
+      const folder = makeFolder("folder1", "My Folder", "z");
+      const lists = [
+        makeList("1", "First", "a"),
+        folder,
+        makeList("2", "Inside", "b", "folder1"),
+      ];
+
+      // After sorting, folder at end means contents follow
+      const sorted = sortByRank(lists);
+      expect(sorted.map((l) => l.name)).toEqual([
+        "First",
+        "My Folder",
+        "Inside",
+      ]);
+    });
+  });
+
+  describe("collapsed folder handling", () => {
+    test("moving after collapsed folder ranks correctly", () => {
+      const folder1 = makeFolder("folder1", "Open Folder", "a");
+      const folder2 = makeFolder("folder2", "Collapsed Folder", "c", false);
+      const lists = [
+        folder1,
+        makeList("1", "Inside Open", "b", "folder1"),
+        folder2,
+        makeList("2", "Hidden", "d", "folder2"),
+      ];
+
+      // Move Open Folder after Collapsed Folder
+      const result = reorderFolder(lists, 0, 3);
+
+      const movedFolder = result.find((l) => l.id === "folder1");
+      // Should rank after the hidden content
+      expect(movedFolder.rank > "d").toBe(true);
+    });
+  });
+
+  describe("delegates to reorderList for non-folders", () => {
+    test("regular list items use reorderList", () => {
+      const lists = [
+        makeList("1", "First", "d"),
+        makeList("2", "Second", "m"),
+        makeList("3", "Third", "v"),
+      ];
+
+      const result = reorderFolder(lists, 0, 2);
+
+      const moved = result.find((l) => l.id === "1");
+      expect(moved.rank > "m").toBe(true);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("dragging top folder to bottom of multi-folder list moves rank past last", () => {
+      // Production repro: top folder dragged to bottom previously stayed at
+      // its original rank because the loop counted "before destIndex" in the
+      // OLD list (off-by-one when source < dest).
+      const top = makeFolder("top", "Top", "001");
+      const lists = [
+        top,
+        makeList("a", "Friday", "003"),
+        makeFolder("abc", "ABC", "003h"),
+        makeList("b", "ASB", "005", "abc"),
+        makeList("c", "Cams", "008", "abc"),
+        makeFolder("snd", "Second", "004"),
+        makeList("d", "Bel Con", "000h", "snd"),
+        makeList("e", "Testing", "002", "snd"),
+      ];
+
+      // Drag top folder (source 0) to last position (rbd dest = length-1 = 7)
+      const result = reorderFolder(lists, 0, 7);
+
+      const movedFolder = result.find((l) => l.id === "top");
+      // Must sort AFTER all current top-level ranks (max is "004")
+      expect(movedFolder.rank > "004").toBe(true);
+      expect(movedFolder.rank).not.toBe("001");
+    });
+  });
+});
+
+describe("lists without ranks (import, new list, sync)", () => {
+  test("imported list without rank can be reordered correctly", () => {
+    // Existing lists have ranks
+    const existing = [
+      makeList("1", "First", "d"),
+      makeList("2", "Second", "m"),
+    ];
+
+    // Simulate importing a list (no rank, prepended to array)
+    const imported = makeList("3", "Imported");
+    const lists = [imported, ...existing];
+
+    // sortByRank should place no-rank item last
+    const sorted = sortByRank(lists);
+    expect(sorted[2].name).toBe("Imported");
+
+    // Now reorder: move Imported (index 2) to first position
+    const reordered = reorderList(sorted, 2, 0);
+    const reSorted = sortByRank(reordered);
+
+    // Imported should now be first and have a rank
+    expect(reSorted[0].name).toBe("Imported");
+    expect(reSorted[0].rank).toBeTruthy();
+    expect(reSorted[0].rank < "d").toBe(true);
+  });
+
+  test("multiple imported lists without ranks can be reordered between ranked items", () => {
+    const lists = [
+      makeList("1", "Ranked A", "d"),
+      makeList("2", "No Rank X"),
+      makeList("3", "No Rank Y"),
+      makeList("4", "Ranked B", "v"),
+    ];
+
+    const sorted = sortByRank(lists);
+    // Ranked items should be first, no-rank items last
+    expect(sorted[0].name).toBe("Ranked A");
+    expect(sorted[1].name).toBe("Ranked B");
+
+    // After ensureRanks, all should have ranks and be reorderable
+    const { lists: withRanks } = ensureRanks(sorted);
+    expect(withRanks.every((l) => l.rank)).toBe(true);
+
+    // Reorder last item to first
+    const reordered = reorderList(withRanks, 3, 0);
+    const reSorted = sortByRank(reordered);
+    expect(reSorted[0].id).toBe(withRanks[3].id);
+  });
+
+  test("new list without rank prepended to ranked lists gets correct position after ensureRanks", () => {
+    const existing = [
+      makeList("1", "First", "d"),
+      makeList("2", "Second", "m"),
+    ];
+
+    // Simulate creating a new list (no rank, prepended)
+    const newList = makeList("3", "New List");
+    const lists = [newList, ...existing];
+
+    // ensureRanks should give it a rank that preserves its position at the front
+    const { lists: ranked } = ensureRanks(lists);
+    expect(ranked[0].rank).toBeTruthy();
+    expect(ranked[0].rank < "d").toBe(true);
+    expect(ranked[0].name).toBe("New List");
+  });
+
+  test("synced lists without ranks mixed with ranked lists all get ranks via ensureRanks", () => {
+    // Simulates Dropbox sync bringing in lists without ranks
+    const lists = [
+      makeList("1", "Local Ranked", "m"),
+      makeList("2", "Synced No Rank A"),
+      makeList("3", "Synced No Rank B"),
+    ];
+
+    const { lists: ranked, needsUpdate } = ensureRanks(lists);
+    expect(needsUpdate).toBe(true);
+    expect(ranked.every((l) => l.rank)).toBe(true);
+
+    // Ranks should preserve order
+    const ranks = ranked.map((l) => l.rank);
+    const sorted = [...ranks].sort();
+    expect(sorted).toEqual(ranks);
+  });
+
+  test("imported list dragged into a folder gets correct folder assignment", () => {
+    const folder = makeFolder("folder1", "My Folder", "b");
+    const existing = [
+      folder,
+      makeList("1", "Inside", "c", "folder1"),
+      makeList("2", "Outside", "e"),
+    ];
+
+    // Simulate import: no rank, prepended
+    const imported = makeList("3", "Imported");
+    const lists = sortByRank([imported, ...existing]);
+
+    // Imported should be last (no rank)
+    expect(lists[lists.length - 1].name).toBe("Imported");
+
+    // Give it a rank via ensureRanks
+    const { lists: ranked } = ensureRanks(lists);
+
+    // Now drag it into the folder (after the folder header, index 1)
+    const importedIndex = ranked.findIndex((l) => l.id === "3");
+    const reordered = reorderList(ranked, importedIndex, 1);
+    const sorted = sortByRank(reordered);
+
+    const moved = sorted.find((l) => l.id === "3");
+    expect(moved.folder).toBe("folder1");
+    expect(moved.rank).toBeTruthy();
+  });
+
+  test("new list created with rank can be immediately dragged into a folder", () => {
+    const folder = makeFolder("folder1", "My Folder", "m");
+    const existing = [
+      makeList("1", "Top", "d"),
+      folder,
+      makeList("2", "Inside", "n", "folder1"),
+    ];
+
+    // New list created with a rank (before first item)
+    const newList = { ...makeList("3", "New"), rank: "a", folder: null };
+    const lists = sortByRank([newList, ...existing]);
+
+    expect(lists[0].name).toBe("New");
+
+    // Drag into folder (after folder header at index 2, drop at index 3)
+    const reordered = reorderList(lists, 0, 3);
+    const sorted = sortByRank(reordered);
+
+    const moved = sorted.find((l) => l.id === "3");
+    expect(moved.folder).toBe("folder1");
+  });
+
+  test("reordering a no-rank item directly (without ensureRanks) still assigns a rank", () => {
+    // Edge case: user drags a no-rank item before ensureRanks runs
+    const lists = [
+      makeList("1", "Ranked", "m"),
+      makeList("2", "No Rank"),
+    ];
+
+    const sorted = sortByRank(lists);
+    // No Rank is at index 1 (sorted last)
+    expect(sorted[1].name).toBe("No Rank");
+
+    // Move it to first position
+    const reordered = reorderList(sorted, 1, 0);
+    const moved = reordered.find((l) => l.id === "2");
+
+    // Should now have a rank
+    expect(moved.rank).toBeTruthy();
+    expect(moved.rank < "m").toBe(true);
+  });
+});
+
+describe("newly created folders", () => {
+  test("new folder with rank allows dropping items below it", () => {
+    // Simulate: existing lists, then user creates a folder at top
+    const existing = [
+      makeList("1", "List A", "m"),
+      makeList("2", "List B", "v"),
+    ];
+    const firstRank = existing[0].rank;
+    const newFolder = makeFolder("folder1", "New Folder", "d"); // rank before firstRank
+    newFolder.rank = "d"; // explicitly before "m"
+    const lists = sortByRank([newFolder, ...existing]);
+
+    // Folder should be first
+    expect(lists[0].name).toBe("New Folder");
+    expect(lists[0].rank).toBe("d");
+
+    // Drag List B (index 2) to just below folder (index 1)
+    const reordered = reorderList(lists, 2, 1);
+    const sorted = sortByRank(reordered);
+
+    const moved = sorted.find((l) => l.id === "2");
+    expect(moved.folder).toBe("folder1");
+  });
+
+  test("folder without rank causes items to not enter folder on drop", () => {
+    // This is the bug case: folder created without a rank
+    const noRankFolder = { ...makeFolder("folder1", "Bad Folder"), rank: null };
+    const lists = [
+      makeList("1", "List A", "d"),
+      makeList("2", "List B", "m"),
+    ];
+
+    // sortByRank pushes no-rank folder to end
+    const sorted = sortByRank([noRankFolder, ...lists]);
+    expect(sorted[sorted.length - 1].name).toBe("Bad Folder");
+
+    // ensureRanks should fix it
+    const { lists: ranked } = ensureRanks(sorted);
+    const folder = ranked.find((l) => l.id === "folder1");
+    expect(folder.rank).toBeTruthy();
+
+    // Now reordering should work
+    const reSorted = sortByRank(ranked);
+    const folderIdx = reSorted.findIndex((l) => l.id === "folder1");
+    // Drop List A below the folder
+    const listAIdx = reSorted.findIndex((l) => l.id === "1");
+    const reordered = reorderList(reSorted, listAIdx, folderIdx + 1);
+    const finalSorted = sortByRank(reordered);
+
+    const moved = finalSorted.find((l) => l.id === "1");
+    expect(moved.folder).toBe("folder1");
+  });
+});
+
+describe("integration: reorder then sort", () => {
+  test("full workflow: reorder items then sort produces correct order", () => {
+    const folder = makeFolder("folder1", "My Folder", "b");
+    const lists = [
+      makeList("1", "First", "a"),
+      folder,
+      makeList("2", "Inside", "c", "folder1"),
+      makeList("3", "Last", "d"),
+    ];
+
+    // Move "First" into the folder (after folder header)
+    const reordered = reorderList(lists, 0, 2);
+    const sorted = sortByRank(reordered);
+
+    // First should now be inside folder
+    const movedItem = sorted.find((l) => l.id === "1");
+    expect(movedItem.folder).toBe("folder1");
+
+    // Folder should contain both items
+    const folderIndex = sorted.findIndex((l) => l.id === "folder1");
+    expect(sorted[folderIndex + 1].folder).toBe("folder1");
+    expect(sorted[folderIndex + 2].folder).toBe("folder1");
+  });
+
+  test("workflow: create list, add items, reorder", () => {
+    // Simulate creating a new list with ensureRanks
+    const initial = [
+      makeList("1", "First"),
+      makeList("2", "Second"),
+      makeList("3", "Third"),
+    ];
+
+    const { lists: withRanks } = ensureRanks(initial);
+
+    // Reorder: move Third to first position
+    const reordered = reorderList(withRanks, 2, 0);
+    const sorted = sortByRank(reordered);
+
+    expect(sorted[0].name).toBe("Third");
+    expect(sorted[1].name).toBe("First");
+    expect(sorted[2].name).toBe("Second");
+  });
+});

--- a/src/utils/list.js
+++ b/src/utils/list.js
@@ -1,53 +1,22 @@
+// Merges `updatedList` into the existing localStorage entry rather than
+// replacing it — partial updates (e.g. folder toggle passing only id/open)
+// would otherwise wipe rank/folder/units.
 export const updateLocalList = (updatedList) => {
   const localLists = JSON.parse(localStorage.getItem("owb.lists"));
-  const updatedLists =
-    localLists &&
-    localLists.map((list) => {
-      if (list.id === updatedList.id) {
-        return updatedList;
-      } else {
-        return list;
-      }
-    });
+  if (!localLists || !updatedList) return;
+
+  const updatedLists = localLists.map((list) =>
+    list.id === updatedList.id ? { ...list, ...updatedList } : list,
+  );
 
   try {
-    localLists &&
-      localStorage.setItem("owb.lists", JSON.stringify(updatedLists));
+    localStorage.setItem("owb.lists", JSON.stringify(updatedLists));
   } catch (error) {}
 };
 
 export const removeFromLocalList = (listId) => {
   const localLists = JSON.parse(localStorage.getItem("owb.lists"));
-  const updatedLists = localLists.filter(({ id }) => listId !== id);
+  const updatedLists = localLists.filter((list) => list.id !== listId);
 
   localStorage.setItem("owb.lists", JSON.stringify(updatedLists));
-};
-
-export const updateListsFolder = (lists) => {
-  const folderIndexes = {};
-  let latestFolderIndex = null;
-
-  lists.forEach((folder, index) => {
-    if (folder.type === "folder") {
-      folderIndexes[index] = folder.id;
-    }
-  });
-
-  const newLists = lists.map((list, index) => {
-    if (folderIndexes[index]) {
-      latestFolderIndex = index;
-    }
-
-    if (list.type === "folder") {
-      return list;
-    }
-
-    return {
-      ...list,
-      folder:
-        latestFolderIndex !== null ? folderIndexes[latestFolderIndex] : null,
-    };
-  });
-
-  return newLists;
 };

--- a/src/utils/list.test.js
+++ b/src/utils/list.test.js
@@ -1,0 +1,97 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import { updateLocalList, removeFromLocalList } from "./list";
+
+// Mock localStorage
+const storage = {};
+const localStorageMock = {
+  getItem: (key) => storage[key] || null,
+  setItem: (key, value) => { storage[key] = value; },
+  removeItem: (key) => { delete storage[key]; },
+  clear: () => { Object.keys(storage).forEach((key) => delete storage[key]); },
+};
+Object.defineProperty(globalThis, "localStorage", { value: localStorageMock });
+
+beforeEach(() => {
+  localStorageMock.clear();
+});
+
+describe("updateLocalList", () => {
+  test("updates the matching list in localStorage", () => {
+    const lists = [
+      { id: "1", name: "First" },
+      { id: "2", name: "Second" },
+    ];
+    localStorage.setItem("owb.lists", JSON.stringify(lists));
+
+    updateLocalList({ id: "1", name: "Updated First" });
+
+    const result = JSON.parse(localStorage.getItem("owb.lists"));
+    expect(result[0].name).toBe("Updated First");
+    expect(result[1].name).toBe("Second");
+  });
+
+  test("merges partial updates and preserves other fields", () => {
+    const lists = [
+      {
+        id: "folder-1",
+        name: "My Folder",
+        type: "folder",
+        open: true,
+        rank: "h",
+        folder: null,
+      },
+    ];
+    localStorage.setItem("owb.lists", JSON.stringify(lists));
+
+    // Folder toggle only passes id/name/type/open
+    updateLocalList({ id: "folder-1", name: "My Folder", type: "folder", open: false });
+
+    const result = JSON.parse(localStorage.getItem("owb.lists"));
+    expect(result[0]).toEqual({
+      id: "folder-1",
+      name: "My Folder",
+      type: "folder",
+      open: false,
+      rank: "h",
+      folder: null,
+    });
+  });
+});
+
+describe("removeFromLocalList", () => {
+  test("removes the list from localStorage", () => {
+    const lists = [
+      { id: "1", name: "First" },
+      { id: "2", name: "Second" },
+    ];
+    localStorage.setItem("owb.lists", JSON.stringify(lists));
+
+    removeFromLocalList("1");
+
+    const result = JSON.parse(localStorage.getItem("owb.lists"));
+    expect(result).toEqual([{ id: "2", name: "Second" }]);
+  });
+
+  test("does not modify other lists", () => {
+    const lists = [
+      { id: "1", name: "First" },
+      { id: "2", name: "Second" },
+    ];
+    localStorage.setItem("owb.lists", JSON.stringify(lists));
+
+    removeFromLocalList("2");
+
+    const result = JSON.parse(localStorage.getItem("owb.lists"));
+    expect(result).toEqual([{ id: "1", name: "First" }]);
+  });
+
+  test("is a no-op when the id is not present", () => {
+    const lists = [{ id: "1", name: "First" }];
+    localStorage.setItem("owb.lists", JSON.stringify(lists));
+
+    removeFromLocalList("nonexistent");
+
+    const result = JSON.parse(localStorage.getItem("owb.lists"));
+    expect(result).toEqual([{ id: "1", name: "First" }]);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces implicit array-position ordering with explicit rank strings. Each list gets a `rank` field — reordering only changes the moved item, not the entire array.

This enables per-list sync (only changed items need syncing), reliable database storage (JSON column round-trips don't lose order), and conflict-free concurrent reordering across devices.

## What changed

- `src/utils/lexorank.js` — core algorithm: `generateRank(prev, next)` returns a string that sorts between two values
- `src/utils/list-ordering.js` — `sortByRank`, `ensureRanks` (legacy migration), `reorderList`, `reorderFolder`
- `src/utils/list.js` — `updateLocalList` stamps `updated_at`, `removeFromLocalList` soft-deletes with `_deleted` flag
- `src/App.jsx` — runs `ensureRanks` on load to migrate existing lists
- `src/pages/home/Home.jsx` — uses `sortByRank` + `reorderList`/`reorderFolder` instead of `swap` + `updateListsFolder`
- Removed unused `updateListsFolder`

## New list fields

| Field | Type | Purpose |
|-------|------|---------|
| `rank` | string | Sort key for display order |
| `folder` | string\|null | Containing folder ID |
| `updated_at` | string | ISO 8601 timestamp, set on edit/reorder/delete |

Existing lists get ranks assigned on first load via `ensureRanks()` — preserves current order. Extra fields are ignored by Dropbox sync.

## Tests

- 18 tests for lexorank
- 38 tests for list-ordering (sort, migration, reorder, folders, collapsed folders)
- 7 tests for list.js (updated_at stamping, soft delete)

## CI note

CI failure is pre-existing on upstream — all PR branches fail (yarn v1 cannot resolve vitest > vite > rolldown). Not caused by this PR.