### PR TITLE
Add note about Arcane Item usage for High Elf Princes and Nobles

### DIFF
--- a/public/games/the-old-world/high-elf-realms.json
+++ b/public/games/the-old-world/high-elf-realms.json
@@ -448,6 +448,7 @@
           "name_it": "Oggetti Magici",
           "name_de": "Magische Gegenstände",
           "name_es": "Objetos mágicos",
+          "name_fr": "Objets Magiques",
           "types": [
             "weapon",
             "armor",
@@ -457,7 +458,14 @@
           ],
           "selected": [],
           "maxPoints": 100,
-          "name_fr": "Objets Magiques"
+          "notes": {
+            "name_en": "Arcane Items require the Loremaster Elven Honour",
+            "name_cn": "Arcane Items require the Loremaster Elven Honour",
+            "name_it": "Arcane Items require the Loremaster Elven Honour",
+            "name_de": "Arcane Items require the Loremaster Elven Honour",
+            "name_es": "Arcane Items require the Loremaster Elven Honour",
+            "name_fr": "Arcane Items require the Loremaster Elven Honour"
+          }
         },
         {
           "name_en": "Elven Honours",
@@ -465,10 +473,10 @@
           "name_it": "Onoroficenze Elfiche",
           "name_de": "Elfenehrungen",
           "name_es": "Honores élficos",
+          "name_fr": "Honneurs Elfiques",
           "types": ["elven-honour"],
           "selected": [],
-          "maxPoints": 0,
-          "name_fr": "Honneurs Elfiques"
+          "maxPoints": 0
         }
       ],
       "specialRules": {
@@ -952,7 +960,15 @@
             "arcane-item"
           ],
           "selected": [],
-          "maxPoints": 50
+          "maxPoints": 50,
+          "notes": {
+            "name_en": "Arcane Items require the Loremaster Elven Honour",
+            "name_cn": "Arcane Items require the Loremaster Elven Honour",
+            "name_it": "Arcane Items require the Loremaster Elven Honour",
+            "name_de": "Arcane Items require the Loremaster Elven Honour",
+            "name_es": "Arcane Items require the Loremaster Elven Honour",
+            "name_fr": "Arcane Items require the Loremaster Elven Honour"
+          }
         },
         {
           "name_en": "Elven Honours",


### PR DESCRIPTION
A little clarification about when Arcane Items can be taken by High Elf Lords.
<img width="406" height="250" alt="image" src="https://github.com/user-attachments/assets/e25b64ca-8817-4d05-82c2-9b825c170fdb" />
