### PR TITLE
Fix CI: add yarn resolutions for vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
     "deploy": "gh-pages -d build",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject --org booky --project old-world-builder ./build && sentry-cli sourcemaps upload --org booky --project old-world-builder ./build"
   },
+  "resolutions": {
+    "vite": "^7.3.1"
+  },
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
## Summary
- Yarn v1 fails at the linking step because it can't resolve `vite` into `vitest/node_modules` — the `rolldown` WASM bindings confuse yarn's hoisting algorithm
- Adding a `resolutions` entry forces yarn to use a single copy of `vite`, fixing the install

## Test plan
- [ ] CI passes on this PR (currently all PRs fail at `yarn install`)