### PR TITLE
Change "<25%" to "≤25%" in game view

### DIFF
--- a/src/pages/game-view/GameView.jsx
+++ b/src/pages/game-view/GameView.jsx
@@ -576,7 +576,7 @@ export const GameView = () => {
           spaceTop
           onClick={() => updateVictoryPoints({ unit, value: "25" })}
         >
-          {"<25%"}
+          {"≤25%"}
         </Button>
         {unit.detachments &&
           !unit.ignoreNoDetachment &&


### PR DESCRIPTION
The rule now states that a unit reduced to 25% or less of its original size contributes victory points, where as originally it was less than 25%.