### PR TITLE
Fixes and standardizations for Forces of Fantasy armies

### DIFF
--- a/public/games/the-old-world/dwarfen-mountain-holds.json
+++ b/public/games/the-old-world/dwarfen-mountain-holds.json
@@ -1429,13 +1429,6 @@
       "points": 8,
       "minimum": 5,
       "maximum": 0,
-      "notes": {
-        "name_de": "0-1 Einheit Zwergenkrieger pro 1000 Punkte kann Standartenrunen erwerben",
-        "name_en": "0-1 unit of Dwarf Warriors per 1000 points may purchase Standard runes",
-        "name_cn": "每1000分0-1个单位的矮人勇士可以购买标准符文",
-        "name_fr": "0-1 unité de Guerriers Nains par tranche de 1000 points peut acheter des runes de Bannière",
-        "name_it": "0-1 unità di Nani Guerrieri ogni 1000 punti può avere Rune di Stendardo"
-      },
       "command": [
         {
           "name_en": "Veteran (champion)",
@@ -1466,6 +1459,14 @@
                 "maxPoints": 75
               }
             }
+          },
+          "notes": {
+            "name_de": "0-1 Einheit Zwergenkrieger pro 1000 Punkte kann Standartenrunen erwerben",
+            "name_en": "0-1 unit of Dwarf Warriors per 1000 points may purchase Standard runes",
+            "name_cn": "每1000分0-1个单位的矮人勇士可以购买标准符文",
+            "name_fr": "0-1 unité de Guerriers Nains par tranche de 1000 points peut acheter des runes de Bannière",
+            "name_it": "0-1 unità di Nani Guerrieri ogni 1000 punti può avere Rune di Stendardo",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
           }
         },
         {
@@ -1720,7 +1721,7 @@
       "name_it": "Barbalunga",
       "name_de": "Langbärte",
       "name_fr": "Longues-barbes",
-      "id": "long-beards",
+      "id": "long-beards-core",
       "points": 12,
       "minimum": 5,
       "maximum": 0,
@@ -2105,6 +2106,7 @@
             "name_de": "0-1 Einheit Musketenschützen pro 1.000 Punkte",
             "name_en": "0-1 unit per 1000 points",
             "name_cn": "每1000分0-1单位",
+            "name_es": "0-1 por cada 1000 puntos",
             "name_fr": "0-1 unité par tranche de 1000 points"
           }
         }
@@ -2742,13 +2744,6 @@
       "points": 15,
       "minimum": 5,
       "maximum": 0,
-      "notes": {
-        "name_de": "0-1 Einheit Eisenbrecher pro 1000 Punkte kann Standartenrunen erwerben",
-        "name_en": "0-1 unit of Ironbreakers per 1000 points may purchase Standard runes",
-        "name_cn": "0-1个单位的Ironbreakers per 1000 points may purchase Standard runes",
-        "name_fr": "0-1 unité de Brise-fer par tranche de 1000 points peut acheter des runes de Bannière",
-        "name_it": "0-1 unità di Spaccaferro ogni 1000 punti può avere Rune di Stendardo"
-      },
       "command": [
         {
           "name_en": "Ironbeard (champion)",
@@ -2817,6 +2812,14 @@
                 "maxPoints": 75
               }
             }
+          },
+          "notes": {
+            "name_de": "0-1 Einheit Eisenbrecher pro 1000 Punkte kann Standartenrunen erwerben",
+            "name_en": "0-1 unit of Ironbreakers per 1000 points may purchase Standard runes",
+            "name_cn": "0-1个单位的Ironbreakers per 1000 points may purchase Standard runes",
+            "name_fr": "0-1 unité de Brise-fer par tranche de 1000 points peut acheter des runes de Bannière",
+            "name_it": "0-1 unità di Spaccaferro ogni 1000 punti può avere Rune di Stendardo",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
           }
         },
         {
@@ -2933,6 +2936,14 @@
                 "maxPoints": 50
               }
             }
+          },
+          "notes": {
+            "name_de": "0-1 Einheit Bergwerker pro 1000 Punkte kann Standartenrunen erwerben",
+            "name_en": "0-1 unit of Miners per 1000 points may purchase Standard runes",
+            "name_cn": "0-1个单位的Miners per 1000 points may purchase Standard runes",
+            "name_fr": "0-1 unité de Mineurs par tranche de 1000 points peut acheter des runes de Bannière",
+            "name_it": "0-1 unità di Minatori ogni 1000 punti può avere Rune di Stendardo",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
           }
         },
         {
@@ -3028,13 +3039,6 @@
         "name_de": "Überfall, Geschlossene Ränge, Hass (Orks & Goblins), Magieresistenz (-1), Resolut, Vorhut",
         "name_es": "Ambushers, Close Order, Hatred (Orcs & Goblins), Magic Resistance (-1), Resolute, Vanguard",
         "name_fr": "Embusqueurs, Ordre Serré, Haine (Orques & Gobelins), Résistance à la Magie (-1), Résolu, Avant-garde"
-      },
-      "notes": {
-        "name_de": "0-1 Einheit Bergwerker pro 1000 Punkte kann Standartenrunen erwerben",
-        "name_en": "0-1 unit of Miners per 1000 points may purchase Standard runes",
-        "name_cn": "0-1个单位的Miners per 1000 points may purchase Standard runes",
-        "name_fr": "0-1 unité de Mineurs par tranche de 1000 points peut acheter des runes de Bannière",
-        "name_it": "0-1 unità di Minatori ogni 1000 punti può avere Rune di Stendardo"
       },
       "armyComposition": {
         "dwarfen-mountain-holds": {
@@ -4027,6 +4031,14 @@
                 "maxPoints": 75
               }
             }
+          },
+          "notes": {
+            "name_de": "0-1 Einheit Eisendrachen pro 1000 Punkte kann Standartenrunen erwerben",
+            "name_en": "0-1 unit of Irondrakes per 1000 points may purchase Standard runes",
+            "name_cn": "0-1个单位的Irondrakes per 1000 points may purchase Standard runes",
+            "name_fr": "0-1 unité de Dracs de Fer par tranche de 1000 points peut acheter des runes de Bannière",
+            "name_it": "0-1 unità di Draghi di Ferro ogni 1000 punti può avere Rune di Stendardo",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
           }
         },
         {
@@ -4096,13 +4108,6 @@
         "name_de": "Geschlossene Ränge, Abteilung, Gromrilrüstung, Hass (Orks & Goblins), Magieresistenz (-1), Resolut, Schirmrunen, Unnachgiebig",
         "name_es": "Close Order, Detachment, Gromril Armour, Hatred (Orcs & Goblins), Magic Resistance (-1), Resolute, Runes of Warding, Stubborn",
         "name_fr": "Ordre Serré, Détachement, Armure en Gromril, Haine (Orques & Gobelins), Résistance à la Magie (-1), Résolu, Runes de Sauvegarde, Obstiné"
-      },
-      "notes": {
-        "name_de": "0-1 Einheit Eisendrachen pro 1000 Punkte kann Standartenrunen erwerben",
-        "name_en": "0-1 unit of Irondrakes per 1000 points may purchase Standard runes",
-        "name_cn": "0-1个单位的Irondrakes per 1000 points may purchase Standard runes",
-        "name_fr": "0-1 unité de Dracs de Fer par tranche de 1000 points peut acheter des runes de Bannière",
-        "name_it": "0-1 unità di Draghi di Ferro ogni 1000 punti può avere Rune di Stendardo"
       },
       "armyComposition": {
         "dwarfen-mountain-holds": {

--- a/public/games/the-old-world/empire-of-man.json
+++ b/public/games/the-old-world/empire-of-man.json
@@ -4143,6 +4143,14 @@
           "magic": {
             "types": ["banner"],
             "maxPoints": 25
+          },
+          "notes": {
+            "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
+            "name_it": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
           }
         },
         {
@@ -4196,7 +4204,14 @@
           "points": 1,
           "perModel": true,
           "minimum": 0,
-          "maximum": 0
+          "maximum": 0,
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         },
         {
           "name_en": "Detachment",
@@ -5628,6 +5643,14 @@
           "magic": {
             "types": ["banner"],
             "maxPoints": 50
+          },
+          "notes": {
+            "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
+            "name_it": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
           }
         },
         {
@@ -5673,7 +5696,14 @@
           "points": 2,
           "perModel": true,
           "minimum": 0,
-          "maximum": 0
+          "maximum": 0,
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         },
         {
           "name_en": "Veteran",
@@ -5684,7 +5714,14 @@
           "points": 1,
           "perModel": true,
           "minimum": 0,
-          "maximum": 0
+          "maximum": 0,
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         }
       ],
       "mounts": [],
@@ -5935,7 +5972,14 @@
           "name_fr": "Avant-garde",
           "name_es": "Vanguardia",
           "points": 2,
-          "perModel": true
+          "perModel": true,
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         }
       ],
       "mounts": [],

--- a/public/games/the-old-world/high-elf-realms.json
+++ b/public/games/the-old-world/high-elf-realms.json
@@ -1918,9 +1918,16 @@
           "name_it": "Corno di Isha",
           "name_de": "Horn der Isha",
           "name_es": "Cuerno de Isha",
+          "name_fr": "Cor d’Isha",
           "points": 25,
           "perModel": true,
-          "name_fr": "Cor d’Isha"
+          "notes": {
+            "name_en": "0-1 per army",
+            "name_cn": "0-1 per army",
+            "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
+            "name_fr": "0-1 par armée"
+          }
         }
       ],
       "mounts": [],
@@ -2605,12 +2612,20 @@
           "name_it": "Alfiere",
           "name_de": "Standartenträger",
           "name_es": "Portaestandarte",
+          "name_fr": "Porte-étendard",
           "points": 5,
           "magic": {
             "types": ["banner"],
             "maxPoints": 50
           },
-          "name_fr": "Porte-étendard"
+          "notes": {
+            "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
+            "name_it": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
+          }
         },
         {
           "name_en": "Musician",
@@ -2672,9 +2687,16 @@
           "name_it": "Veterani",
           "name_de": "Veteranen",
           "name_es": "Veteranos",
+          "name_fr": "Vétérans",
           "points": 1,
           "perModel": true,
-          "name_fr": "Vétérans"
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         },
         {
           "name_en": "Move Through Cover",
@@ -2687,10 +2709,11 @@
           "perModel": true,
           "armyComposition": "the-chracian-warhost",
           "notes": {
-            "name_en": "0-1 unit per 1000 points",
-            "name_cn": "每1000分0-1单位",
-            "name_fr": "0-1 unité par tranche de 1000 points",
-            "name_de": "0-1 Einheit pro 1.000 Punkte"
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
           }
         },
         {
@@ -2751,12 +2774,20 @@
           "name_it": "Alfiere",
           "name_de": "Standartenträger",
           "name_es": "Portaestandarte",
+          "name_fr": "Porte-étendard",
           "points": 5,
           "magic": {
             "types": ["banner"],
             "maxPoints": 25
           },
-          "name_fr": "Porte-étendard"
+          "notes": {
+            "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
+            "name_it": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
+          }
         },
         {
           "name_en": "Musician",
@@ -2799,9 +2830,16 @@
           "name_it": "Veterani",
           "name_de": "Veteranen",
           "name_es": "Veteranos",
+          "name_fr": "Vétérans",
           "points": 1,
           "perModel": true,
-          "name_fr": "Vétérans"
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         },
         {
           "name_en": "Detachment",
@@ -2823,10 +2861,11 @@
           "perModel": true,
           "armyComposition": "the-chracian-warhost",
           "notes": {
-            "name_en": "0-1 unit per 1000 points",
-            "name_cn": "每1000分0-1单位",
-            "name_fr": "0-1 unité par tranche de 1000 points",
-            "name_de": "0-1 Einheit pro 1.000 Punkte"
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
           }
         },
         {
@@ -2890,12 +2929,20 @@
           "name_it": "Alfiere",
           "name_de": "Standartenträger",
           "name_es": "Portaestandarte",
+          "name_fr": "Porte-étendard",
           "points": 5,
           "magic": {
             "types": ["banner"],
             "maxPoints": 50
           },
-          "name_fr": "Porte-étendard"
+          "notes": {
+            "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
+            "name_it": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
+          }
         },
         {
           "name_en": "Musician",
@@ -2950,7 +2997,14 @@
           "name_es": "Veteranos",
           "name_fr": "Vétérans",
           "points": 1,
-          "perModel": true
+          "perModel": true,
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         },
         {
           "name_en": "Drilled",
@@ -2962,10 +3016,11 @@
           "points": 0,
           "armyComposition": "sea-guard-garrison",
           "notes": {
-            "name_en": "0-1 unit per 1000 points",
-            "name_cn": "每1000分0-1单位",
-            "name_fr": "0-1 unité par tranche de 1000 points",
-            "name_de": "0-1 Einheit pro 1.000 Punkte"
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
           }
         }
       ],
@@ -3018,12 +3073,20 @@
           "name_it": "Alfiere",
           "name_de": "Standartenträger",
           "name_es": "Portaestandarte",
+          "name_fr": "Porte-étendard",
           "points": 6,
           "magic": {
             "types": ["banner"],
             "maxPoints": 25
           },
-          "name_fr": "Porte-étendard"
+          "notes": {
+            "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
+            "name_it": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
+          }
         },
         {
           "name_en": "Musician",
@@ -3077,9 +3140,9 @@
           "name_it": "Archi Corti",
           "name_de": "Kurzbögen",
           "name_es": "Arcos cortos",
+          "name_fr": "Arcs courts",
           "points": 2,
-          "perModel": true,
-          "name_fr": "Arcs courts"
+          "perModel": true
         },
         {
           "name_en": "Scouts",
@@ -3087,9 +3150,16 @@
           "name_it": "Esploratori",
           "name_de": "Kundschafter",
           "name_es": "Exploradores",
+          "name_fr": "Éclaireurs",
           "points": 2,
           "perModel": true,
-          "name_fr": "Éclaireurs"
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         },
         {
           "name_en": "Skirmishers",
@@ -3099,7 +3169,14 @@
           "name_fr": "Tirailleurs",
           "name_es": "Escaramuzadores",
           "points": 1,
-          "perModel": true
+          "perModel": true,
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         }
       ],
       "mounts": [],
@@ -3285,12 +3362,11 @@
           "points": 1,
           "perModel": true,
           "notes": {
-            "name_en": "0-1 unit",
-            "name_cn": "0-1单位",
-            "name_fr": "0-1 unité",
-            "name_es": "0-1 unidad",
-            "name_de": "0-1 Einheit",
-            "name_it": "0-1 unit"
+            "name_en": "0-1 per army",
+            "name_cn": "0-1 per army",
+            "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
+            "name_fr": "0-1 par armée"
           }
         },
         {
@@ -3303,12 +3379,11 @@
           "points": 1,
           "perModel": true,
           "notes": {
-            "name_en": "0-1 unit",
-            "name_cn": "0-1单位",
-            "name_fr": "0-1 unité",
-            "name_es": "0-1 unidad",
-            "name_de": "0-1 Einheit",
-            "name_it": "0-1 unit"
+            "name_en": "0-1 per army",
+            "name_cn": "0-1 per army",
+            "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
+            "name_fr": "0-1 par armée"
           }
         }
       ],
@@ -4205,10 +4280,11 @@
           "points": 1,
           "perModel": true,
           "notes": {
-            "name_en": "0-1 unit",
-            "name_cn": "0-1单位",
-            "name_fr": "0-1 unité",
-            "name_de": "0-1 Einheit"
+            "name_en": "0-1 per army",
+            "name_cn": "0-1 per army",
+            "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
+            "name_fr": "0-1 par armée"
           }
         },
         {
@@ -4221,10 +4297,11 @@
           "points": 1,
           "perModel": true,
           "notes": {
-            "name_en": "0-1 unit",
-            "name_cn": "0-1单位",
-            "name_fr": "0-1 unité",
-            "name_de": "0-1 Einheit"
+            "name_en": "0-1 per army",
+            "name_cn": "0-1 per army",
+            "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
+            "name_fr": "0-1 par armée"
           }
         },
         {
@@ -4237,10 +4314,11 @@
           "points": 1,
           "perModel": true,
           "notes": {
-            "name_en": "0-1 unit",
-            "name_cn": "0-1单位",
-            "name_fr": "0-1 unité",
-            "name_de": "0-1 Einheit"
+            "name_en": "0-1 per army",
+            "name_cn": "0-1 per army",
+            "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
+            "name_fr": "0-1 par armée"
           }
         },
         {
@@ -4254,10 +4332,11 @@
           "perModel": true,
           "armyComposition": "sea-guard-garrison",
           "notes": {
-            "name_en": "0-1 unit",
-            "name_cn": "0-1单位",
-            "name_fr": "0-1 unité",
-            "name_de": "0-1 Einheit"
+            "name_en": "0-1 per army",
+            "name_cn": "0-1 per army",
+            "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
+            "name_fr": "0-1 par armée"
           }
         }
       ],
@@ -4572,12 +4651,11 @@
           "points": 1,
           "perModel": true,
           "notes": {
-            "name_en": "0-1 unit",
-            "name_cn": "0-1单位",
-            "name_fr": "0-1 unité",
-            "name_es": "0-1 unidad",
-            "name_de": "0-1 Einheit",
-            "name_it": "0-1 unit"
+            "name_en": "0-1 per army",
+            "name_cn": "0-1 per army",
+            "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
+            "name_fr": "0-1 par armée"
           }
         },
         {
@@ -4590,12 +4668,11 @@
           "points": 1,
           "perModel": true,
           "notes": {
-            "name_en": "0-1 unit",
-            "name_cn": "0-1单位",
-            "name_fr": "0-1 unité",
-            "name_es": "0-1 unidad",
-            "name_de": "0-1 Einheit",
-            "name_it": "0-1 unit"
+            "name_en": "0-1 per army",
+            "name_cn": "0-1 per army",
+            "name_de": "0-1 pro Armee",
+            "name_es": "0-1 per army",
+            "name_fr": "0-1 par armée"
           }
         }
       ],

--- a/public/games/the-old-world/wood-elf-realms.json
+++ b/public/games/the-old-world/wood-elf-realms.json
@@ -1659,6 +1659,14 @@
           "magic": {
             "types": ["banner"],
             "maxPoints": 50
+          },
+          "notes": {
+            "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_cn": "0-1单位/每1000分可以选择装备一个魔法战旗",
+            "name_it": "0-1 unit per 1000 points may purchase a magic standard",
+            "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
+            "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
+            "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
           }
         },
         {
@@ -1694,7 +1702,14 @@
           "name_es": "Disparar y Huir",
           "name_pl": "Strzał i Ucieczka",
           "points": 1,
-          "perModel": true
+          "perModel": true,
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         },
         {
           "name_en": "Vanguard",
@@ -1704,7 +1719,14 @@
           "name_es": "Vanguardia",
           "name_pl": "Awangarda",
           "points": 1,
-          "perModel": true
+          "perModel": true,
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         },
         {
           "name_en": "Arcane Bodkins",
@@ -2015,7 +2037,14 @@
           "name_es": "Entrenados",
           "name_pl": "Wymusztrowani",
           "points": 1,
-          "perModel": true
+          "perModel": true,
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         },
         {
           "name_en": "Veteran",
@@ -2025,7 +2054,14 @@
           "name_es": "Veteranos",
           "name_pl": "Weterani",
           "points": 1,
-          "perModel": true
+          "perModel": true,
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         }
       ],
       "mounts": [],
@@ -3362,7 +3398,14 @@
           "name_es": "Emboscadores",
           "name_pl": "Zasadzka",
           "points": 1,
-          "perModel": true
+          "perModel": true,
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         },
         {
           "name_en": "Vanguard",
@@ -3372,7 +3415,14 @@
           "name_es": "Vanguardia",
           "name_pl": "Awangarda",
           "points": 1,
-          "perModel": true
+          "perModel": true,
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         },
         {
           "name_en": "Veteran",
@@ -3382,7 +3432,14 @@
           "name_es": "Veteranos",
           "name_pl": "Weterani",
           "points": 1,
-          "perModel": true
+          "perModel": true,
+          "notes": {
+            "name_en": "0-1 per 1000 points",
+            "name_cn": "每1000分0-1",
+            "name_de": "0-1 pro 1000 Punkte",
+            "name_es": "0-1 por cada 1000 puntos",
+            "name_fr": "0-1 par tranche de 1000 points"
+          }
         },
         {
           "name_en": "Arcane Bodkins",


### PR DESCRIPTION
Similar to my PR for the Ravening Hordes armies, this is a pass through to find and mark the various "0-1 per army" or "0-1 per 1000 points" options that were not correctly noted. Some armies like Dwarfs were better marked out than others. Again, this is is in preparation for actual validation checks for these options.