### PR TITLE
Export share: pass data to canShare and ignore AbortError

### DIFF
--- a/src/pages/export/Export.jsx
+++ b/src/pages/export/Export.jsx
@@ -65,20 +65,17 @@ export const Export = ({ isMobile }) => {
     listText,
     asText: true,
   });
-  const share = async ({ asText }) => {
-    const shareData = {};
-
+  const share = async ({ asText } = {}) => {
     asText ? setShareError(false) : setOwbShareError(false);
 
-    if (asText) {
-      shareData.text = listText;
-    } else {
-      shareData.title = list.name;
-      shareData.files = [file];
-      shareData.text = list.description;
-    }
+    const shareData = asText
+      ? { text: listText }
+      : { title: list.name, text: list.description, files: [file] };
 
-    if (!navigator.canShare) {
+    // navigator.canShare(data) — without the argument this only checks the
+    // API exists, not whether the browser can share THIS data (file shares
+    // fail this check on some browsers).
+    if (!navigator.canShare?.(shareData)) {
       asText ? setShareError(true) : setOwbShareError(true);
       return;
     }
@@ -86,6 +83,8 @@ export const Export = ({ isMobile }) => {
     try {
       await navigator.share(shareData);
     } catch (error) {
+      // AbortError = user dismissed the system share sheet, not a failure.
+      if (error?.name === "AbortError") return;
       asText ? setShareError(true) : setOwbShareError(true);
     }
   };


### PR DESCRIPTION
## Summary
- `navigator.canShare` is now called with `shareData` so the gate actually reflects whether the browser can share what we're about to send (file shares were passing the existence check then failing in `navigator.share()`).
- `AbortError` from `navigator.share()` (user dismissed the system share sheet) is now ignored instead of being shown as a share failure.

Fixes #433.

## Test plan
- [x] Desktop Chrome (no file-share support): clicking the OWB share button now shows the share-error message immediately rather than failing silently.
- [ ] Mobile / supporting browser: share sheet opens; dismissing it no longer flashes the "did not work" message; completing the share works as before.
- [x] Text share path still works on supporting browsers.