### PR TITLE
Language of the Priests notes and Mortuary Cult generalIsHierophant check

### DIFF
--- a/public/games/the-old-world/tomb-kings-of-khemri.json
+++ b/public/games/the-old-world/tomb-kings-of-khemri.json
@@ -18,7 +18,26 @@
           "name_fr": "Général",
           "name_es": "General",
           "points": 0,
-          "armyComposition": ["tomb-kings-of-khemri", "nehekharan-royal-hosts"]
+          "armyComposition": ["tomb-kings-of-khemri", "nehekharan-royal-hosts"],
+          "options": [
+            {
+              "name_en": "Arise!, Level 1 Wizard",
+              "name_cn": "唤醒!, 1级法师",
+              "name_it": "Risorgi!, Mago di 1° Livello",
+              "name_de": "Erhebt euch!, Level 1 Zauberer",
+              "name_fr": "Levez-vous!, Sorcier de Niveau 1",
+              "points": 35,
+              "notes": {
+                "name_en": "Must be Hierophant",
+                "name_cn": "Must be Hierophant",
+                "name_de": "Must be Hierophant",
+                "name_es": "Must be Hierophant",
+                "name_fr": "Must be Hierophant",
+                "name_it": "Must be Hierophant"
+              },
+              "armyComposition": "nehekharan-royal-hosts"
+            }
+          ]
         },
         {
           "name_en": "The Hierophant",
@@ -30,12 +49,12 @@
           "points": 0,
           "exclusive": false,
           "notes": {
-            "name_en": "Must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
-            "name_cn": "Must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
-            "name_de": "Must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
-            "name_es": "Must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
-            "name_fr": "Must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
-            "name_it": "Must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests"
+            "name_en": "Only available to General if given Arise and Level 1 Wizard",
+            "name_cn": "Only available to General if given Arise and Level 1 Wizard",
+            "name_de": "Only available to General if given Arise and Level 1 Wizard",
+            "name_es": "Only available to General if given Arise and Level 1 Wizard",
+            "name_fr": "Only available to General if given Arise and Level 1 Wizard",
+            "name_it": "Only available to General if given Arise and Level 1 Wizard"
           },
           "armyComposition": ["nehekharan-royal-hosts"]
         }
@@ -125,23 +144,6 @@
           "name_fr": "Bouclier",
           "points": 2,
           "perModel": true
-        },
-        {
-          "name_en": "Arise!, Level 1 Wizard",
-          "name_cn": "唤醒!, 1级法师",
-          "name_it": "Risorgi!, Mago di 1° Livello",
-          "name_de": "Erhebt euch!, Level 1 Zauberer",
-          "name_fr": "Levez-vous!, Sorcier de Niveau 1",
-          "points": 35,
-          "notes": {
-            "name_en": "Must be General and Hierophant",
-            "name_cn": "Must be General and Hierophant",
-            "name_de": "Must be General and Hierophant",
-            "name_es": "Must be General and Hierophant",
-            "name_fr": "Must be General and Hierophant",
-            "name_it": "Must be General and Hierophant"
-          },
-          "armyComposition": "nehekharan-royal-hosts"
         }
       ],
       "mounts": [
@@ -326,7 +328,26 @@
           "name_fr": "Général",
           "name_es": "General",
           "points": 0,
-          "armyComposition": ["tomb-kings-of-khemri", "nehekharan-royal-hosts"]
+          "armyComposition": ["tomb-kings-of-khemri", "nehekharan-royal-hosts"],
+          "options": [
+            {
+              "name_en": "Arise!, Level 1 Wizard",
+              "name_cn": "唤醒!, 1级法师",
+              "name_it": "Risorgi!, Mago di 1° Livello",
+              "name_de": "Erhebt euch!, Level 1 Zauberer",
+              "name_fr": "Levez-vous!, Sorcier de Niveau 1",
+              "points": 35,
+              "notes": {
+                "name_en": "Must be Hierophant",
+                "name_cn": "Must be Hierophant",
+                "name_de": "Must be Hierophant",
+                "name_es": "Must be Hierophant",
+                "name_fr": "Must be Hierophant",
+                "name_it": "Must be Hierophant"
+              },
+              "armyComposition": "nehekharan-royal-hosts"
+            }
+          ]
         },
         {
           "name_en": "The Hierophant",
@@ -338,12 +359,12 @@
           "points": 0,
           "exclusive": false,
           "notes": {
-            "name_en": "General must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
-            "name_cn": "General must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
-            "name_de": "General must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
-            "name_es": "General must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
-            "name_fr": "General must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
-            "name_it": "General must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests"
+            "name_en": "Only available to General if given Arise and Level 1 Wizard",
+            "name_cn": "Only available to General if given Arise and Level 1 Wizard",
+            "name_de": "Only available to General if given Arise and Level 1 Wizard",
+            "name_es": "Only available to General if given Arise and Level 1 Wizard",
+            "name_fr": "Only available to General if given Arise and Level 1 Wizard",
+            "name_it": "Only available to General if given Arise and Level 1 Wizard"
           },
           "armyComposition": ["nehekharan-royal-hosts"]
         }
@@ -433,23 +454,6 @@
           "name_fr": "Bouclier",
           "points": 2,
           "perModel": true
-        },
-        {
-          "name_en": "Arise!, Level 1 Wizard",
-          "name_cn": "唤醒!, 1级法师",
-          "name_it": "Risorgi!, Mago di 1° Livello",
-          "name_de": "Erhebt euch!, Level 1 Zauberer",
-          "name_fr": "Levez-vous!, Sorcier de Niveau 1",
-          "points": 35,
-          "notes": {
-            "name_en": "Must be General and Hierophant",
-            "name_cn": "Must be General and Hierophant",
-            "name_de": "Must be General and Hierophant",
-            "name_es": "Must be General and Hierophant",
-            "name_fr": "Must be General and Hierophant",
-            "name_it": "Must be General and Hierophant"
-          },
-          "armyComposition": "nehekharan-royal-hosts"
         }
       ],
       "mounts": [

--- a/public/games/the-old-world/tomb-kings-of-khemri.json
+++ b/public/games/the-old-world/tomb-kings-of-khemri.json
@@ -19,6 +19,25 @@
           "name_es": "General",
           "points": 0,
           "armyComposition": ["tomb-kings-of-khemri", "nehekharan-royal-hosts"]
+        },
+        {
+          "name_en": "The Hierophant",
+          "name_cn": "The Hierophant",
+          "name_it": "The Hierophant",
+          "name_de": "The Hierophant",
+          "name_fr": "The Hierophant",
+          "name_es": "The Hierophant",
+          "points": 0,
+          "exclusive": false,
+          "notes": {
+            "name_en": "Must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
+            "name_cn": "Must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
+            "name_de": "Must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
+            "name_es": "Must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
+            "name_fr": "Must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
+            "name_it": "Must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests"
+          },
+          "armyComposition": ["nehekharan-royal-hosts"]
         }
       ],
       "equipment": [
@@ -114,6 +133,14 @@
           "name_de": "Erhebt euch!, Level 1 Zauberer",
           "name_fr": "Levez-vous!, Sorcier de Niveau 1",
           "points": 35,
+          "notes": {
+            "name_en": "Must be General and Hierophant",
+            "name_cn": "Must be General and Hierophant",
+            "name_de": "Must be General and Hierophant",
+            "name_es": "Must be General and Hierophant",
+            "name_fr": "Must be General and Hierophant",
+            "name_it": "Must be General and Hierophant"
+          },
           "armyComposition": "nehekharan-royal-hosts"
         }
       ],
@@ -236,7 +263,7 @@
           }
         }
       ],
-      "lores": [],
+      "lores": ["necromancy"],
       "specialRules": {
         "name_en": "Curse of the Necropolis, Dry as Dust, Flammable, Indomitable (2), Khopesh, My Will Be Done, Nehekharan Undead, Regeneration (5+)",
         "name_cn": "墓地诅咒, 干枯如尘, 易燃, 顽强不屈(2), 霍佩什, 吾愿必达, 尼赫喀拉亡灵, 重生(5+)",
@@ -300,6 +327,25 @@
           "name_es": "General",
           "points": 0,
           "armyComposition": ["tomb-kings-of-khemri", "nehekharan-royal-hosts"]
+        },
+        {
+          "name_en": "The Hierophant",
+          "name_cn": "The Hierophant",
+          "name_it": "The Hierophant",
+          "name_de": "The Hierophant",
+          "name_fr": "The Hierophant",
+          "name_es": "The Hierophant",
+          "points": 0,
+          "exclusive": false,
+          "notes": {
+            "name_en": "General must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
+            "name_cn": "General must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
+            "name_de": "General must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
+            "name_es": "General must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
+            "name_fr": "General must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests",
+            "name_it": "General must be Hierophant if given Arise and Level 1 Wizard with the Language of the Priests"
+          },
+          "armyComposition": ["nehekharan-royal-hosts"]
         }
       ],
       "equipment": [
@@ -395,6 +441,14 @@
           "name_de": "Erhebt euch!, Level 1 Zauberer",
           "name_fr": "Levez-vous!, Sorcier de Niveau 1",
           "points": 35,
+          "notes": {
+            "name_en": "Must be General and Hierophant",
+            "name_cn": "Must be General and Hierophant",
+            "name_de": "Must be General and Hierophant",
+            "name_es": "Must be General and Hierophant",
+            "name_fr": "Must be General and Hierophant",
+            "name_it": "Must be General and Hierophant"
+          },
           "armyComposition": "nehekharan-royal-hosts"
         }
       ],
@@ -467,7 +521,7 @@
           }
         }
       ],
-      "lores": [],
+      "lores": ["necromancy"],
       "specialRules": {
         "name_en": "Curse of the Necropolis, Dry as Dust, Flammable, Indomitable (2), Khopesh, My Will Be Done, Nehekharan Undead, Regeneration (5+)",
         "name_cn": "墓地诅咒, 干枯如尘, 易燃, 顽强不屈(2), 霍佩什, 吾愿必达, 尼赫喀拉亡灵, 重生(5+)",

--- a/src/i18n/cn.json
+++ b/src/i18n/cn.json
@@ -127,6 +127,7 @@
   "misc.error.noHierophant": "You need a Hierophant",
   "misc.error.multipleHierophants": "Only one Hierophant allowed",
   "misc.error.hierophantLevel": "Your Hierophant doesn't have the highest wizard level of your Liche Priests",
+  "misc.error.hierophantGeneral": "Your general must also be the Hierophant",
   "misc.error.wizardGeneral": "Your general must have wizard levels",
   "pwa.button": "安装app",
   "pwa.prompt": "旧世界写表器可以作为app被安装到你的设备上。现在安装？",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -127,6 +127,7 @@
   "misc.error.noHierophant": "You need a Hierophant",
   "misc.error.multipleHierophants": "Nur ein Hierophant erlaubt",
   "misc.error.hierophantLevel": "Dein Hierophant hat nicht die höchste Magiestufe deiner Hohepriester",
+  "misc.error.hierophantGeneral": "Your general must also be the Hierophant",
   "misc.error.wizardGeneral": "Your general must have wizard levels",
   "pwa.button": "App installieren",
   "pwa.prompt": "Old World Builder kann als App auf deinem Gerät installiert werden. Jetzt installieren?",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -127,6 +127,7 @@
   "misc.error.noHierophant": "You need a Hierophant",
   "misc.error.multipleHierophants": "Only one Hierophant allowed",
   "misc.error.hierophantLevel": "Your Hierophant doesn't have the highest wizard level of your Liche Priests",
+  "misc.error.hierophantGeneral": "Your general must also be the Hierophant",
   "misc.error.wizardGeneral": "Your general must have wizard levels",
   "pwa.button": "Install app",
   "pwa.prompt": "Old World Builder can be installed as an app on your device. Install now?",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -127,6 +127,7 @@
   "misc.error.noHierophant": "Necesitas un Hierofante",
   "misc.error.multipleHierophants": "Solo se permite un Hierofante",
   "misc.error.hierophantLevel": "Tu Hierofante no tiene el nivel de hechicería más alto de tus Sacerdotes Funerarios",
+  "misc.error.hierophantGeneral": "Your general must also be the Hierophant",
   "misc.error.wizardGeneral": "Tu general debe tener niveles de Hechiceria",
   "pwa.button": "Instalar app",
   "pwa.prompt": "Old World Builder se puede instalar como una aplicación en su dispositivo. ¿Instalar ahora?",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -127,6 +127,7 @@
   "misc.error.noHierophant": "You need a Hierophant",
   "misc.error.multipleHierophants": "Only one Hierophant allowed",
   "misc.error.hierophantLevel": "Your Hierophant doesn't have the highest wizard level of your Liche Priests",
+  "misc.error.hierophantGeneral": "Your general must also be the Hierophant",
   "misc.error.wizardGeneral": "Your general must have wizard levels",
   "pwa.button": "Installer l'application",
   "pwa.prompt": "Old World Builder peut être installé comme une application sur votre appareil. Installer maintenant ?",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -127,6 +127,7 @@
   "misc.error.noHierophant": "You need a Hierophant",
   "misc.error.multipleHierophants": "Only one Hierophant allowed",
   "misc.error.hierophantLevel": "Your Hierophant doesn't have the highest wizard level of your Liche Priests",
+  "misc.error.hierophantGeneral": "Your general must also be the Hierophant",
   "misc.error.wizardGeneral": "Your general must have wizard levels",
   "pwa.button": "Install app",
   "pwa.prompt": "Old World Builder can be installed as an app on your device. Install now?",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -127,6 +127,7 @@
   "misc.error.noHierophant": "You need a Hierophant",
   "misc.error.multipleHierophants": "Only one Hierophant allowed",
   "misc.error.hierophantLevel": "Your Hierophant doesn't have the highest wizard level of your Liche Priests",
+  "misc.error.hierophantGeneral": "Your general must also be the Hierophant",
   "misc.error.wizardGeneral": "Your general must have wizard levels",
   "pwa.button": "Install app",
   "pwa.prompt": "Old World Builder can be installed as an app on your device. Install now?",

--- a/src/utils/validation-checks.js
+++ b/src/utils/validation-checks.js
@@ -137,18 +137,24 @@ export const hierophantChecks = (list) => {
         ) {
           const wizardLevel = getWizardLevels(unit).lastIndexOf(1);
           if (wizardLevel && wizardLevel > highestLichePriestLevel) {
-            // Settra is always the Hierophant
+            // Settra and characters with the "Language of the Priests" option are always the Hierophant
+            const hasLanguageOfThePriests = (unit.name_en === "Tomb King" || unit.name_en === "Tomb Prince") &&
+              unit.options.find((option) => option.name_en === "Arise!, Level 1 Wizard") !== undefined;
             highestLichePriestLevel =
-              unit.name_en === "Settra the Imperishable" ? 6 : wizardLevel;
+              (unit.name_en === "Settra the Imperishable" || hasLanguageOfThePriests) 
+                ? 6 
+                : wizardLevel;
           }
         }
       });
     }
-
+    
+    const hasLanguageOfThePriests = (hierophants[0].name_en === "Tomb King" || hierophants[0].name_en === "Tomb Prince") &&
+      hierophants[0].options.find((option) => option.name_en === "Arise!, Level 1 Wizard") !== undefined;
     const hierophantLevel =
-      (hierophants[0].name_en === "Settra the Imperishable"
+      (hierophants[0].name_en === "Settra the Imperishable" || hasLanguageOfThePriests)
         ? 6
-        : getWizardLevels(hierophants[0]).lastIndexOf(1));
+        : getWizardLevels(hierophants[0]).lastIndexOf(1);
 
     if (hierophantLevel < highestLichePriestLevel) {
       return [{
@@ -159,6 +165,21 @@ export const hierophantChecks = (list) => {
       return [];
     }
   }
+}
+
+export const generalIsHierophant = (list) => {
+  const errors = [];
+  const generals = getGenerals(list);
+  if (generals.length === 1) {
+    const isHierophant = generals[0].command.find((command) => command.active && command.name_en === "The Hierophant");
+    if (!isHierophant) {
+      errors.push({
+        message: "misc.error.hierophantGeneral",
+        section: "characters",
+      });
+    }
+  }
+  return errors;
 }
 
 export const generalIsWizard = (list) => {

--- a/src/utils/validation-checks.js
+++ b/src/utils/validation-checks.js
@@ -135,22 +135,25 @@ export const hierophantChecks = (list) => {
                 equalsOrIncludes(command.armyComposition, list.armyComposition)),
           )
         ) {
-          const wizardLevel = getWizardLevels(unit).lastIndexOf(1);
+          // Settra and characters with the "Language of the Priests" option are always the Hierophant
+          const hasLanguageOfThePriests = (unit.name_en === "Tomb King" || unit.name_en === "Tomb Prince") &&
+            unit.command[0].options?.find(
+              (option) => option.name_en === "Arise!, Level 1 Wizard" && option.active
+            ) !== undefined;
+          const wizardLevel = (unit.name_en === "Settra the Imperishable" || hasLanguageOfThePriests) 
+            ? 6 
+            : getWizardLevels(unit).lastIndexOf(1);
           if (wizardLevel && wizardLevel > highestLichePriestLevel) {
-            // Settra and characters with the "Language of the Priests" option are always the Hierophant
-            const hasLanguageOfThePriests = (unit.name_en === "Tomb King" || unit.name_en === "Tomb Prince") &&
-              unit.options.find((option) => option.name_en === "Arise!, Level 1 Wizard") !== undefined;
-            highestLichePriestLevel =
-              (unit.name_en === "Settra the Imperishable" || hasLanguageOfThePriests) 
-                ? 6 
-                : wizardLevel;
+            highestLichePriestLevel = wizardLevel;
           }
         }
       });
     }
     
     const hasLanguageOfThePriests = (hierophants[0].name_en === "Tomb King" || hierophants[0].name_en === "Tomb Prince") &&
-      hierophants[0].options.find((option) => option.name_en === "Arise!, Level 1 Wizard") !== undefined;
+      hierophants[0].command[0].options?.find(
+        (option) => option.name_en === "Arise!, Level 1 Wizard" && option.active
+      ) !== undefined;
     const hierophantLevel =
       (hierophants[0].name_en === "Settra the Imperishable" || hasLanguageOfThePriests)
         ? 6

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -7,6 +7,7 @@ import {
   createLimitUnitRepeats,
   createMaxPointsSingleUnit,
   createMinNonCharacters,
+  generalIsHierophant,
   generalIsWizard,
   generalLeadership,
   grandMeleeWizardLimits,
@@ -51,6 +52,9 @@ export const validateList = ({ list, language, intl }) => {
   }
   if (list?.army === "tomb-kings-of-khemri") {
     checks.push(hierophantChecks);
+    if (list.armyComposition === "mortuary-cults") {
+      checks.push(generalIsHierophant);
+    }
   }
   if (list?.army === "vampire-counts") {
     checks.push(generalIsWizard);

--- a/src/utils/validation.test.js
+++ b/src/utils/validation.test.js
@@ -757,6 +757,62 @@ describe("validateList", () => {
     expect(getMessages(errors)).toEqual(["misc.error.hierophantLevel"]);
   });
 
+  test("applies Language of the Priests special hierophant priority level", () => {
+    const list = {
+      ...baseList,
+      army: "tomb-kings-of-khemri",
+      characters: [
+        makeCharacter({
+          id: "tomb-king.1",
+          name_en: "Settra the Imperishable",
+          command: [{ name_en: "The Hierophant", active: false, points: 0 }],
+          options: [{ name_en: "Arise!, Level 1 Wizard", active: true }],
+          isGeneral: true,
+        }),
+        makeCharacter({
+          id: "high-priest.1",
+          name_en: "High Priest",
+          command: [{ name_en: "The Hierophant", active: true, points: 0 }],
+          options: [{ name_en: "Level 4 Wizard", active: true }],
+        }),
+      ],
+    };
+
+    const errors = validateList({ list, language: "en", intl });
+    expect(getMessages(errors)).toEqual(["misc.error.hierophantLevel"]);
+  });
+
+  test("adds hierophantGeneral if a Mortuary Cult general is not the Hierophant", () => {
+    const list = {
+      ...baseList,
+      army: "tomb-kings-of-khemri",
+      armyComposition: "mortuary-cults",
+      characters: [
+        makeCharacter({
+          id: "high-priest.1",
+          name_en: "High Priest",
+          command: [{ name_en: "The Hierophant", active: false, points: 0 }],
+          options: [{ name_en: "Level 3 Wizard", active: true }],
+          isGeneral: true
+        }),
+        makeCharacter({
+          id: "high-priest.2",
+          name_en: "High Priest",
+          command: [{ name_en: "The Hierophant", active: true, points: 0 }],
+          options: [{ name_en: "Level 4 Wizard", active: true }],
+          isGeneral: false,
+        }),
+      ],
+      special: [
+        {id: "tomb-scorpion.1", name_en:"Tomb Scorpion"},
+        {id: "tomb-scorpion.2", name_en:"Tomb Scorpion"},
+      ]
+    };
+
+    const errors = validateList({ list, language: "en", intl });
+    expect(getMessages(errors)).toEqual(["misc.error.hierophantGeneral"]);
+  });
+
   test("adds wizardGeneral if a Vampire Count general is not a wizard", () => {
     const list = {
       ...baseList,

--- a/src/utils/validation.test.js
+++ b/src/utils/validation.test.js
@@ -765,8 +765,12 @@ describe("validateList", () => {
         makeCharacter({
           id: "tomb-king.1",
           name_en: "Settra the Imperishable",
-          command: [{ name_en: "The Hierophant", active: false, points: 0 }],
-          options: [{ name_en: "Arise!, Level 1 Wizard", active: true }],
+          command: [
+            { name_en: "General", active: true, points: 0, options: [
+              { name_en: "Arise!, Level 1 Wizard", active: true }
+            ] },
+            { name_en: "The Hierophant", active: false, points: 0 }
+          ],
           isGeneral: true,
         }),
         makeCharacter({


### PR DESCRIPTION
Added some more Tomb Kings improvements and validations. 

* [The Language of the Priests rule](https://tow.whfb.app/special-rules/the-language-of-the-priests) for the Royal Host army comp is only available for the General, who must also be the Hierophant if its taken. The Hierophant command option should only be available to characters who have taken it, but best I think we can do is add a note to the option.
* The general of a Mortuary Cults list must also be the Hierophant and vice versa. 

Tomb Kings are definitely proving to have the most complicated rules about being General, but hopefully we've gotten there now. Until a new army of infamy come along with new rules, at least.