### PR TITLE
Ignore .env.* and .claude/ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ yarn-error.log*
 
 # Sentry Config File
 .env.sentry-build-plugin
+
+# local env files
+.env.*
+
+# AI assistant settings
+.claude/


### PR DESCRIPTION
## Summary
- Adds `.env.*` so locally-overridden env files (e.g. `.env.development`) don't get accidentally committed.
- Adds `.claude/` for contributors using Claude Code so its per-project settings/cache stay local.

## Test plan
- [ ] `git status` no longer surfaces `.env.development` or a `.claude/` directory if either exists locally.