### PR TITLE
Fixes and standardizations for Ravening Hordes armies

### DIFF
--- a/public/games/the-old-world/beastmen-brayherds.json
+++ b/public/games/the-old-world/beastmen-brayherds.json
@@ -104,7 +104,42 @@
           "minimum": 0,
           "maximum": 0,
           "name_es": "Emboscada",
-          "name_fr": "Embusqueurs"
+          "name_fr": "Embusqueurs",
+          "armyComposition": ["beastmen-brayherds", "minotaur-blood-herd"],
+          "notes": [
+            {
+              "name_en": "Cannot be mounted on a chariot",
+              "name_cn": "Cannot be mounted on a chariot",
+              "name_de": "Cannot be mounted on a chariot",
+              "name_es": "Cannot be mounted on a chariot",
+              "name_fr": "Cannot be mounted on a chariot"
+            },
+            {
+              "name_en": "0-1 per 1000 points",
+              "name_cn": "每1000分0-1",
+              "name_de": "0-1 pro 1000 Punkte",
+              "name_es": "0-1 por cada 1000 puntos",
+              "name_fr": "0-1 par tranche de 1000 points"
+            }
+          ]
+        },
+        {
+          "name_en": "Ambushers",
+          "name_cn": "伏击",
+          "name_de": "Überfall",
+          "points": 10,
+          "minimum": 0,
+          "maximum": 0,
+          "name_es": "Emboscada",
+          "name_fr": "Embusqueurs",
+          "armyComposition": "wild-herd",
+          "notes": {
+            "name_en": "Cannot be mounted on a chariot",
+            "name_cn": "Cannot be mounted on a chariot",
+            "name_de": "Cannot be mounted on a chariot",
+            "name_es": "Cannot be mounted on a chariot",
+            "name_fr": "Cannot be mounted on a chariot"
+          }
         }
       ],
       "mounts": [
@@ -123,7 +158,14 @@
           "name_de": "Tuskgor-Streitwagen",
           "points": 85,
           "name_es": "Carro de Tuskgors",
-          "name_fr": "Char à Sangleboucs"
+          "name_fr": "Char à Sangleboucs",
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         },
         {
           "name_en": "Razorgor Chariot",
@@ -131,7 +173,14 @@
           "name_de": "Gnargor-Streitwagen",
           "points": 120,
           "name_es": "Carro de Garragors",
-          "name_fr": "Char à Razorgors"
+          "name_fr": "Char à Razorgors",
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         }
       ],
       "items": [
@@ -297,8 +346,43 @@
           "points": 10,
           "minimum": 0,
           "maximum": 0,
-          "name_es": "Esboscada",
-          "name_fr": "Embusqueurs"
+          "name_es": "Emboscada",
+          "name_fr": "Embusqueurs",
+          "armyComposition": ["beastmen-brayherds", "minotaur-blood-herd"],
+          "notes": [
+            {
+              "name_en": "Cannot be mounted on a chariot",
+              "name_cn": "Cannot be mounted on a chariot",
+              "name_de": "Cannot be mounted on a chariot",
+              "name_es": "Cannot be mounted on a chariot",
+              "name_fr": "Cannot be mounted on a chariot"
+            },
+            {
+              "name_en": "0-1 per 1000 points",
+              "name_cn": "每1000分0-1",
+              "name_de": "0-1 pro 1000 Punkte",
+              "name_es": "0-1 por cada 1000 puntos",
+              "name_fr": "0-1 par tranche de 1000 points"
+            }
+          ]
+        },
+        {
+          "name_en": "Ambushers",
+          "name_cn": "伏击",
+          "name_de": "Überfall",
+          "points": 10,
+          "minimum": 0,
+          "maximum": 0,
+          "name_es": "Emboscada",
+          "name_fr": "Embusqueurs",
+          "armyComposition": "wild-herd",
+          "notes": {
+            "name_en": "Cannot be mounted on a chariot",
+            "name_cn": "Cannot be mounted on a chariot",
+            "name_de": "Cannot be mounted on a chariot",
+            "name_es": "Cannot be mounted on a chariot",
+            "name_fr": "Cannot be mounted on a chariot"
+          }
         }
       ],
       "mounts": [
@@ -317,7 +401,14 @@
           "name_de": "Tuskgor-Streitwagen",
           "points": 85,
           "name_es": "Carro de Tuskgors",
-          "name_fr": "Char à Sangleboucs"
+          "name_fr": "Char à Sangleboucs",
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         },
         {
           "name_en": "Razorgor Chariot",
@@ -325,7 +416,14 @@
           "name_de": "Gnargor-Streitwagen",
           "points": 120,
           "name_es": "Carro de Garragors",
-          "name_fr": "Char à Razorgors"
+          "name_fr": "Char à Razorgors",
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         }
       ],
       "items": [
@@ -441,7 +539,23 @@
           "minimum": 0,
           "maximum": 0,
           "name_es": "Emboscada",
-          "name_fr": "Embusqueurs"
+          "name_fr": "Embusqueurs",
+          "notes": [
+            {
+              "name_en": "Cannot be mounted on a chariot",
+              "name_cn": "Cannot be mounted on a chariot",
+              "name_de": "Cannot be mounted on a chariot",
+              "name_es": "Cannot be mounted on a chariot",
+              "name_fr": "Cannot be mounted on a chariot"
+            },
+            {
+              "name_en": "0-1 per 1000 points",
+              "name_cn": "每1000分0-1",
+              "name_de": "0-1 pro 1000 Punkte",
+              "name_es": "0-1 por cada 1000 puntos",
+              "name_fr": "0-1 par tranche de 1000 points"
+            }
+          ]
         },
         {
           "name_en": "Wizard",
@@ -491,7 +605,14 @@
           "name_de": "Tuskgor-Streitwagen",
           "points": 85,
           "name_es": "Carro de Tuskgors",
-          "name_fr": "Char à Sangleboucs"
+          "name_fr": "Char à Sangleboucs",
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         },
         {
           "name_en": "Razorgor Chariot",
@@ -499,7 +620,14 @@
           "name_de": "Gnargor-Streitwagen",
           "points": 120,
           "name_es": "Carro de Garragors",
-          "name_fr": "Char à Razorgors"
+          "name_fr": "Char à Razorgors",
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         }
       ],
       "items": [
@@ -632,7 +760,23 @@
           "minimum": 0,
           "maximum": 0,
           "name_es": "Emboscada",
-          "name_fr": "Embusqueurs"
+          "name_fr": "Embusqueurs",
+          "notes": [
+            {
+              "name_en": "Cannot be mounted on a chariot",
+              "name_cn": "Cannot be mounted on a chariot",
+              "name_de": "Cannot be mounted on a chariot",
+              "name_es": "Cannot be mounted on a chariot",
+              "name_fr": "Cannot be mounted on a chariot"
+            },
+            {
+              "name_en": "0-1 per 1000 points",
+              "name_cn": "每1000分0-1",
+              "name_de": "0-1 pro 1000 Punkte",
+              "name_es": "0-1 por cada 1000 puntos",
+              "name_fr": "0-1 par tranche de 1000 points"
+            }
+          ]
         },
         {
           "name_en": "Wizard",
@@ -682,7 +826,14 @@
           "name_de": "Tuskgor-Streitwagen",
           "points": 85,
           "name_es": "Carro de Tuskgors",
-          "name_fr": "Char à Sangleboucs"
+          "name_fr": "Char à Sangleboucs",
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         },
         {
           "name_en": "Razorgor Chariot",
@@ -690,7 +841,14 @@
           "name_de": "Gnargor-Streitwagen",
           "points": 120,
           "name_es": "Carro de Garragors",
-          "name_fr": "Char à Razorgors"
+          "name_fr": "Char à Razorgors",
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         }
       ],
       "items": [
@@ -1158,7 +1316,7 @@
       "name_de": "Kriegshuf",
       "name_es": "Warhoof",
       "name_fr": "Sabot-guerrier",
-      "id": "centigore-chieftain",
+      "id": "warhoof",
       "points": 75,
       "magicItemsArmy": "beastmen-brayherds",
       "command": [
@@ -1222,13 +1380,24 @@
       ],
       "options": [
         {
-          "name_en": "Throwing axes, Javelins",
-          "name_cn": "飞斧, 标枪",
-          "name_de": "Wurfäxte, Wurfspieße",
+          "name_en": "Throwing axes",
+          "name_cn": "飞斧",
+          "name_de": "Wurfäxte",
           "points": 2,
           "minimum": 0,
           "maximum": 0,
-          "name_fr": "Haches de lancer, Javelines"
+          "name_fr": "Haches de lancer",
+          "exclusive": true
+        },
+        {
+          "name_en": "Javelins",
+          "name_cn": "标枪",
+          "name_de": "Wurfspieße",
+          "points": 2,
+          "minimum": 0,
+          "maximum": 0,
+          "name_fr": "Javelines",
+          "exclusive": true
         },
         {
           "name_en": "Shield",
@@ -1246,7 +1415,25 @@
           "points": 10,
           "minimum": 0,
           "maximum": 0,
-          "name_fr": "Embusqueurs"
+          "name_fr": "Embusqueurs",
+          "armyComposition": ["beastmen-brayherds", "minotaur-blood-herd"],
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
+        },
+        {
+          "name_en": "Ambushers",
+          "name_cn": "伏击",
+          "name_de": "Überfall",
+          "points": 10,
+          "minimum": 0,
+          "maximum": 0,
+          "name_fr": "Embusqueurs",
+          "armyComposition": "wild-herd"
         }
       ],
       "mounts": [],
@@ -1648,7 +1835,7 @@
       "name_de": "Bestigor-Herden",
       "name_es": "Rebaño de bestigors",
       "name_fr": "Harde de Bestigor",
-      "id": "bestigor-herds",
+      "id": "bestigor-herds-core",
       "points": 13,
       "minimum": 5,
       "maximum": 0,
@@ -1702,13 +1889,21 @@
           "name_en": "Standard bearer",
           "name_cn": "旗手",
           "name_de": "Standartenträger",
+          "name_es": "Portaesdantarte",
+          "name_fr": "Porte-étendard",
           "points": 6,
           "magic": {
             "types": ["banner"],
             "maxPoints": 50
           },
-          "name_es": "Portaesdantarte",
-          "name_fr": "Porte-étendard"
+          "notes": {
+            "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
+            "name_it": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
+          }
         },
         {
           "name_en": "Musician",
@@ -1752,7 +1947,14 @@
           "maximum": 0,
           "perModel": true,
           "name_es": "Tozudo",
-          "name_fr": "Obstiné"
+          "name_fr": "Obstiné",
+          "notes": {
+            "name_en": "0-1 per army",
+            "name_cn": "0-1 per army",
+            "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
+            "name_fr": "0-1 par armée"
+          }
         },
         {
           "name_en": "Veteran",
@@ -1763,7 +1965,14 @@
           "maximum": 0,
           "perModel": true,
           "name_es": "Veterano",
-          "name_fr": "Vétérans"
+          "name_fr": "Vétérans",
+          "notes": {
+            "name_en": "0-1 per army",
+            "name_cn": "0-1 per army",
+            "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
+            "name_fr": "0-1 par armée"
+          }
         }
       ],
       "mounts": [],
@@ -1883,7 +2092,25 @@
           "name_es": "Emboscada",
           "name_fr": "Embusqueurs",
           "points": 1,
-          "perModel": true
+          "perModel": true,
+          "armyComposition": ["beastmen-brayherds", "minotaur-blood-herd"],
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
+        },
+        {
+          "name_en": "Ambushers",
+          "name_cn": "伏击",
+          "name_de": "Überfall",
+          "name_es": "Emboscada",
+          "name_fr": "Embusqueurs",
+          "points": 1,
+          "perModel": true,
+          "armyComposition": "wild-herd"
         },
         {
           "name_en": "Ambushers",
@@ -1993,12 +2220,28 @@
           "name_en": "Ambushers",
           "name_cn": "伏击",
           "name_de": "Überfall",
-          "points": 1,
-          "minimum": 0,
-          "maximum": 0,
-          "perModel": true,
           "name_es": "Emboscada",
-          "name_fr": "Embusqueurs"
+          "name_fr": "Embusqueurs",
+          "points": 1,
+          "perModel": true,
+          "armyComposition": ["beastmen-brayherds", "minotaur-blood-herd"],
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
+        },
+        {
+          "name_en": "Ambushers",
+          "name_cn": "伏击",
+          "name_de": "Überfall",
+          "name_es": "Emboscada",
+          "name_fr": "Embusqueurs",
+          "points": 1,
+          "perModel": true,
+          "armyComposition": "wild-herd"
         },
         {
           "name_en": "Ambushers",
@@ -2011,7 +2254,7 @@
           "armyComposition": "wild-herd",
           "notes": {
             "name_en": "0-1 Gor Herd, Ungor Herd or Centigor Herd per 1000 points with a Unit Strength of 10 or less",
-            "name_de": "0-1 Gor-Herde, Ungor-Herde oder Zentigor-Herde pro 1000 Punkte mit einer Einheitenstärke von 10 oder weniger",
+            "name_de": "0-1 Gor-Herde, Ungor-Herde oder Zentigor-Herde pro 1.000 Punkte mit einer Einheitenstärke von 10 oder weniger",
             "name_fr": "0-1 Harde de Gor, Harde d’Ungor ou Harde de Centigor par tranche de 1000 points avec une Puissance d’Unité de 10 ou moins"
           }
         }
@@ -2261,7 +2504,15 @@
             "types": ["banner"],
             "maxPoints": 50
           },
-          "name_fr": "Porte-étendard"
+          "name_fr": "Porte-étendard",
+          "notes": {
+            "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
+            "name_it": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
+          }
         },
         {
           "name_en": "Musician",
@@ -2330,9 +2581,28 @@
           "name_en": "Ambushers",
           "name_cn": "伏击",
           "name_de": "Überfall",
+          "name_es": "Emboscada",
+          "name_fr": "Embusqueurs",
           "points": 1,
           "perModel": true,
-          "name_fr": "Embusqueurs"
+          "armyComposition": ["beastmen-brayherds", "minotaur-blood-herd"],
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
+        },
+        {
+          "name_en": "Ambushers",
+          "name_cn": "伏击",
+          "name_de": "Überfall",
+          "name_es": "Emboscada",
+          "name_fr": "Embusqueurs",
+          "points": 1,
+          "perModel": true,
+          "armyComposition": "wild-herd"
         },
         {
           "name_en": "Ambushers",
@@ -2424,7 +2694,7 @@
       "name_de": "Minotauren-Herden",
       "name_es": "Minotaur Herd",
       "name_fr": "Harde de Minotaure",
-      "id": "minotaur-herd",
+      "id": "minotaur-herds-core",
       "points": 44,
       "minimum": 2,
       "maximum": 0,
@@ -2534,7 +2804,14 @@
           "name_de": "Überfall",
           "points": 3,
           "perModel": true,
-          "name_fr": "Embusqueurs"
+          "name_fr": "Embusqueurs",
+          "notes": {
+            "name_en": "0-1 per army",
+            "name_cn": "0-1 per army",
+            "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
+            "name_fr": "0-1 par armée"
+          }
         }
       ],
       "mounts": [],
@@ -2652,7 +2929,14 @@
           "minimum": 0,
           "maximum": 0,
           "perModel": true,
-          "name_fr": "Obstiné"
+          "name_fr": "Obstiné",
+          "notes": {
+            "name_en": "0-1 per army",
+            "name_cn": "0-1 per army",
+            "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
+            "name_fr": "0-1 par armée"
+          }
         },
         {
           "name_en": "Veteran",
@@ -2662,17 +2946,14 @@
           "minimum": 0,
           "maximum": 0,
           "perModel": true,
-          "name_fr": "Vétérans"
-        },
-        {
-          "name_en": "Ambushers",
-          "name_cn": "伏击",
-          "name_de": "Überfall",
-          "name_es": "Emboscada",
-          "name_fr": "Embusqueurs",
-          "points": 1,
-          "perModel": true,
-          "armyComposition": "wild-herd"
+          "name_fr": "Vétérans",
+          "notes": {
+            "name_en": "0-1 per army",
+            "name_cn": "0-1 per army",
+            "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
+            "name_fr": "0-1 par armée"
+          }
         }
       ],
       "mounts": [],
@@ -2830,7 +3111,14 @@
           "name_de": "Überfall",
           "points": 3,
           "perModel": true,
-          "name_fr": "Embusqueurs"
+          "name_fr": "Embusqueurs",
+          "notes": {
+            "name_en": "0-1 per army",
+            "name_cn": "0-1 per army",
+            "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
+            "name_fr": "0-1 par armée"
+          }
         }
       ],
       "mounts": [],
@@ -2943,30 +3231,38 @@
           "name_en": "Gorehoof (champion)",
           "name_cn": "血蹄",
           "name_de": "Donnerhuf (Champion)",
+          "name_fr": "Éventreur (champion)",
           "points": 8,
           "magic": {
             "types": ["enchanted-item", "talisman", "armor", "weapon"],
             "maxPoints": 25
-          },
-          "name_fr": "Éventreur (champion)"
+          }
         },
         {
           "name_en": "Standard bearer",
           "name_cn": "旗手",
           "name_de": "Standartenträger",
+          "name_fr": "Porte-étendard",
           "points": 6,
           "magic": {
             "types": ["banner"],
             "maxPoints": 50
           },
-          "name_fr": "Porte-étendard"
+          "notes": {
+            "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
+            "name_it": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
+          }
         },
         {
           "name_en": "Musician",
           "name_cn": "乐手",
           "name_de": "Musiker",
-          "points": 6,
-          "name_fr": "Musicien"
+          "name_fr": "Musicien",
+          "points": 6
         }
       ],
       "equipment": [
@@ -3028,9 +3324,28 @@
           "name_en": "Ambushers",
           "name_cn": "伏击",
           "name_de": "Überfall",
+          "name_es": "Emboscada",
+          "name_fr": "Embusqueurs",
           "points": 1,
           "perModel": true,
-          "name_fr": "Embusqueurs"
+          "armyComposition": ["beastmen-brayherds", "minotaur-blood-herd"],
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
+        },
+        {
+          "name_en": "Ambushers",
+          "name_cn": "伏击",
+          "name_de": "Überfall",
+          "name_es": "Emboscada",
+          "name_fr": "Embusqueurs",
+          "points": 1,
+          "perModel": true,
+          "armyComposition": "wild-herd"
         },
         {
           "name_en": "Ambushers",

--- a/public/games/the-old-world/orc-and-goblin-tribes.json
+++ b/public/games/the-old-world/orc-and-goblin-tribes.json
@@ -153,9 +153,10 @@
                 },
                 {
                   "name_en": "0-1 per 1000 points",
-                  "name_cn": "0-1 per 1000 points",
-                  "name_fr": "0-1 par tranche de 1000 points",
-                  "name_de": "0-1 pro 1000 Punkte"
+                  "name_cn": "每1000分0-1",
+                  "name_de": "0-1 pro 1000 Punkte",
+                  "name_es": "0-1 por cada 1000 puntos",
+                  "name_fr": "0-1 par tranche de 1000 points"
                 }
               ]
             },
@@ -174,9 +175,10 @@
                 },
                 {
                   "name_en": "0-1 per 1000 points",
-                  "name_cn": "0-1 per 1000 points",
-                  "name_fr": "0-1 par tranche de 1000 points",
-                  "name_de": "0-1 pro 1000 Punkte"
+                  "name_cn": "每1000分0-1",
+                  "name_de": "0-1 pro 1000 Punkte",
+                  "name_es": "0-1 por cada 1000 puntos",
+                  "name_fr": "0-1 par tranche de 1000 points"
                 }
               ]
             },
@@ -422,9 +424,10 @@
                 },
                 {
                   "name_en": "0-1 per 1000 points",
-                  "name_cn": "0-1 per 1000 points",
-                  "name_fr": "0-1 par tranche de 1000 points",
-                  "name_de": "0-1 pro 1000 Punkte"
+                  "name_cn": "每1000分0-1",
+                  "name_de": "0-1 pro 1000 Punkte",
+                  "name_es": "0-1 por cada 1000 puntos",
+                  "name_fr": "0-1 par tranche de 1000 points"
                 }
               ]
             },
@@ -443,9 +446,10 @@
                 },
                 {
                   "name_en": "0-1 per 1000 points",
-                  "name_cn": "0-1 per 1000 points",
-                  "name_fr": "0-1 par tranche de 1000 points",
-                  "name_de": "0-1 pro 1000 Punkte"
+                  "name_cn": "每1000分0-1",
+                  "name_de": "0-1 pro 1000 Punkte",
+                  "name_es": "0-1 por cada 1000 puntos",
+                  "name_fr": "0-1 par tranche de 1000 points"
                 }
               ]
             },
@@ -628,8 +632,9 @@
           "notes": {
             "name_en": "0-1 per 1000 points",
             "name_cn": "每1000分0-1",
-            "name_fr": "0-1 par tranche de 1000 points",
-            "name_de": "0-1 pro 1000 Punkte"
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
           }
         }
       ],
@@ -710,9 +715,10 @@
                 },
                 {
                   "name_en": "0-1 per 1000 points",
-                  "name_cn": "0-1 per 1000 points",
-                  "name_fr": "0-1 par tranche de 1000 points",
-                  "name_de": "0-1 pro 1000 Punkte"
+                  "name_cn": "每1000分0-1",
+                  "name_de": "0-1 pro 1000 Punkte",
+                  "name_es": "0-1 por cada 1000 puntos",
+                  "name_fr": "0-1 par tranche de 1000 points"
                 }
               ]
             },
@@ -731,9 +737,10 @@
                 },
                 {
                   "name_en": "0-1 per 1000 points",
-                  "name_cn": "0-1 per 1000 points",
-                  "name_fr": "0-1 par tranche de 1000 points",
-                  "name_de": "0-1 pro 1000 Punkte"
+                  "name_cn": "每1000分0-1",
+                  "name_de": "0-1 pro 1000 Punkte",
+                  "name_es": "0-1 por cada 1000 puntos",
+                  "name_fr": "0-1 par tranche de 1000 points"
                 }
               ]
             },
@@ -878,8 +885,9 @@
           "notes": {
             "name_en": "0-1 per 1000 points",
             "name_cn": "每1000分0-1",
-            "name_fr": "0-1 par tranche de 1000 points",
-            "name_de": "0-1 pro 1000 Punkte"
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
           }
         }
       ],
@@ -960,9 +968,10 @@
                 },
                 {
                   "name_en": "0-1 per 1000 points",
-                  "name_cn": "0-1 per 1000 points",
-                  "name_fr": "0-1 par tranche de 1000 points",
-                  "name_de": "0-1 pro 1000 Punkte"
+                  "name_cn": "每1000分0-1",
+                  "name_de": "0-1 pro 1000 Punkte",
+                  "name_es": "0-1 por cada 1000 puntos",
+                  "name_fr": "0-1 par tranche de 1000 points"
                 }
               ]
             },
@@ -981,9 +990,10 @@
                 },
                 {
                   "name_en": "0-1 per 1000 points",
-                  "name_cn": "0-1 per 1000 points",
-                  "name_fr": "0-1 par tranche de 1000 points",
-                  "name_de": "0-1 pro 1000 Punkte"
+                  "name_cn": "每1000分0-1",
+                  "name_de": "0-1 pro 1000 Punkte",
+                  "name_es": "0-1 por cada 1000 puntos",
+                  "name_fr": "0-1 par tranche de 1000 points"
                 }
               ]
             },
@@ -1090,8 +1100,9 @@
           "notes": {
             "name_en": "0-1 per 1000 points",
             "name_cn": "每1000分0-1",
-            "name_fr": "0-1 par tranche de 1000 points",
-            "name_de": "0-1 pro 1000 Punkte"
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
           }
         }
       ],
@@ -1237,8 +1248,9 @@
           "notes": {
             "name_en": "0-1 per 1000 points",
             "name_cn": "每1000分0-1",
-            "name_fr": "0-1 par tranche de 1000 points",
-            "name_de": "0-1 pro 1000 Punkte"
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
           }
         }
       ],
@@ -2983,12 +2995,6 @@
           "category": "core"
         }
       },
-      "notes": {
-        "name_de": "0-1 Ork-Mob pro 1.000 Punkte kann eine Magische Standarte erwerben im Wert bis zu 50 Punkte",
-        "name_en": "0-1 Orc Mob per 1000 points may purchase a magic standard worth up to 50 points",
-        "name_cn": "每1000分，0-1兽人战帮可以购买一面最多50分的魔法战旗",
-        "name_fr": "0-1 Bande d’Orques par tranche de 1000 points peut acheter une bannière magique pour une valeur maximale de 50 points"
-      },
       "command": [
         {
           "name_en": "Boss (champion)",
@@ -3010,6 +3016,14 @@
           "magic": {
             "types": ["banner"],
             "maxPoints": 50
+          },
+          "notes": {
+            "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
+            "name_it": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
           }
         },
         {
@@ -3085,6 +3099,7 @@
             "name_en": "0-1 per 1000 points",
             "name_cn": "每1000分0-1",
             "name_de": "0-1 pro 1.000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
             "name_fr": "0-1 par tranche de 1000 points"
           }
         }
@@ -3134,8 +3149,9 @@
           "perModel": true,
           "notes": {
             "name_en": "0-1 per army",
-            "name_cn": "0-1per army",
+            "name_cn": "0-1 per army",
             "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
             "name_fr": "0-1 par armée"
           }
         },
@@ -3157,6 +3173,7 @@
               "name_en": "0-1 per army",
               "name_cn": "0-1 per army",
               "name_de": "0-1 pro Armee",
+              "name_es": "0-1 per army",
               "name_fr": "0-1 par armée"
             }
           ]
@@ -3250,6 +3267,7 @@
             "name_en": "0-1 per army",
             "name_cn": "0-1 per army",
             "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
             "name_fr": "0-1 par armée"
           }
         },
@@ -3264,6 +3282,7 @@
             "name_en": "0-1 per army",
             "name_cn": "0-1 per army",
             "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
             "name_fr": "0-1 par armée"
           }
         },
@@ -3342,6 +3361,14 @@
           "magic": {
             "types": ["banner"],
             "maxPoints": 50
+          },
+          "notes": {
+            "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
+            "name_it": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
           }
         },
         {
@@ -3418,18 +3445,13 @@
               "name_en": "0-1 per 1000 points",
               "name_cn": "每1000分0-1",
               "name_de": "0-1 pro 1.000 Punkte",
+              "name_es": "0-1 por cada 1000 puntos",
               "name_fr": "0-1 par tranche de 1000 points"
             }
           ]
         }
       ],
       "mounts": [],
-      "notes": {
-        "name_en": "0-1 unit per 1000 points may purchase a magic standard worth up to 50 points",
-        "name_cn": "0-1unit per 1000 points may purchase a magic standard worth up to 50 points",
-        "name_de": "0-1 Einheit pro 1.000 Punkte kann eine Magische Standarte erwerben im Werte von bis zu 50 Punkten",
-        "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique pour une valeur maximale de 50 points"
-      },
       "specialRules": {
         "name_en": "Close Order, Fear of Elves, Horde, Impetuous, Warband",
         "name_cn": "紧密阵型, 惧怕精灵, 部群, 鲁莽, 战帮",
@@ -3509,6 +3531,14 @@
           "magic": {
             "types": ["banner"],
             "maxPoints": 50
+          },
+          "notes": {
+            "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
+            "name_it": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
           }
         },
         {
@@ -3560,11 +3590,11 @@
       ],
       "mounts": [],
       "notes": {
-        "name_en": "0-1 Night Goblin Mob per Night Goblin Chief or Night Goblin Shaman taken, 0-1 Night Goblin Mob per 1000 points may purchase a magic standard worth up to 50 points",
-        "name_cn": "0-1 Night Goblin Mob per Night Goblin Chief or Night Goblin Shaman taken, 0-1 Night Goblin Mob per 1000 points may purchase a magic standard worth up to 50 points",
-        "name_de": "0-1 Nachtgoblin-Mob pro gewähltem Nachtgoblin-Boss oder Nachtgobline-Schamane, 0-1 Nachtgoblin-Mob pro 1.000 Punkte kann eine Magische Standarte erwerben im Wert von bis zu 50 Punkten",
-        "name_es": "0-1 Night Goblin Mob per Night Goblin Chief or Night Goblin Shaman taken, 0-1 Night Goblin Mob per 1000 points may purchase a magic standard worth up to 50 points",
-        "name_fr": "0-1 Bande de Gobelins de la Nuit par Chef Gobelin de la Nuit ou Chamane Gobelin de la Nuit sélectionné, 0-1 Bande de Gobelins de la Nuit par tranche de 1000 points peut acheter une bannière magique pour une valeur maximale de 50 points"
+        "name_en": "0-1 Night Goblin Mob per Night Goblin Chief or Night Goblin Shaman taken,",
+        "name_cn": "0-1 Night Goblin Mob per Night Goblin Chief or Night Goblin Shaman taken",
+        "name_de": "0-1 Nachtgoblin-Mob pro gewähltem Nachtgoblin-Boss oder Nachtgobline-Schamane",
+        "name_es": "0-1 Night Goblin Mob per Night Goblin Chief or Night Goblin Shaman taken",
+        "name_fr": "0-1 Bande de Gobelins de la Nuit par Chef Gobelin de la Nuit ou Chamane Gobelin de la Nuit sélectionné"
       },
       "specialRules": {
         "name_en": "Close Order, Fear of Elves, Hatred (Dwarfs), Horde, Warband",
@@ -3625,12 +3655,6 @@
       "points": 12,
       "minimum": 5,
       "maximum": 0,
-      "notes": {
-        "name_en": "0-1 Goblin Spider Rider Mob per 1000 points may purchase a magic standard worth up to 50 points",
-        "name_cn": "0-1Goblin Spider Rider Mob per 1000 points may purchase a magic standard worth up to 50 points",
-        "name_de": "0-1 Goblin-Spinnenreiter-Mob pro 1.000 Punkte kann eine Magische Standarte erwerben im Wert von bis zu 50 Punkten",
-        "name_fr": "0-1 Bande de Gobelins sur Araignées par tranche de 1000 points peut acheter une bannière magique pour une valeur maximale de 50 points"
-      },
       "armyComposition": {
         "orc-and-goblin-tribes": {
           "category": "core"
@@ -3656,6 +3680,14 @@
           "magic": {
             "types": ["banner"],
             "maxPoints": 50
+          },
+          "notes": {
+            "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
+            "name_it": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
           }
         },
         {
@@ -3722,12 +3754,6 @@
       "points": 10,
       "minimum": 5,
       "maximum": 0,
-      "notes": {
-        "name_en": "0-1 Goblin Wolf Rider Mob per 1000 points may purchase a magic standard worth up to 50 points",
-        "name_cn": "0-1Goblin Wolf Rider Mob per 1000 points may purchase a magic standard worth up to 50 points",
-        "name_de": "0-1 Goblin-Wolfsreiter-Mob pro 1.000 Punkte kann eine Magische Standarte erwerben im Wert von bis zu 50 Punkten",
-        "name_fr": "0-1 Bande de Gobelins sur Loups par tranche de 1000 points peut acheter une bannière magique pour une valeur maximale de 50 points"
-      },
       "command": [
         {
           "name_en": "Boss (champion)",
@@ -3745,6 +3771,14 @@
           "magic": {
             "types": ["banner"],
             "maxPoints": 50
+          },
+          "notes": {
+            "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
+            "name_it": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
           }
         },
         {
@@ -3803,8 +3837,9 @@
           "notes": {
             "name_en": "0-1 per 1000 points",
             "name_cn": "每1000分0-1",
-            "name_fr": "0-1 par tranche de 1000 points",
-            "name_de": "0-1 pro 1.000 Punkte"
+            "name_de": "0-1 pro 1.000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
           }
         },
         {
@@ -3817,7 +3852,8 @@
           "notes": {
             "name_en": "0-1 per 1000 points",
             "name_cn": "每1000分0-1",
-            "name_de": "0-1 per 1.000 Punkte",
+            "name_de": "0-1 pro 1.000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
             "name_fr": "0-1 par tranche de 1000 points"
           }
         },
@@ -3842,6 +3878,7 @@
             "name_en": "0-1 Goblin Wolf Rider Mob if Kiknik is in the army",
             "name_cn": "0-1Goblin Wolf Rider Mob if Kiknik is in the army",
             "name_de": "0-1 Goblin Wolfsreiter-Mob, wenn Kiknik Teil der Armee ist",
+            "name_es": "0-1 Goblin Wolf Rider Mob if Kiknik is in the army",
             "name_fr": "0-1 Bande de Gobelins sur Loups si Kiknik est dans l’armée"
           }
         },
@@ -3873,7 +3910,7 @@
       "name_cn": "兽人战猪小子战帮",
       "name_de": "Ork-Wildschweinreiter-Mob",
       "name_fr": "Bande d’Orques sur Sangliers",
-      "id": "orc-boar-boy-mob",
+      "id": "orc-boar-boy-mob-core",
       "points": 15,
       "minimum": 4,
       "maximum": 0,
@@ -3881,10 +3918,10 @@
         "nomadic-waaagh": {
           "category": "core",
           "notes": {
-            "name_en": "0-1 Orc Boar Boy Mob may be taken as a Core choice if your General is an Orc Boss , 0-1 Orc Boar Boy Mob per 1000 points may purchase a magic standard worth up to 50 points",
-            "name_cn": "0-1 Orc Boar Boy Mob may be taken as a Core choice if your General is an Orc Boss, 0-1 Orc Boar Boy Mob per 1000 points may purchase a magic standard worth up to 50 points",
-            "name_de": "0-1 Ork-Wildschweinreiter-Mob können als Kernauswahl gewählt werden, wenn dein General ein Ork-Boss ist, 0-1 Ork-Wildschweinreiter-Mob pro 1.000 Punkte kann eine Magische Standarte erwerben im Wert von bis zu 50 Punkten",
-            "name_fr": "0-1 Bande d’Orques sur Sangliers peut être prise comme Unité de Base si votre Général est un Chef Orque , 0-1 Bande d’Orques sur Sangliers par tranche de 1000 points peut acheter une bannière magique pour une valeur maximale de 50 points"
+            "name_en": "0-1 Orc Boar Boy Mob may be taken as a Core choice if your General is an Orc Boss",
+            "name_cn": "0-1 Orc Boar Boy Mob may be taken as a Core choice if your General is an Orc Boss",
+            "name_de": "0-1 Ork-Wildschweinreiter-Mob können als Kernauswahl gewählt werden, wenn dein General ein Ork-Boss ist",
+            "name_fr": "0-1 Bande d’Orques sur Sangliers peut être prise comme Unité de Base si votre Général est un Chef Orque"
           }
         }
       },
@@ -3909,6 +3946,14 @@
           "magic": {
             "types": ["banner"],
             "maxPoints": 50
+          },
+          "notes": {
+            "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
+            "name_it": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
           }
         },
         {
@@ -3968,6 +4013,7 @@
             "name_en": "0-1 per 1000 points",
             "name_cn": "每1000分0-1",
             "name_de": "0-1 pro 1.000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
             "name_fr": "0-1 par tranche de 1000 points"
           }
         }
@@ -3992,8 +4038,9 @@
           "perModel": true,
           "notes": {
             "name_en": "0-1 per army",
-            "name_cn": "0-1per army",
+            "name_cn": "0-1 per army",
             "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
             "name_fr": "0-1 par armée"
           }
         },
@@ -4261,6 +4308,7 @@
             "name_en": "0-1 per army",
             "name_cn": "0-1 per army",
             "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
             "name_fr": "0-1 par armée"
           }
         },
@@ -4275,6 +4323,7 @@
             "name_en": "0-1 per army",
             "name_cn": "0-1 per army",
             "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
             "name_fr": "0-1 par armée"
           }
         },
@@ -4323,31 +4372,19 @@
       "maximum": 0,
       "armyComposition": {
         "orc-and-goblin-tribes": {
-          "category": "special",
-          "notes": {
-            "name_de": "0-1 Ork-Wildschweinreiter-Mob pro 1.000 Punkte können eine Magische Standarte im Wert von bis zu 50 Punkten erwerben",
-            "name_en": "0-1 Orc Boar Boy Mob per 1000 points may purchase a magic standard worth up to 50 points",
-            "name_cn": "0-1 Orc Boar Boy Mob per 1000 points may purchase a magic standard worth up to 50 points",
-            "name_fr": "0-1 Bande d’Orques sur Sangliers par tranche de 1000 points peut acheter une bannière magique pour une valeur maximale de 50 points"
-          }
+          "category": "special"
         },
         "troll-horde": {
           "category": "special",
           "notes": {
-            "name_en": "0-1 Orc Boar Boy Mob per 1000 points, 0-1 Orc Boar Boy Mob per 1000 points may purchase a magic standard worth up to 50 points",
-            "name_cn": "每1000分0-1兽人战猪小子战帮, 0-1 Orc Boar Boy Mob per 1000 points may purchase a magic standard worth up to 50 points",
-            "name_de": "0-1 0-1 Ork-Wildschweinreiter-Mob pro 1.000 Punkte, 0-1 Ork-Wildschweinreiter-Mob pro 1.000 Punkte können eine Magische Standarte im Wert von bis zu 50 Punkten erwerben",
-            "name_fr": "0-1 Bande d’Orques sur Sangliers par tranche de 1000 points, 0-1 Bande d’Orques sur Sangliers par tranche de 1000 points peut acheter une bannière magique pour une valeur maximale de 50 points"
+            "name_en": "0-1 Orc Boar Boy Mob per 1000 points",
+            "name_cn": "每1000分0-1兽人战猪小子战帮",
+            "name_de": "0-1 0-1 Ork-Wildschweinreiter-Mob pro 1.000 Punkte",
+            "name_fr": "0-1 Bande d’Orques sur Sangliers par tranche de 1000 points"
           }
         },
         "nomadic-waaagh": {
-          "category": "special",
-          "notes": {
-            "name_de": "0-1 Ork-Wildschweinreiter-Mob pro 1.000 Punkte können eine Magische Standarte im Wert von bis zu 50 Punkten erwerben",
-            "name_en": "0-1 Orc Boar Boy Mob per 1000 points may purchase a magic standard worth up to 50 points",
-            "name_cn": "0-1 Orc Boar Boy Mob per 1000 points may purchase a magic standard worth up to 50 points",
-            "name_fr": "0-1 Bande d’Orques sur Sangliers par tranche de 1000 points peut acheter une bannière magique pour une valeur maximale de 50 points"
-          }
+          "category": "special"
         }
       },
       "command": [
@@ -4371,6 +4408,14 @@
           "magic": {
             "types": ["banner"],
             "maxPoints": 50
+          },
+          "notes": {
+            "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
+            "name_it": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
           }
         },
         {
@@ -4430,6 +4475,7 @@
             "name_en": "0-1 per 1000 points",
             "name_cn": "每1000分0-1",
             "name_de": "0-1 pro 1.000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
             "name_fr": "0-1 par tranche de 1000 points"
           }
         }
@@ -4452,8 +4498,9 @@
           "perModel": true,
           "notes": {
             "name_en": "0-1 per army",
-            "name_cn": "0-1per army",
+            "name_cn": "0-1 per army",
             "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
             "name_fr": "0-1 par armée"
           }
         },
@@ -4643,9 +4690,10 @@
             },
             {
               "name_en": "0-1 per 1000 points",
-              "name_cn": "0-1 per 1000 points",
-              "name_fr": "0-1 par tranche de 1000 points",
-              "name_de": "0-1 pro 1.000 Punkte"
+              "name_cn": "每1000分0-1",
+              "name_de": "0-1 pro 1.000 Punkte",
+              "name_es": "0-1 por cada 1000 puntos",
+              "name_fr": "0-1 par tranche de 1000 points"
             }
           ]
         },
@@ -4664,9 +4712,10 @@
             },
             {
               "name_en": "0-1 per 1000 points",
-              "name_cn": "0-1 per 1000 points",
-              "name_fr": "0-1 par tranche de 1000 points",
-              "name_de": "0-1 pro 1.000 Punkte"
+              "name_cn": "每1000分0-1",
+              "name_de": "0-1 pro 1.000 Punkte",
+              "name_es": "0-1 por cada 1000 puntos",
+              "name_fr": "0-1 par tranche de 1000 points"
             }
           ]
         },
@@ -5346,7 +5395,7 @@
       "name_fr": "Char à Sangliers Orque Noir",
       "name_it": "Black Orc Boar Chariot",
       "name_pl": "Black Orc Boar Chariot",
-      "id": "black-orc-boar-chariot",
+      "id": "black-orc-boar-chariot-rare",
       "points": 130,
       "armyComposition": {
         "nomadic-waaagh": {

--- a/public/games/the-old-world/tomb-kings-of-khemri.json
+++ b/public/games/the-old-world/tomb-kings-of-khemri.json
@@ -1520,6 +1520,14 @@
           "magic": {
             "types": ["banner"],
             "maxPoints": 50
+          },
+          "notes": {
+            "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
+            "name_it": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
           }
         },
         {
@@ -1577,14 +1585,21 @@
           "maximum": 0
         },
         {
-          "name_en": "Nehekharan Phalanx (0-1 per 1000 points)",
-          "name_cn": "尼赫喀拉方阵(每1000分0-1)",
-          "name_it": "Falange di Nehekharan (una ogni 1000pti)",
-          "name_de": "Nehekharanische Phalanx (0-1 pro 1000 Punkte)",
-          "name_fr": "Phalange de Nehekhara (0-1 par tranche de 1000 points)",
+          "name_en": "Nehekharan Phalanx",
+          "name_cn": "尼赫喀拉方阵",
+          "name_it": "Falange di Nehekharan",
+          "name_de": "Nehekharanische Phalanx",
+          "name_fr": "Phalange de Nehekhara",
           "points": 10,
           "minimum": 0,
-          "maximum": 0
+          "maximum": 0,
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         }
       ],
       "mounts": [],
@@ -1734,7 +1749,7 @@
       "name_es": "Tomb Guard",
       "name_fr": "Gardien des Tombes",
       "name_it": "Guardia dei Sepolcri",
-      "id": "tomb-guard",
+      "id": "tomb-guard-core",
       "points": 10,
       "minimum": 5,
       "maximum": 0,
@@ -1813,26 +1828,40 @@
       ],
       "options": [
         {
-          "name_en": "Drilled (0-1 per 1000 points)",
-          "name_cn": "受训(每1000分0-1)",
-          "name_it": "Addestrato (una ogni 1000pti)",
-          "name_de": "Gut ausgebildet (0-1 pro 1000 Punkte)",
-          "name_fr": "Bien Entraînés (0-1 par tranche de 1000 points)",
+          "name_en": "Drilled",
+          "name_cn": "受训",
+          "name_it": "Addestrato",
+          "name_de": "Gut ausgebildet",
+          "name_fr": "Bien Entraînés",
           "points": 1,
           "perModel": true,
           "minimum": 0,
-          "maximum": 0
+          "maximum": 0,
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         },
         {
-          "name_en": "Nehekharan Phalanx (0-1 per 1000 points)",
-          "name_cn": "尼赫喀拉方阵(每1000分0-1)",
-          "name_it": "Falange di Nehekharan (una ogni 1000 points)",
-          "name_de": "Nehekharanische Phalanx (0-1 pro 1000 Punkte)",
-          "name_fr": "Phalange de Nehekhara (0-1 par tranche de 1000 points)",
+          "name_en": "Nehekharan Phalanx",
+          "name_cn": "尼赫喀拉方阵",
+          "name_it": "Falange di Nehekharan",
+          "name_de": "Nehekharanische Phalanx",
+          "name_fr": "Phalange de Nehekhara",
           "points": 1,
           "perModel": true,
           "minimum": 0,
-          "maximum": 0
+          "maximum": 0,
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         }
       ],
       "mounts": [],
@@ -1864,7 +1893,7 @@
             "name_en": "0-1 unit of Tomb Guard or Tomb Guard Chariots may be taken as a Core choice",
             "name_cn": "0-1个单位的古墓守卫或古墓守卫战车可作为核心选择",
             "name_de": "0-1 Einheit Gruftwächter oder Streitwagen der Gruftwächter darf als Kernauswahl gewählt werden",
-            "name_es": "",
+            "name_es": "0-1 unit of Tomb Guard or Tomb Guard Chariots may be taken as a Core choice",
             "name_fr": "0-1 unité de Gardien des Tombes ou Chars Gardien des Tombes peut être prise comme choix d’Unité de Base",
             "name_it": "0-1 unità di Guardia dei Sepolcri o Carri della Guardia dei Sepolcri possono essere scelte come Truppa"
           }
@@ -1878,7 +1907,7 @@
       "name_es": "Sepulchral Stalkers",
       "name_fr": "Rôdeurs Sépulcraux",
       "name_it": "Cacciatore dei Sepolcri",
-      "id": "sepulchral-stalkers",
+      "id": "sepulchral-stalkers-core",
       "points": 52,
       "minimum": 2,
       "maximum": 0,
@@ -1917,7 +1946,14 @@
           "points": 2,
           "perModel": true,
           "minimum": 0,
-          "maximum": 1
+          "maximum": 1,
+          "notes": {
+            "name_en": "0-1 per army",
+            "name_cn": "0-1 per army",
+            "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
+            "name_fr": "0-1 par armée"
+          }
         }
       ],
       "mounts": [],
@@ -2000,7 +2036,14 @@
           "points": 1,
           "perModel": true,
           "minimum": 0,
-          "maximum": 0
+          "maximum": 0,
+          "notes": {
+            "name_en": "0-1 per army",
+            "name_cn": "0-1 per army",
+            "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
+            "name_fr": "0-1 par armée"
+          }
         },
         {
           "name_en": "Ambushers",
@@ -2268,10 +2311,11 @@
           },
           "notes": {
             "name_en": "0-1 unit per 1000 points may purchase a magic standard",
-            "name_cn": "每1000分，0-1个单位可以购买一面魔法战旗",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
             "name_it": "0-1 unit per 1000 points may purchase a magic standard",
             "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
-            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique"
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
           }
         },
         {
@@ -2813,7 +2857,7 @@
       "name_de": "Streitwagen der Gruftwächter",
       "name_es": "Tomb Guard Chariots",
       "name_fr": "Chars Gardien des Tombes",
-      "id": "tomb-guard-chariots",
+      "id": "tomb-guard-chariots-core",
       "points": 49,
       "minimum": 3,
       "maximum": 0,
@@ -2886,7 +2930,7 @@
             "name_en": "0-1 unit of Tomb Guard or Tomb Guard Chariots may be taken as a Core choice",
             "name_cn": "0-1个单位的古墓守卫或古墓守卫战车可作为核心选择",
             "name_de": "0-1 Einheit Gruftwächter oder Streitwagen der Gruftwächter können als Kernauswahl gewählt werden",
-            "name_es": "",
+            "name_es": "0-1 unit of Tomb Guard or Tomb Guard Chariots may be taken as a Core choice",
             "name_fr": "0-1 unité de Gardien des Tombes ou Chars Gardien des Tombes peut être prise comme choix d’Unité de Base",
             "name_it": "0-1 unità di Guardia dei Sepolci 0 Carri della Guardia del Sepolcro può essere presa come scelta di Truppa"
           }
@@ -3591,7 +3635,14 @@
           "points": 2,
           "perModel": true,
           "minimum": 0,
-          "maximum": 0
+          "maximum": 0,
+          "notes": {
+            "name_en": "0-1 per army",
+            "name_cn": "0-1 per army",
+            "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
+            "name_fr": "0-1 par armée"
+          }
         }
       ],
       "mounts": [],

--- a/public/games/the-old-world/warriors-of-chaos.json
+++ b/public/games/the-old-world/warriors-of-chaos.json
@@ -3175,10 +3175,11 @@
           },
           "notes": {
             "name_en": "0-1 unit per 1000 points may purchase a magic standard",
-            "name_cn": "每1000分，0-1个单位可以购买一面魔法战旗",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
             "name_it": "0-1 unit per 1000 points may purchase a magic standard",
             "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
-            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique"
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
           },
           "points": 5
         },
@@ -3476,10 +3477,11 @@
           },
           "notes": {
             "name_en": "0-1 unit per 1000 points may purchase a magic standard",
-            "name_cn": "每1000分，0-1个单位可以购买一面魔法战旗",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
             "name_it": "0-1 unit per 1000 points may purchase a magic standard",
             "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
-            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique"
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
           },
           "points": 5
         },


### PR DESCRIPTION
I did a pass through Ravening Hordes with an eye to options with limitations, like "0-1 per army" or "0-1 per 1000 points" and found a fair number of gaps in our rules. I also moved "0-1 units per 1000 can have magic standards" from unit notes to command option notes for orcs and goblins. There were quite a few misses in the Beastmen, unfortunately. I tried to get all of them but I'm less familiar with them.

This is some prep work for attempting to add some validation for army/points limited options. Hopefully I can tackle that next, unless you had plans in that direction.