### PR TITLE
Option restrictions

### DIFF
--- a/docs/option-restrictions-rules.md
+++ b/docs/option-restrictions-rules.md
@@ -1,0 +1,105 @@
+# Adding checks for restrictions on options
+Many units have options with restrictions on how many units in an army may take them. For example, only one unit of Orc Boys can have Big 'Uns, and only one per 1000 points can have Frenzy.
+
+Restricted options must have a unique `id` parameter. This is used to find other instances of the same option on other units. If multiple units share the same restriction, for example "0-1 units of Jade Warriors or 0-1 unit of Jade Lancers can be upgraded", make sure the option has the same `id` for both units.
+
+### 1 per army
+"0-1 unit in your army may have the Big 'Uns special rule."
+```
+{
+  "id": "orc-mob-big-uns",
+  "name_en": "Big 'Uns",
+  "points": 2,
+  "perModel": true,
+  "notes": {
+    "name_en": "0-1 per army"
+  }
+  "restrictions": {
+    "max": 1
+  }
+}
+```
+
+### Up to 1 per 1000 points
+"0-1 unit per 1,000 points may have the Frenzy special rule."
+```
+{
+  "id": "orc-mob-frenzy",
+  "name_en": "Frenzy",
+  "points": 1,
+  "perModel": true,
+  "notes": {
+    "name_en": "0-1 per 1000 points"
+  }
+  "restrictions": {
+    "max": 1,
+    "perArmyPoints": 1000
+  }
+}
+```
+
+### Command magic items per 1000 points
+"0-1 unit per 1,000 points may purchase a magic standard worth up to 50 points."
+```
+{
+  "id": "orc-mob-standard-bearer",
+  "name_en": "Standard bearer",
+  "points": 5,
+  "magic": {
+    "types": ["banner"],
+    "maxPoints": 50
+  },
+  "notes": {
+    "name_en": "0-1 unit per 1000 points may purchase a magic standard",
+  },
+  "restrictions": {
+    "subOption": "magic",
+    "max": 1,
+    "perArmyPoints": 1000
+  }
+}
+```
+
+### Requires a character
+"0-1 unit in the same muster list as Kiknik may have the Ambushers special rule for free."
+```
+{
+  "id": "wolf-rider-kiknik-ambushers",
+  "name_en": "Ambushers",
+  "points": 0,
+  "perModel": true,
+  "notes": {
+    "name_en": "0-1 Goblin Wolf Rider Mob if Kiknik is in the army",
+  },
+  "restrictions": {
+    "requires": {
+      "unitIds": ["kiknik-toofsnatcha"],
+      "types": "characters"
+    },
+    "max": 1
+  }
+}
+```
+
+### Requires a character with a specific option per choice
+"For each character in your army that has the Renegade Knight Infamous Origin, 0-1 unit of Freeblade Knights or Veteran Freeblade Knights may have the Lance Formation and the Noble Disdain special rules for +2 points."
+```
+{
+  "id": "freeblade-lance-noble-disdain",
+  "name_en": "Lance Formation, Noble Disdain",
+  "points": 2,
+  "perModel": true,
+  "notes": {
+    "name_en": "0-1 unit for each character with the Renegade Knight Infamous Origin",
+  },
+  "restrictions": {
+    "requires": {
+      "unitIds": ["renegade-prince", "renegade-captain", "outcast-wizard"],
+      "option": "renegade-knight",
+      "perUnit": true,
+      "types": "characters"
+    },
+    "max": 1
+  }
+}
+```

--- a/docs/option-restrictions-rules.md
+++ b/docs/option-restrictions-rules.md
@@ -13,7 +13,7 @@ Restricted options must have a unique `id` parameter. This is used to find other
   "perModel": true,
   "notes": {
     "name_en": "0-1 per army"
-  }
+  },
   "restrictions": {
     "max": 1
   }
@@ -30,10 +30,10 @@ Restricted options must have a unique `id` parameter. This is used to find other
   "perModel": true,
   "notes": {
     "name_en": "0-1 per 1000 points"
-  }
+  },
   "restrictions": {
     "max": 1,
-    "perArmyPoints": 1000
+    "points": 1000
   }
 }
 ```
@@ -55,7 +55,7 @@ Restricted options must have a unique `id` parameter. This is used to find other
   "restrictions": {
     "subOption": "magic",
     "max": 1,
-    "perArmyPoints": 1000
+    "points": 1000
   }
 }
 ```

--- a/docs/option-restrictions-rules.md
+++ b/docs/option-restrictions-rules.md
@@ -74,7 +74,7 @@ Restricted options must have a unique `id` parameter. This is used to find other
   "restrictions": {
     "requires": {
       "unitIds": ["kiknik-toofsnatcha"],
-      "types": "characters"
+      "type": "characters"
     },
     "max": 1
   }

--- a/docs/option-restrictions-rules.md
+++ b/docs/option-restrictions-rules.md
@@ -53,7 +53,7 @@ Restricted options must have a unique `id` parameter. This is used to find other
     "name_en": "0-1 unit per 1000 points may purchase a magic standard",
   },
   "restrictions": {
-    "subOption": "magic",
+    "restrictMagicItems": true,
     "max": 1,
     "points": 1000
   }

--- a/docs/option-restrictions-rules.md
+++ b/docs/option-restrictions-rules.md
@@ -96,8 +96,9 @@ Restricted options must have a unique `id` parameter. This is used to find other
     "requires": {
       "unitIds": ["renegade-prince", "renegade-captain", "outcast-wizard"],
       "option": "renegade-knight",
+      "optionType": "command",
       "perUnit": true,
-      "types": "characters"
+      "type": "characters"
     },
     "max": 1
   }

--- a/public/games/the-old-world/orc-and-goblin-tribes.json
+++ b/public/games/the-old-world/orc-and-goblin-tribes.json
@@ -3126,6 +3126,7 @@
           }
         },
         {
+          "id": "orc-mob-biguns",
           "name_en": "Big 'Uns",
           "name_cn": "大只佬",
           "name_de": "Moschas",
@@ -3137,6 +3138,9 @@
             "name_cn": "0-1per army",
             "name_de": "0-1 pro Armee",
             "name_fr": "0-1 par armée"
+          },
+          "restrictions": {
+            "max": 1
           }
         },
         {

--- a/public/games/the-old-world/orc-and-goblin-tribes.json
+++ b/public/games/the-old-world/orc-and-goblin-tribes.json
@@ -139,6 +139,7 @@
               "points": 5
             },
             {
+              "id": "orc-chariot-frenzy-2",
               "name_en": "Frenzy",
               "name_cn": "狂暴",
               "name_de": "Raserei",
@@ -158,9 +159,15 @@
                   "name_es": "0-1 por cada 1000 puntos",
                   "name_fr": "0-1 par tranche de 1000 points"
                 }
-              ]
+              ],
+              "restrictions": {
+                "max": 1,
+                "points": 1000,
+                "ids": ["orc-chariot-frenzy-2", "orc-chariot-frenzy-3"]
+              }
             },
             {
+              "id": "orc-chariot-frenzy-3",
               "name_en": "Frenzy",
               "name_cn": "狂暴",
               "name_de": "Raserei",
@@ -180,7 +187,12 @@
                   "name_es": "0-1 por cada 1000 puntos",
                   "name_fr": "0-1 par tranche de 1000 points"
                 }
-              ]
+              ],
+              "restrictions": {
+                "max": 1,
+                "points": 1000,
+                "ids": ["orc-chariot-frenzy-2", "orc-chariot-frenzy-3"]
+              }
             },
             {
               "name_en": "Warpaint",
@@ -410,6 +422,7 @@
               "points": 5
             },
             {
+              "id": "orc-chariot-frenzy-2",
               "name_en": "Frenzy",
               "name_cn": "狂暴",
               "name_de": "Raserei",
@@ -429,9 +442,15 @@
                   "name_es": "0-1 por cada 1000 puntos",
                   "name_fr": "0-1 par tranche de 1000 points"
                 }
-              ]
+              ],
+              "restrictions": {
+                "max": 1,
+                "points": 1000,
+                "ids": ["orc-chariot-frenzy-2", "orc-chariot-frenzy-3"]
+              }
             },
             {
+              "id": "orc-chariot-frenzy-3",
               "name_en": "Frenzy",
               "name_cn": "狂暴",
               "name_de": "Raserei",
@@ -451,7 +470,12 @@
                   "name_es": "0-1 por cada 1000 puntos",
                   "name_fr": "0-1 par tranche de 1000 points"
                 }
-              ]
+              ],
+              "restrictions": {
+                "max": 1,
+                "points": 1000,
+                "ids": ["orc-chariot-frenzy-2", "orc-chariot-frenzy-3"]
+              }
             },
             {
               "name_en": "Warpaint",
@@ -623,6 +647,7 @@
           "perModel": true
         },
         {
+          "id": "orc-boss-frenzy",
           "name_en": "Frenzy",
           "name_cn": "狂暴",
           "name_de": "Raserei",
@@ -635,6 +660,10 @@
             "name_de": "0-1 pro 1000 Punkte",
             "name_es": "0-1 por cada 1000 puntos",
             "name_fr": "0-1 par tranche de 1000 points"
+          },
+          "restrictions": {
+            "max": 1,
+            "points": 1000
           }
         }
       ],
@@ -701,6 +730,7 @@
               "points": 5
             },
             {
+              "id": "orc-chariot-frenzy-2",
               "name_en": "Frenzy",
               "name_cn": "狂暴",
               "name_de": "Raserei",
@@ -720,9 +750,15 @@
                   "name_es": "0-1 por cada 1000 puntos",
                   "name_fr": "0-1 par tranche de 1000 points"
                 }
-              ]
+              ],
+              "restrictions": {
+                "max": 1,
+                "points": 1000,
+                "ids": ["orc-chariot-frenzy-2", "orc-chariot-frenzy-3"]
+              }
             },
             {
+              "id": "orc-chariot-frenzy-3",
               "name_en": "Frenzy",
               "name_cn": "狂暴",
               "name_de": "Raserei",
@@ -742,7 +778,12 @@
                   "name_es": "0-1 por cada 1000 puntos",
                   "name_fr": "0-1 par tranche de 1000 points"
                 }
-              ]
+              ],
+              "restrictions": {
+                "max": 1,
+                "points": 1000,
+                "ids": ["orc-chariot-frenzy-2", "orc-chariot-frenzy-3"]
+              }
             },
             {
               "name_en": "Warpaint",
@@ -876,6 +917,7 @@
           "perModel": true
         },
         {
+          "id": "orc-boss-frenzy",
           "name_en": "Frenzy",
           "name_cn": "狂暴",
           "name_de": "Raserei",
@@ -888,6 +930,10 @@
             "name_de": "0-1 pro 1000 Punkte",
             "name_es": "0-1 por cada 1000 puntos",
             "name_fr": "0-1 par tranche de 1000 points"
+          },
+          "restrictions": {
+            "max": 1,
+            "points": 1000
           }
         }
       ],
@@ -954,6 +1000,7 @@
               "points": 5
             },
             {
+              "id": "orc-chariot-frenzy-2",
               "name_en": "Frenzy",
               "name_cn": "狂暴",
               "name_de": "Raserei",
@@ -973,9 +1020,15 @@
                   "name_es": "0-1 por cada 1000 puntos",
                   "name_fr": "0-1 par tranche de 1000 points"
                 }
-              ]
+              ],
+              "restrictions": {
+                "max": 1,
+                "points": 1000,
+                "ids": ["orc-chariot-frenzy-2", "orc-chariot-frenzy-3"]
+              }
             },
             {
+              "id": "orc-chariot-frenzy-3",
               "name_en": "Frenzy",
               "name_cn": "狂暴",
               "name_de": "Raserei",
@@ -995,7 +1048,12 @@
                   "name_es": "0-1 por cada 1000 puntos",
                   "name_fr": "0-1 par tranche de 1000 points"
                 }
-              ]
+              ],
+              "restrictions": {
+                "max": 1,
+                "points": 1000,
+                "ids": ["orc-chariot-frenzy-2", "orc-chariot-frenzy-3"]
+              }
             },
             {
               "name_en": "Warpaint",
@@ -1091,6 +1149,7 @@
       ],
       "armor": [
         {
+          "id": "orc-shaman-frenzy",
           "name_en": "Frenzy",
           "name_cn": "狂暴",
           "name_de": "Raserei",
@@ -1103,6 +1162,10 @@
             "name_de": "0-1 pro 1000 Punkte",
             "name_es": "0-1 por cada 1000 puntos",
             "name_fr": "0-1 par tranche de 1000 points"
+          },
+          "restrictions": {
+            "max": 1,
+            "points": 1000
           }
         }
       ],
@@ -1239,6 +1302,7 @@
       ],
       "armor": [
         {
+          "id": "orc-shaman-frenzy",
           "name_en": "Frenzy",
           "name_cn": "狂暴",
           "name_de": "Raserei",
@@ -1251,6 +1315,10 @@
             "name_de": "0-1 pro 1000 Punkte",
             "name_es": "0-1 por cada 1000 puntos",
             "name_fr": "0-1 par tranche de 1000 points"
+          },
+          "restrictions": {
+            "max": 1,
+            "points": 1000
           }
         }
       ],
@@ -3089,6 +3157,7 @@
           "active": true
         },
         {
+          "id": "orc-mob-frenzy",
           "name_en": "Frenzy",
           "name_cn": "狂暴",
           "name_de": "Raserei",
@@ -3101,6 +3170,10 @@
             "name_de": "0-1 pro 1.000 Punkte",
             "name_es": "0-1 por cada 1000 puntos",
             "name_fr": "0-1 par tranche de 1000 points"
+          },
+          "restrictions": {
+            "max": 1,
+            "points": 1000
           }
         }
       ],
@@ -3160,6 +3233,7 @@
           }
         },
         {
+          "id": "orc-mob-skirmishers",
           "name_en": "Skirmishers",
           "name_cn": "散兵",
           "name_de": "Plänkler",
@@ -3180,7 +3254,10 @@
               "name_es": "0-1 per army",
               "name_fr": "0-1 par armée"
             }
-          ]
+          ],
+          "restrictions": {
+            "max": 1
+          }
         }
       ],
       "mounts": [],
@@ -3261,6 +3338,7 @@
       ],
       "options": [
         {
+          "id": "black-orc-stubborn",
           "name_en": "Stubborn",
           "name_cn": "坚毅",
           "name_de": "Unnachgiebig",
@@ -3273,9 +3351,13 @@
             "name_de": "0-1 pro Armee",
             "name_es": "0-1 per army",
             "name_fr": "0-1 par armée"
+          },
+          "restrictions": {
+            "max": 1
           }
         },
         {
+          "id": "black-orc-veteran",
           "name_en": "Veteran",
           "name_cn": "老兵",
           "name_de": "Veteranen",
@@ -3288,6 +3370,9 @@
             "name_de": "0-1 pro Armee",
             "name_es": "0-1 per army",
             "name_fr": "0-1 par armée"
+          },
+          "restrictions": {
+            "max": 1
           }
         },
         {
@@ -3432,6 +3517,7 @@
           "maximum": 3
         },
         {
+          "id": "goblin-mob-skirmishers",
           "name_en": "Skirmishers",
           "name_cn": "散兵",
           "name_de": "Plänkler",
@@ -3452,7 +3538,11 @@
               "name_es": "0-1 por cada 1000 puntos",
               "name_fr": "0-1 par tranche de 1000 points"
             }
-          ]
+          ],
+          "restrictions": {
+            "max": 1,
+            "points": 1000
+          }
         }
       ],
       "mounts": [],
@@ -3832,6 +3922,7 @@
       ],
       "options": [
         {
+          "id": "wolf-rider-feigned-flight",
           "name_en": "Feigned Flight",
           "name_cn": "诱敌诈退",
           "name_de": "Vorgetäuschte Flucht",
@@ -3844,9 +3935,14 @@
             "name_de": "0-1 pro 1.000 Punkte",
             "name_es": "0-1 por cada 1000 puntos",
             "name_fr": "0-1 par tranche de 1000 points"
+          },
+          "restrictions": {
+            "max": 1,
+            "points": 1000
           }
         },
         {
+          "id": "wolf-rider-reserve-move",
           "name_en": "Reserve Move",
           "name_cn": "预备移动",
           "name_de": "Reservebewegung",
@@ -3859,6 +3955,10 @@
             "name_de": "0-1 pro 1.000 Punkte",
             "name_es": "0-1 por cada 1000 puntos",
             "name_fr": "0-1 par tranche de 1000 points"
+          },
+          "restrictions": {
+            "max": 1,
+            "points": 1000
           }
         },
         {
@@ -4007,6 +4107,7 @@
           "perModel": true
         },
         {
+          "id": "boar-boy-frenzy",
           "name_en": "Frenzy",
           "name_cn": "狂暴",
           "name_de": "Raserei",
@@ -4019,6 +4120,10 @@
             "name_de": "0-1 pro 1.000 Punkte",
             "name_es": "0-1 por cada 1000 puntos",
             "name_fr": "0-1 par tranche de 1000 points"
+          },
+          "restrictions": {
+            "max": 1,
+            "points": 1000
           }
         }
       ],
@@ -4034,6 +4139,7 @@
           "maximum": 0
         },
         {
+          "id": "boar-boy-biguns",
           "name_en": "Big 'Uns",
           "name_cn": "大只佬",
           "name_de": "Moschas",
@@ -4046,6 +4152,9 @@
             "name_de": "0-1 pro Armee",
             "name_es": "0-1 per army",
             "name_fr": "0-1 par armée"
+          },
+          "restrictions": {
+            "max": 1
           }
         },
         {
@@ -4063,6 +4172,7 @@
           }
         },
         {
+          "id": "nomadic-waaagh-boar-boy-vanguard",
           "name_en": "Vanguard",
           "name_cn": "先锋",
           "name_de": "Vorhut",
@@ -4074,6 +4184,10 @@
             "name_en": "0-1 per 1000 points",
             "name_cn": "每1000分0-1",
             "name_fr": "0-1 par tranche de 1000 points"
+          },
+          "restrictions": {
+            "max": 1,
+            "points": 1000
           }
         }
       ],
@@ -4302,6 +4416,7 @@
       ],
       "options": [
         {
+          "id": "black-orc-stubborn",
           "name_en": "Stubborn",
           "name_cn": "坚毅",
           "name_de": "Unnachgiebig",
@@ -4314,9 +4429,13 @@
             "name_de": "0-1 pro Armee",
             "name_es": "0-1 per army",
             "name_fr": "0-1 par armée"
+          },
+          "restrictions": {
+            "max": 1
           }
         },
         {
+          "id": "black-orc-veteran",
           "name_en": "Veteran",
           "name_cn": "老兵",
           "name_de": "Veteranen",
@@ -4329,6 +4448,9 @@
             "name_de": "0-1 pro Armee",
             "name_es": "0-1 per army",
             "name_fr": "0-1 par armée"
+          },
+          "restrictions": {
+            "max": 1
           }
         },
         {
@@ -4383,7 +4505,7 @@
           "notes": {
             "name_en": "0-1 Orc Boar Boy Mob per 1000 points",
             "name_cn": "每1000分0-1兽人战猪小子战帮",
-            "name_de": "0-1 0-1 Ork-Wildschweinreiter-Mob pro 1.000 Punkte",
+            "name_de": "0-1 Ork-Wildschweinreiter-Mob pro 1.000 Punkte",
             "name_fr": "0-1 Bande d’Orques sur Sangliers par tranche de 1000 points"
           }
         },
@@ -4469,6 +4591,7 @@
           "perModel": true
         },
         {
+          "id": "boar-boy-frenzy",
           "name_en": "Frenzy",
           "name_cn": "狂暴",
           "name_de": "Raserei",
@@ -4481,6 +4604,10 @@
             "name_de": "0-1 pro 1.000 Punkte",
             "name_es": "0-1 por cada 1000 puntos",
             "name_fr": "0-1 par tranche de 1000 points"
+          },
+          "restrictions": {
+            "max": 1,
+            "points": 1000
           }
         }
       ],
@@ -4494,6 +4621,7 @@
           "perModel": true
         },
         {
+          "id": "boar-boy-biguns",
           "name_en": "Big 'Uns",
           "name_cn": "大只佬",
           "name_de": "Moschas",
@@ -4506,6 +4634,9 @@
             "name_de": "0-1 pro Armee",
             "name_es": "0-1 per army",
             "name_fr": "0-1 par armée"
+          },
+          "restrictions": {
+            "max": 1
           }
         },
         {
@@ -4522,6 +4653,7 @@
           }
         },
         {
+          "id": "nomadic-waaagh-boar-boy-vanguard",
           "name_en": "Vanguard",
           "name_cn": "先锋",
           "name_de": "Vorhut",
@@ -4534,6 +4666,10 @@
             "name_cn": "每1000分0-1",
             "name_de": "0-1 pro 1.000 Punkte",
             "name_fr": "0-1 par tranche de 1000 points"
+          },
+          "restrictions": {
+            "max": 1,
+            "points": 1000
           }
         }
       ],
@@ -4680,6 +4816,7 @@
           "points": 5
         },
         {
+          "id": "orc-chariot-frenzy-2",
           "name_en": "Frenzy",
           "name_cn": "狂暴",
           "name_de": "Raserei",
@@ -4699,9 +4836,15 @@
               "name_es": "0-1 por cada 1000 puntos",
               "name_fr": "0-1 par tranche de 1000 points"
             }
-          ]
+          ],
+          "restrictions": {
+            "max": 1,
+            "points": 1000,
+            "ids": ["orc-chariot-frenzy-2", "orc-chariot-frenzy-3"]
+          }
         },
         {
+          "id": "orc-chariot-frenzy-3",
           "name_en": "Frenzy",
           "name_cn": "狂暴",
           "name_de": "Raserei",
@@ -4721,7 +4864,12 @@
               "name_es": "0-1 por cada 1000 puntos",
               "name_fr": "0-1 par tranche de 1000 points"
             }
-          ]
+          ],
+          "restrictions": {
+            "max": 1,
+            "points": 1000,
+            "ids": ["orc-chariot-frenzy-2", "orc-chariot-frenzy-3"]
+          }
         },
         {
           "name_en": "Warpaint",

--- a/public/games/the-old-world/orc-and-goblin-tribes.json
+++ b/public/games/the-old-world/orc-and-goblin-tribes.json
@@ -3076,6 +3076,7 @@
           }
         },
         {
+          "id": "orc-mob-standard-bearer",
           "name_en": "Standard bearer",
           "name_cn": "旗手",
           "name_de": "Standartenträger",
@@ -3092,6 +3093,11 @@
             "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
             "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
             "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
+          },
+          "restrictions": {
+            "restrictMagicItems": true,
+            "max": 1,
+            "points": 1000
           }
         },
         {
@@ -3857,6 +3863,7 @@
           "points": 7
         },
         {
+          "id": "wolf-rider-mob-standard-bearer",
           "name_en": "Standard bearer",
           "name_cn": "旗手",
           "name_de": "Standartenträger",
@@ -3873,6 +3880,11 @@
             "name_de": "0-1 Einheit pro 1000 Punkte darf eine Magische Standarte erwerben",
             "name_fr": "0-1 unité par tranche de 1000 points peut acheter une bannière magique",
             "name_es": "0-1 unidad cada 1.000 puntos puede adquirir un estandarte mágico"
+          },
+          "restrictions": {
+            "restrictMagicItems": true,
+            "max": 1,
+            "points": 1000
           }
         },
         {

--- a/public/games/the-old-world/orc-and-goblin-tribes.json
+++ b/public/games/the-old-world/orc-and-goblin-tribes.json
@@ -3971,19 +3971,26 @@
           "armyComposition": ["nomadic-waaagh"]
         },
         {
+          "id": "wolf-rider-kiknik-ambushers",
           "name_en": "Ambushers",
           "name_cn": "伏击",
           "name_de": "Überfall",
           "name_fr": "Embusqueurs",
           "points": 0,
           "perModel": true,
-          "armyComposition": ["nomadic-waaagh"],
           "notes": {
             "name_en": "0-1 Goblin Wolf Rider Mob if Kiknik is in the army",
             "name_cn": "0-1Goblin Wolf Rider Mob if Kiknik is in the army",
             "name_de": "0-1 Goblin Wolfsreiter-Mob, wenn Kiknik Teil der Armee ist",
             "name_es": "0-1 Goblin Wolf Rider Mob if Kiknik is in the army",
             "name_fr": "0-1 Bande de Gobelins sur Loups si Kiknik est dans l’armée"
+          },
+          "restrictions": {
+            "requires": {
+              "unitIds": ["kiknik-toofsnatcha"],
+              "type": "characters"
+            },
+            "max": 1
           }
         },
         {

--- a/public/games/the-old-world/renegade-crowns.json
+++ b/public/games/the-old-world/renegade-crowns.json
@@ -19,6 +19,7 @@
           "exclusive": false
         },
         {
+          "id": "might-of-miragliano",
           "name_en": "The Might of Miragliano",
           "name_cn": "米拉格连诺伟力",
           "name_de": "The Might of Miragliano",
@@ -39,6 +40,7 @@
           ]
         },
         {
+          "id": "renegade-knight",
           "name_en": "The Renegade Knight",
           "name_cn": "变节骑士",
           "name_de": "The Renegade Knight",
@@ -59,6 +61,7 @@
           ]
         },
         {
+          "id": "noble-outlaw",
           "name_en": "The Noble Outlaw",
           "name_cn": "强盗贵族",
           "name_de": "The Noble Outlaw",
@@ -154,6 +157,7 @@
           ]
         },
         {
+          "id": "wandering-diestro",
           "name_en": "The Wandering Diestro",
           "name_cn": "游荡决斗士",
           "name_de": "The Wandering Diestro",
@@ -478,6 +482,7 @@
           }
         },
         {
+          "id": "might-of-miragliano",
           "name_en": "The Might of Miragliano",
           "name_cn": "米拉格连诺伟力",
           "name_de": "The Might of Miragliano",
@@ -498,6 +503,7 @@
           ]
         },
         {
+          "id": "renegade-knight",
           "name_en": "The Renegade Knight",
           "name_cn": "变节骑士",
           "name_de": "The Renegade Knight",
@@ -518,6 +524,7 @@
           ]
         },
         {
+          "id": "noble-outlaw",
           "name_en": "The Noble Outlaw",
           "name_cn": "强盗贵族",
           "name_de": "The Noble Outlaw",
@@ -613,6 +620,7 @@
           ]
         },
         {
+          "id": "wandering-diestro",
           "name_en": "The Wandering Diestro",
           "name_cn": "游荡决斗士",
           "name_de": "The Wandering Diestro",
@@ -867,6 +875,7 @@
           "exclusive": false
         },
         {
+          "id": "might-of-miragliano",
           "name_en": "The Might of Miragliano",
           "name_cn": "米拉格连诺伟力",
           "name_de": "The Might of Miragliano",
@@ -887,6 +896,7 @@
           ]
         },
         {
+          "id": "renegade-knight",
           "name_en": "The Renegade Knight",
           "name_cn": "变节骑士",
           "name_de": "The Renegade Knight",
@@ -907,6 +917,7 @@
           ]
         },
         {
+          "id": "noble-outlaw",
           "name_en": "The Noble Outlaw",
           "name_cn": "贵族强盗",
           "name_de": "The Noble Outlaw",
@@ -1002,6 +1013,7 @@
           ]
         },
         {
+          "id": "wandering-diestro",
           "name_en": "The Wandering Diestro",
           "name_cn": "游荡决斗士",
           "name_de": "The Wandering Diestro",
@@ -1306,6 +1318,7 @@
           "perModel": true
         },
         {
+          "id": "sellsword-heavy-phalanx",
           "name_en": "Heavy Infantry, Phalanx",
           "name_cn": "重步兵, 方阵",
           "name_it": "Heavy Infantry, Phalanx",
@@ -1316,6 +1329,16 @@
             "name_en": "0-1 unit for each character with the Might of Miragliano Infamous Origin",
             "name_cn": "每有一个米拉格连诺伟力恶名起源角色则0-1单位",
             "name_fr": "0-1 unité pour chaque personnage avec l’Origine d’Exilé la Puissance de Miragliano"
+          },
+          "restrictions": {
+            "requires": {
+              "unitIds": ["renegade-prince", "renegade-captain", "outcast-wizard"],
+              "option": "might-of-miragliano",
+              "optionType": "command",
+              "perUnit": true,
+              "type": "characters"
+            },
+            "max": 1
           }
         }
       ],
@@ -1483,6 +1506,7 @@
           "perModel": true
         },
         {
+          "id": "sellsword-heavy-phalanx",
           "name_en": "Heavy Infantry, Phalanx",
           "name_cn": "重步兵, 方阵",
           "name_it": "Heavy Infantry, Phalanx",
@@ -1493,6 +1517,16 @@
             "name_en": "0-1 unit for each character with the Might of Miragliano Infamous Origin",
             "name_cn": "每有一个米拉格连诺伟力恶名起源角色则0-1单位",
             "name_fr": "0-1 unité pour chaque personnage avec l’Origine d’Exilé la Puissance de Miragliano"
+          },
+          "restrictions": {
+            "requires": {
+              "unitIds": ["renegade-prince", "renegade-captain", "outcast-wizard"],
+              "option": "might-of-miragliano",
+              "optionType": "command",
+              "perUnit": true,
+              "type": "characters"
+            },
+            "max": 1
           }
         }
       ],
@@ -1606,6 +1640,7 @@
           "perModel": true
         },
         {
+          "id": "freeblade-lance-noble-disdain",
           "name_en": "Lance Formation, Noble Disdain",
           "name_cn": "骑枪阵型, 贵族蔑视",
           "name_it": "Lance Formation, Noble Disdain",
@@ -1617,6 +1652,16 @@
             "name_en": "0-1 unit for each character with the Renegade Knight Infamous Origin",
             "name_cn": "每有一个变节骑士恶名起源角色则0-1单位",
             "name_fr": "0-1 unité pour chaque personnage avec l’Origine d’Exilé le Chevalier Renégat"
+          },
+          "restrictions": {
+            "requires": {
+              "unitIds": ["renegade-prince", "renegade-captain", "outcast-wizard"],
+              "option": "renegade-knight",
+              "optionType": "command",
+              "perUnit": true,
+              "type": "characters"
+            },
+            "max": 1
           }
         }
       ],
@@ -1799,6 +1844,7 @@
           }
         },
         {
+          "id": "outriders-ambushers",
           "name_en": "Ambushers",
           "name_cn": "伏击",
           "name_de": "Überfall",
@@ -1810,6 +1856,16 @@
             "name_en": "0-1 unit for each character with the Noble Outlaw Infamous Origin",
             "name_cn": "每有一个强盗贵族恶名起源角色则0-1单位",
             "name_fr": "0-1 unité pour chaque personnage avec l’Origine d’Exilé le Noble Hors-la-Loi"
+          },
+          "restrictions": {
+            "requires": {
+              "unitIds": ["renegade-prince", "renegade-captain", "outcast-wizard"],
+              "option": "noble-outlaw",
+              "optionType": "command",
+              "perUnit": true,
+              "type": "characters"
+            },
+            "max": 1
           }
         }
       ],
@@ -2085,6 +2141,7 @@
           "perModel": true
         },
         {
+          "id": "freeblade-lance-noble-disdain",
           "name_en": "Lance Formation, Noble Disdain",
           "name_cn": "骑枪阵型, 贵族蔑视",
           "name_it": "Lance Formation, Noble Disdain",
@@ -2096,6 +2153,16 @@
             "name_en": "0-1 unit for each character with the Renegade Knight Infamous Origin",
             "name_cn": "每有一个变节骑士恶名起源角色则0-1单位",
             "name_fr": "0-1 unité pour chaque personnage avec l’Origine d’Exilé le Chevalier Renégat"
+          },
+          "restrictions": {
+            "requires": {
+              "unitIds": ["renegade-prince", "renegade-captain", "outcast-wizard"],
+              "option": "renegade-knight",
+              "optionType": "command",
+              "perUnit": true,
+              "type": "characters"
+            },
+            "max": 1
           }
         }
       ],
@@ -2339,6 +2406,7 @@
           }
         },
         {
+          "id": "brigands-weapon-skill",
           "name_en": "+1 to Weapon Skill",
           "name_cn": "+1武器技能",
           "name_de": "+1 to Weapon Skill",
@@ -2350,6 +2418,16 @@
             "name_en": "0-1 unit for each character with the Wandering Diestro Infamous Origin",
             "name_cn": "每有一个游荡决斗家恶名起源角色则0-1单位",
             "name_fr": "0-1 unité pour chaque personnage avec l’Origine d’Exilé le Diestro Errant"
+          },
+          "restrictions": {
+            "requires": {
+              "unitIds": ["renegade-prince", "renegade-captain", "outcast-wizard"],
+              "option": "wandering-diestro",
+              "optionType": "command",
+              "perUnit": true,
+              "type": "characters"
+            },
+            "max": 1
           }
         }
       ],

--- a/src/i18n/cn.json
+++ b/src/i18n/cn.json
@@ -131,6 +131,7 @@
   "misc.error.wizardGeneral": "Your general must have wizard levels",
   "misc.error.maxOptionPerArmy": "This option is used by {usedby}",
   "misc.error.optionRequiresUnit": "This option requires another unit in the army",
+  "misc.error.optionRequiresUnitWithOption": "This option's requirements are not met",
   "pwa.button": "安装app",
   "pwa.prompt": "旧世界写表器可以作为app被安装到你的设备上。现在安装？",
   "editor.add": "添加",

--- a/src/i18n/cn.json
+++ b/src/i18n/cn.json
@@ -129,6 +129,8 @@
   "misc.error.hierophantLevel": "Your Hierophant doesn't have the highest wizard level of your Liche Priests",
   "misc.error.hierophantGeneral": "Your general must also be the Hierophant",
   "misc.error.wizardGeneral": "Your general must have wizard levels",
+  "misc.error.maxOptionPerArmy": "This option is used by {usedby}",
+  "misc.error.optionRequiresUnit": "This option requires another unit in the army",
   "pwa.button": "安装app",
   "pwa.prompt": "旧世界写表器可以作为app被安装到你的设备上。现在安装？",
   "editor.add": "添加",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -131,6 +131,7 @@
   "misc.error.wizardGeneral": "Your general must have wizard levels",
   "misc.error.maxOptionPerArmy": "This option is used by {usedby}",
   "misc.error.optionRequiresUnit": "This option requires another unit in the army",
+  "misc.error.optionRequiresUnitWithOption": "This option's requirements are not met",
   "pwa.button": "App installieren",
   "pwa.prompt": "Old World Builder kann als App auf deinem Gerät installiert werden. Jetzt installieren?",
   "editor.add": "Hinzufügen",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -129,6 +129,8 @@
   "misc.error.hierophantLevel": "Dein Hierophant hat nicht die höchste Magiestufe deiner Hohepriester",
   "misc.error.hierophantGeneral": "Your general must also be the Hierophant",
   "misc.error.wizardGeneral": "Your general must have wizard levels",
+  "misc.error.maxOptionPerArmy": "This option is used by {usedby}",
+  "misc.error.optionRequiresUnit": "This option requires another unit in the army",
   "pwa.button": "App installieren",
   "pwa.prompt": "Old World Builder kann als App auf deinem Gerät installiert werden. Jetzt installieren?",
   "editor.add": "Hinzufügen",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -129,6 +129,7 @@
   "misc.error.hierophantLevel": "Your Hierophant doesn't have the highest wizard level of your Liche Priests",
   "misc.error.hierophantGeneral": "Your general must also be the Hierophant",
   "misc.error.wizardGeneral": "Your general must have wizard levels",
+  "misc.error.maxOptionPerArmy": "This option is used by {usedby}",
   "pwa.button": "Install app",
   "pwa.prompt": "Old World Builder can be installed as an app on your device. Install now?",
   "editor.add": "Add",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -131,6 +131,7 @@
   "misc.error.wizardGeneral": "Your general must have wizard levels",
   "misc.error.maxOptionPerArmy": "This option is used by {usedby}",
   "misc.error.optionRequiresUnit": "This option requires another unit in the army",
+  "misc.error.optionRequiresUnitWithOption": "This option's requirements are not met",
   "pwa.button": "Install app",
   "pwa.prompt": "Old World Builder can be installed as an app on your device. Install now?",
   "editor.add": "Add",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -130,6 +130,7 @@
   "misc.error.hierophantGeneral": "Your general must also be the Hierophant",
   "misc.error.wizardGeneral": "Your general must have wizard levels",
   "misc.error.maxOptionPerArmy": "This option is used by {usedby}",
+  "misc.error.optionRequiresUnit": "This option requires another unit in the army",
   "pwa.button": "Install app",
   "pwa.prompt": "Old World Builder can be installed as an app on your device. Install now?",
   "editor.add": "Add",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -131,6 +131,7 @@
   "misc.error.wizardGeneral": "Tu general debe tener niveles de Hechiceria",
   "misc.error.maxOptionPerArmy": "This option is used by {usedby}",
   "misc.error.optionRequiresUnit": "This option requires another unit in the army",
+  "misc.error.optionRequiresUnitWithOption": "This option's requirements are not met",
   "pwa.button": "Instalar app",
   "pwa.prompt": "Old World Builder se puede instalar como una aplicación en su dispositivo. ¿Instalar ahora?",
   "editor.add": "Añadir",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -129,6 +129,8 @@
   "misc.error.hierophantLevel": "Tu Hierofante no tiene el nivel de hechicería más alto de tus Sacerdotes Funerarios",
   "misc.error.hierophantGeneral": "Your general must also be the Hierophant",
   "misc.error.wizardGeneral": "Tu general debe tener niveles de Hechiceria",
+  "misc.error.maxOptionPerArmy": "This option is used by {usedby}",
+  "misc.error.optionRequiresUnit": "This option requires another unit in the army",
   "pwa.button": "Instalar app",
   "pwa.prompt": "Old World Builder se puede instalar como una aplicación en su dispositivo. ¿Instalar ahora?",
   "editor.add": "Añadir",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -131,6 +131,7 @@
   "misc.error.wizardGeneral": "Your general must have wizard levels",
   "misc.error.maxOptionPerArmy": "This option is used by {usedby}",
   "misc.error.optionRequiresUnit": "This option requires another unit in the army",
+  "misc.error.optionRequiresUnitWithOption": "This option's requirements are not met",
   "pwa.button": "Installer l'application",
   "pwa.prompt": "Old World Builder peut être installé comme une application sur votre appareil. Installer maintenant ?",
   "editor.add": "Ajouter",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -129,6 +129,8 @@
   "misc.error.hierophantLevel": "Your Hierophant doesn't have the highest wizard level of your Liche Priests",
   "misc.error.hierophantGeneral": "Your general must also be the Hierophant",
   "misc.error.wizardGeneral": "Your general must have wizard levels",
+  "misc.error.maxOptionPerArmy": "This option is used by {usedby}",
+  "misc.error.optionRequiresUnit": "This option requires another unit in the army",
   "pwa.button": "Installer l'application",
   "pwa.prompt": "Old World Builder peut être installé comme une application sur votre appareil. Installer maintenant ?",
   "editor.add": "Ajouter",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -131,6 +131,7 @@
   "misc.error.wizardGeneral": "Your general must have wizard levels",
   "misc.error.maxOptionPerArmy": "This option is used by {usedby}",
   "misc.error.optionRequiresUnit": "This option requires another unit in the army",
+  "misc.error.optionRequiresUnitWithOption": "This option's requirements are not met",
   "pwa.button": "Install app",
   "pwa.prompt": "Old World Builder can be installed as an app on your device. Install now?",
   "editor.add": "Aggiungi",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -129,6 +129,8 @@
   "misc.error.hierophantLevel": "Your Hierophant doesn't have the highest wizard level of your Liche Priests",
   "misc.error.hierophantGeneral": "Your general must also be the Hierophant",
   "misc.error.wizardGeneral": "Your general must have wizard levels",
+  "misc.error.maxOptionPerArmy": "This option is used by {usedby}",
+  "misc.error.optionRequiresUnit": "This option requires another unit in the army",
   "pwa.button": "Install app",
   "pwa.prompt": "Old World Builder can be installed as an app on your device. Install now?",
   "editor.add": "Aggiungi",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -129,6 +129,8 @@
   "misc.error.hierophantLevel": "Your Hierophant doesn't have the highest wizard level of your Liche Priests",
   "misc.error.hierophantGeneral": "Your general must also be the Hierophant",
   "misc.error.wizardGeneral": "Your general must have wizard levels",
+  "misc.error.maxOptionPerArmy": "This option is used by {usedby}",
+  "misc.error.optionRequiresUnit": "This option requires another unit in the army",
   "pwa.button": "Install app",
   "pwa.prompt": "Old World Builder can be installed as an app on your device. Install now?",
   "editor.add": "Dodaj",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -131,6 +131,7 @@
   "misc.error.wizardGeneral": "Your general must have wizard levels",
   "misc.error.maxOptionPerArmy": "This option is used by {usedby}",
   "misc.error.optionRequiresUnit": "This option requires another unit in the army",
+  "misc.error.optionRequiresUnitWithOption": "This option's requirements are not met",
   "pwa.button": "Install app",
   "pwa.prompt": "Old World Builder can be installed as an app on your device. Install now?",
   "editor.add": "Dodaj",

--- a/src/pages/unit/Unit.jsx
+++ b/src/pages/unit/Unit.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, Fragment } from "react";
-import { useParams, useLocation, Redirect } from "react-router-dom";
+import { useParams, useLocation, Link, Redirect } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { FormattedMessage, useIntl } from "react-intl";
 import PropTypes from "prop-types";
@@ -18,6 +18,7 @@ import { NumberInput } from "../../components/number-input";
 import { Icon } from "../../components/icon";
 import { Header, Main } from "../../components/page";
 import { Button } from "../../components/button";
+import { ErrorMessage } from "../../components/error-message";
 import { Stats } from "../../components/stats";
 import {
   RulesIndex,
@@ -43,6 +44,7 @@ import { getGameSystems, getCustomDatasetData } from "../../utils/game-systems";
 
 import "./Unit.css";
 import { updateSetting } from "../../state/settings";
+import { checkOptionRestrictions } from "../../utils/option-restrictions";
 
 export const Unit = ({ isMobile, previewData = {} }) => {
   const isPreview = Boolean(previewData?.type);
@@ -1116,12 +1118,25 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                   options,
                   useCheckboxes,
                   alwaysActive,
+                  restrictions,
                   ...equipment
                 }) => {
                   const exclusiveUnitCheckedOption = unit.options.find(
                     (exclusiveOption) =>
                       exclusiveOption.exclusive && exclusiveOption.active,
                   );
+
+                  const restrictionError = active && restrictions
+                    ? checkOptionRestrictions(unit.id, {id, restrictions}, list, "options")
+                    : undefined;
+                  const usedElsewhereBy = restrictionError?.otherUnits?.map((otherUnit, index) => (
+                    <Fragment key={`${otherUnit.unit.id}-error-link`}>
+                      <Link to={otherUnit.url}>
+                        {getUnitName({ unit: otherUnit.unit, language })}
+                      </Link>
+                      {index !== restrictionError.otherUnits.length - 1 ? ", " : ""}
+                    </Fragment>
+                  ));
 
                   if (!stackable) {
                     const isDisabled =
@@ -1160,6 +1175,22 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                           language,
                           disabled: isDisabled,
                         })}
+                        {restrictionError &&
+                          <ErrorMessage
+                            key={`${id}-restrictederror`}
+                            spaceAfter
+                            spaceBefore={isMobile}
+                          >
+                            <span>
+                              <FormattedMessage
+                                id={restrictionError.message}
+                                values={{
+                                  usedby: usedElsewhereBy,
+                                }}
+                              />
+                            </span>
+                          </ErrorMessage>
+                        }
                         {options?.length > 0 && active && (
                           <>
                             {options

--- a/src/pages/unit/Unit.jsx
+++ b/src/pages/unit/Unit.jsx
@@ -769,7 +769,7 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                       magic.maxPoints;
                   }
                   const restrictionError = active && restrictions
-                    ? checkOptionRestrictions(unit.id, {id, restrictions}, list, "command")
+                    ? checkOptionRestrictions(unit.id, {id, restrictions, magic}, list, "command")
                     : undefined;
                   const usedElsewhereBy = restrictionError?.otherUnits?.map((otherUnit, index) => (
                     <Fragment key={`${otherUnit.unit.id}-error-link`}>

--- a/src/pages/unit/Unit.jsx
+++ b/src/pages/unit/Unit.jsx
@@ -750,6 +750,7 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                     exclusive = true,
                     notes,
                     alwaysActive,
+                    restrictions,
                     ...command
                   },
                   index,
@@ -767,6 +768,17 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                           ?.maxPoints) ||
                       magic.maxPoints;
                   }
+                  const restrictionError = active && restrictions
+                    ? checkOptionRestrictions(unit.id, {id, restrictions}, list, "command")
+                    : undefined;
+                  const usedElsewhereBy = restrictionError?.otherUnits?.map((otherUnit, index) => (
+                    <Fragment key={`${otherUnit.unit.id}-error-link`}>
+                      <Link to={otherUnit.url}>
+                        {getUnitName({ unit: otherUnit.unit, language })}
+                      </Link>
+                      {index !== restrictionError.otherUnits.length - 1 ? ", " : ""}
+                    </Fragment>
+                  ));
 
                   return (
                     <Fragment key={id}>
@@ -958,6 +970,22 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                           <hr className="unit__command-option-hr" />
                         </Fragment>
                       )}
+                      {restrictionError &&
+                        <ErrorMessage
+                          key={`${id}-restrictederror`}
+                          spaceAfter
+                          spaceBefore={isMobile}
+                        >
+                          <span>
+                            <FormattedMessage
+                              id={restrictionError.message}
+                              values={{
+                                usedby: usedElsewhereBy,
+                              }}
+                            />
+                          </span>
+                        </ErrorMessage>
+                      }
                     </Fragment>
                   );
                 },
@@ -986,39 +1014,70 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                   active = false,
                   notes,
                   group,
+                  restrictions,
                   ...equipment
-                }) => (
-                  <Fragment key={id}>
-                    <div className={group ? "checkbox" : "radio"}>
-                      <input
-                        type={group ? "checkbox" : "radio"}
-                        id={`equipment-${id}`}
-                        name="equipment"
-                        value={group || id}
-                        onChange={() => handleEquipmentChange({ id, group })}
-                        checked={active}
-                        className={group ? "checkbox__input" : "radio__input"}
-                      />
-                      <label
-                        htmlFor={`equipment-${id}`}
-                        className={group ? "checkbox__label" : "radio__label"}
-                      >
-                        <span className="unit__label-text">
-                          <RulesWithIcon textObject={equipment} />
-                        </span>
-                        <i className="checkbox__points">
-                          {getPointsText({ points, perModel })}
-                        </i>
-                      </label>
-                    </div>
-                    {getUnitOptionNotes({
-                      notes,
-                      key: `equipment-${id}-note`,
-                      className: "unit__option-note",
-                      language,
-                    })}
-                  </Fragment>
-                ),
+                }) => {
+                  const restrictionError = active && restrictions
+                    ? checkOptionRestrictions(unit.id, {id, restrictions}, list, "equipment")
+                    : undefined;
+                  const usedElsewhereBy = restrictionError?.otherUnits?.map((otherUnit, index) => (
+                    <Fragment key={`${otherUnit.unit.id}-error-link`}>
+                      <Link to={otherUnit.url}>
+                        {getUnitName({ unit: otherUnit.unit, language })}
+                      </Link>
+                      {index !== restrictionError.otherUnits.length - 1 ? ", " : ""}
+                    </Fragment>
+                  ));
+
+                  return (
+                    <Fragment key={id}>
+                      <div className={group ? "checkbox" : "radio"}>
+                        <input
+                          type={group ? "checkbox" : "radio"}
+                          id={`equipment-${id}`}
+                          name="equipment"
+                          value={group || id}
+                          onChange={() => handleEquipmentChange({ id, group })}
+                          checked={active}
+                          className={group ? "checkbox__input" : "radio__input"}
+                        />
+                        <label
+                          htmlFor={`equipment-${id}`}
+                          className={group ? "checkbox__label" : "radio__label"}
+                        >
+                          <span className="unit__label-text">
+                            <RulesWithIcon textObject={equipment} />
+                          </span>
+                          <i className="checkbox__points">
+                            {getPointsText({ points, perModel })}
+                          </i>
+                        </label>
+                      </div>
+                      {getUnitOptionNotes({
+                        notes,
+                        key: `equipment-${id}-note`,
+                        className: "unit__option-note",
+                        language,
+                      })}
+                      {restrictionError &&
+                        <ErrorMessage
+                          key={`${id}-restrictederror`}
+                          spaceAfter
+                          spaceBefore={isMobile}
+                        >
+                          <span>
+                            <FormattedMessage
+                              id={restrictionError.message}
+                              values={{
+                                usedby: usedElsewhereBy,
+                              }}
+                            />
+                          </span>
+                        </ErrorMessage>
+                      }
+                    </Fragment>
+                  );
+                },
               )}
           </>
         )}
@@ -1044,9 +1103,21 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                   activeDefault,
                   active = false,
                   notes,
+                  restrictions,
                   ...equipment
                 }) => {
                   const isRadio = unit.armor.length > 1 || activeDefault;
+                  const restrictionError = active && restrictions
+                    ? checkOptionRestrictions(unit.id, {id, restrictions}, list, "armor")
+                    : undefined;
+                  const usedElsewhereBy = restrictionError?.otherUnits?.map((otherUnit, index) => (
+                    <Fragment key={`${otherUnit.unit.id}-error-link`}>
+                      <Link to={otherUnit.url}>
+                        {getUnitName({ unit: otherUnit.unit, language })}
+                      </Link>
+                      {index !== restrictionError.otherUnits.length - 1 ? ", " : ""}
+                    </Fragment>
+                  ));
 
                   return (
                     <Fragment key={id}>
@@ -1082,6 +1153,22 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                         className: "unit__option-note",
                         language,
                       })}
+                      {restrictionError &&
+                        <ErrorMessage
+                          key={`${id}-restrictederror`}
+                          spaceAfter
+                          spaceBefore={isMobile}
+                        >
+                          <span>
+                            <FormattedMessage
+                              id={restrictionError.message}
+                              values={{
+                                usedby: usedElsewhereBy,
+                              }}
+                            />
+                          </span>
+                        </ErrorMessage>
+                      }
                     </Fragment>
                   );
                 },

--- a/src/pages/unit/Unit.jsx
+++ b/src/pages/unit/Unit.jsx
@@ -44,7 +44,7 @@ import { getGameSystems, getCustomDatasetData } from "../../utils/game-systems";
 
 import "./Unit.css";
 import { updateSetting } from "../../state/settings";
-import { checkOptionRestrictions } from "../../utils/option-restrictions";
+import { checkUnitOptionRestrictions } from "../../utils/option-restrictions";
 
 export const Unit = ({ isMobile, previewData = {} }) => {
   const isPreview = Boolean(previewData?.type);
@@ -66,6 +66,7 @@ export const Unit = ({ isMobile, previewData = {} }) => {
   const unit = units ? units.find(({ id }) => id === unitId) : previewUnit;
   const army = useSelector((state) => state.army);
   const settings = useSelector((state) => state.settings);
+  const [optionErrors, setOptionErrors] = useState({});
   const detachmentActive =
     unit &&
     unit?.options?.length > 0 &&
@@ -544,6 +545,42 @@ export const Unit = ({ isMobile, previewData = {} }) => {
     }
   }, [list, army, dispatch, game, armyData?.version]);
 
+  useEffect(() => {
+    if (unit && list) {
+      setOptionErrors(checkUnitOptionRestrictions(unit, list));
+    }
+  }, [unit, list]);
+
+  const optionErrorMessage = (optionId) => {
+    if (!optionId || !optionErrors[optionId]) {
+      return null;
+    }
+    const usedElsewhereBy = optionErrors[optionId]?.otherUnits?.map((otherUnit, index) => (
+      <Fragment key={`${otherUnit.unit.id}-error-link`}>
+        <Link to={otherUnit.url}>
+          {getUnitName({ unit: otherUnit.unit, language })}
+        </Link>
+        {index !== optionErrors[optionId].otherUnits.length - 1 ? ", " : ""}
+      </Fragment>
+    ));
+    return (
+      <ErrorMessage
+        key={`${optionId}-restrictederror`}
+        spaceAfter
+        spaceBefore={isMobile}
+      >
+        <span>
+          <FormattedMessage
+            id={optionErrors[optionId].message}
+            values={{
+              usedby: usedElsewhereBy,
+            }}
+          />
+        </span>
+      </ErrorMessage>
+    );
+  }
+
   if (redirect === true) {
     return <Redirect to={`/editor/${listId}`} />;
   }
@@ -750,7 +787,6 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                     exclusive = true,
                     notes,
                     alwaysActive,
-                    restrictions,
                     ...command
                   },
                   index,
@@ -768,18 +804,7 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                           ?.maxPoints) ||
                       magic.maxPoints;
                   }
-                  const restrictionError = active && restrictions
-                    ? checkOptionRestrictions(unit.id, {id, restrictions, magic}, list, "command")
-                    : undefined;
-                  const usedElsewhereBy = restrictionError?.otherUnits?.map((otherUnit, index) => (
-                    <Fragment key={`${otherUnit.unit.id}-error-link`}>
-                      <Link to={otherUnit.url}>
-                        {getUnitName({ unit: otherUnit.unit, language })}
-                      </Link>
-                      {index !== restrictionError.otherUnits.length - 1 ? ", " : ""}
-                    </Fragment>
-                  ));
-
+                  
                   return (
                     <Fragment key={id}>
                       <div
@@ -970,22 +995,7 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                           <hr className="unit__command-option-hr" />
                         </Fragment>
                       )}
-                      {restrictionError &&
-                        <ErrorMessage
-                          key={`${id}-restrictederror`}
-                          spaceAfter
-                          spaceBefore={isMobile}
-                        >
-                          <span>
-                            <FormattedMessage
-                              id={restrictionError.message}
-                              values={{
-                                usedby: usedElsewhereBy,
-                              }}
-                            />
-                          </span>
-                        </ErrorMessage>
-                      }
+                      {optionErrors[id] && optionErrorMessage(id)}
                     </Fragment>
                   );
                 },
@@ -1014,21 +1024,8 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                   active = false,
                   notes,
                   group,
-                  restrictions,
                   ...equipment
                 }) => {
-                  const restrictionError = active && restrictions
-                    ? checkOptionRestrictions(unit.id, {id, restrictions}, list, "equipment")
-                    : undefined;
-                  const usedElsewhereBy = restrictionError?.otherUnits?.map((otherUnit, index) => (
-                    <Fragment key={`${otherUnit.unit.id}-error-link`}>
-                      <Link to={otherUnit.url}>
-                        {getUnitName({ unit: otherUnit.unit, language })}
-                      </Link>
-                      {index !== restrictionError.otherUnits.length - 1 ? ", " : ""}
-                    </Fragment>
-                  ));
-
                   return (
                     <Fragment key={id}>
                       <div className={group ? "checkbox" : "radio"}>
@@ -1059,22 +1056,7 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                         className: "unit__option-note",
                         language,
                       })}
-                      {restrictionError &&
-                        <ErrorMessage
-                          key={`${id}-restrictederror`}
-                          spaceAfter
-                          spaceBefore={isMobile}
-                        >
-                          <span>
-                            <FormattedMessage
-                              id={restrictionError.message}
-                              values={{
-                                usedby: usedElsewhereBy,
-                              }}
-                            />
-                          </span>
-                        </ErrorMessage>
-                      }
+                      {optionErrors[id] && optionErrorMessage(id)}
                     </Fragment>
                   );
                 },
@@ -1103,21 +1085,9 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                   activeDefault,
                   active = false,
                   notes,
-                  restrictions,
                   ...equipment
                 }) => {
                   const isRadio = unit.armor.length > 1 || activeDefault;
-                  const restrictionError = active && restrictions
-                    ? checkOptionRestrictions(unit.id, {id, restrictions}, list, "armor")
-                    : undefined;
-                  const usedElsewhereBy = restrictionError?.otherUnits?.map((otherUnit, index) => (
-                    <Fragment key={`${otherUnit.unit.id}-error-link`}>
-                      <Link to={otherUnit.url}>
-                        {getUnitName({ unit: otherUnit.unit, language })}
-                      </Link>
-                      {index !== restrictionError.otherUnits.length - 1 ? ", " : ""}
-                    </Fragment>
-                  ));
 
                   return (
                     <Fragment key={id}>
@@ -1153,22 +1123,7 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                         className: "unit__option-note",
                         language,
                       })}
-                      {restrictionError &&
-                        <ErrorMessage
-                          key={`${id}-restrictederror`}
-                          spaceAfter
-                          spaceBefore={isMobile}
-                        >
-                          <span>
-                            <FormattedMessage
-                              id={restrictionError.message}
-                              values={{
-                                usedby: usedElsewhereBy,
-                              }}
-                            />
-                          </span>
-                        </ErrorMessage>
-                      }
+                      {optionErrors[id] && optionErrorMessage(id)}
                     </Fragment>
                   );
                 },
@@ -1204,25 +1159,12 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                   options,
                   useCheckboxes,
                   alwaysActive,
-                  restrictions,
                   ...equipment
                 }) => {
                   const exclusiveUnitCheckedOption = unit.options.find(
                     (exclusiveOption) =>
                       exclusiveOption.exclusive && exclusiveOption.active,
                   );
-
-                  const restrictionError = active && restrictions
-                    ? checkOptionRestrictions(unit.id, {id, restrictions}, list, "options")
-                    : undefined;
-                  const usedElsewhereBy = restrictionError?.otherUnits?.map((otherUnit, index) => (
-                    <Fragment key={`${otherUnit.unit.id}-error-link`}>
-                      <Link to={otherUnit.url}>
-                        {getUnitName({ unit: otherUnit.unit, language })}
-                      </Link>
-                      {index !== restrictionError.otherUnits.length - 1 ? ", " : ""}
-                    </Fragment>
-                  ));
 
                   if (!stackable) {
                     const isDisabled =
@@ -1261,22 +1203,7 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                           language,
                           disabled: isDisabled,
                         })}
-                        {restrictionError &&
-                          <ErrorMessage
-                            key={`${id}-restrictederror`}
-                            spaceAfter
-                            spaceBefore={isMobile}
-                          >
-                            <span>
-                              <FormattedMessage
-                                id={restrictionError.message}
-                                values={{
-                                  usedby: usedElsewhereBy,
-                                }}
-                              />
-                            </span>
-                          </ErrorMessage>
-                        }
+                        {optionErrors[id] && optionErrorMessage(id)}
                         {options?.length > 0 && active && (
                           <>
                             {options

--- a/src/utils/option-restrictions.js
+++ b/src/utils/option-restrictions.js
@@ -1,0 +1,62 @@
+
+export const checkUnitOptionRestrictions = (unit, list) => {
+  const errors = {};
+  const categories = [
+    "command",
+    "equipment",
+    "armor",
+    "options",
+    "mounts",
+  ]
+  for (let category of categories) {
+    if (unit[category] && unit[category].length) {
+      for (let option of unit.options) {
+        if (option.active && option.restrictions) {
+          errors[option.id] = checkOptionRestrictions(unit.id, option, list, "options");
+        }
+      }
+    }
+  }
+  return errors;
+}
+
+export const checkOptionRestrictions = (unitId, option, list, optionType) => {
+  if (option.id === undefined) {
+    console.log("Options with restrictions require ids");
+    return null;
+  }
+  const type = optionType || "options";
+
+  const allUnits = [
+    ...(list.characters || []),
+    ...(list.core || []),
+    ...(list.special || []),
+    ...(list.rare || []),
+    ...(list.mercenaries || []),
+  ];
+  let count = 1;
+  let otherUnits = [];
+  for (let targetUnit of allUnits) {
+    if (targetUnit.id !== unitId) {
+      if (targetUnit[type]) {
+        for (let targetOption of targetUnit[type]) {
+          if (targetOption.id === option.id && targetOption.active) {
+            count += 1;
+            otherUnits.push(targetUnit.id);
+          }
+        }
+      }
+    }
+  }
+  const max = option.restrictions.points
+      ? Math.floor(list.points / option.restrictions.points) * option.restrictions.max
+      : option.restrictions.max;
+  if (count > max) {
+    return {
+      message: "misc.error.maxOptionPerArmy",
+      otherUnits
+    }
+  } else {
+    return [];
+  }
+}

--- a/src/utils/option-restrictions.js
+++ b/src/utils/option-restrictions.js
@@ -27,22 +27,28 @@ export const checkOptionRestrictions = (unitId, option, list, optionType) => {
   }
   const type = optionType || "options";
 
-  const allUnits = [
-    ...(list.characters || []),
-    ...(list.core || []),
-    ...(list.special || []),
-    ...(list.rare || []),
-    ...(list.mercenaries || []),
+  const unitCategories = [
+    "characters",
+    "core",
+    "special",
+    "rare",
+    "mercenaries",
+    "allies",
   ];
   let count = 1;
   let otherUnits = [];
-  for (let targetUnit of allUnits) {
-    if (targetUnit.id !== unitId) {
-      if (targetUnit[type]) {
-        for (let targetOption of targetUnit[type]) {
-          if (targetOption.id === option.id && targetOption.active) {
-            count += 1;
-            otherUnits.push(targetUnit.id);
+  for (let targetCategory of unitCategories) {
+    for (let targetUnit of list[targetCategory]) {
+      if (targetUnit.id !== unitId) {
+        if (targetUnit[type]) {
+          for (let targetOption of targetUnit[type]) {
+            if (targetOption.id === option.id && targetOption.active) {
+              count += 1;
+              otherUnits.push({
+                url: `/editor/${list.id}/${targetCategory}/${targetUnit.id}/`,
+                unit: targetUnit,
+              });
+            }
           }
         }
       }
@@ -57,6 +63,6 @@ export const checkOptionRestrictions = (unitId, option, list, optionType) => {
       otherUnits
     }
   } else {
-    return [];
+    return undefined;
   }
 }

--- a/src/utils/option-restrictions.js
+++ b/src/utils/option-restrictions.js
@@ -20,7 +20,7 @@ export const checkUnitOptionRestrictions = (unit, list) => {
     if (unit[category] && unit[category].length) {
       for (let option of unit.options) {
         if (option.active && option.restrictions && option.id) {
-          errors[option.id] = checkOptionRestrictions(unit.id, option, list, "options");
+          errors[option.id] = checkOptionRestrictions(unit.id, option, list, category);
         }
       }
     }
@@ -62,7 +62,10 @@ export const checkOptionRestrictions = (unitId, option, list, optionType) => {
       if (targetUnit.id !== unitId) {
         if (targetUnit[type]) {
           for (let targetOption of targetUnit[type]) {
-            if (targetOption.id === option.id && targetOption.active) {
+            const violation = targetOption.active && option.restrictions.ids
+              ? option.restrictions.ids.includes(targetOption.id)
+              : targetOption.id === option.id
+            if (violation) {
               count += 1;
               otherUnits.push({
                 url: `/editor/${list.id}/${targetCategory}/${targetUnit.id}/`,
@@ -77,7 +80,6 @@ export const checkOptionRestrictions = (unitId, option, list, optionType) => {
   const max = option.restrictions.points
       ? Math.floor(list.points / option.restrictions.points) * option.restrictions.max
       : option.restrictions.max;
-  console.log(`max: ${max}, count: ${count}`)
   if (count > max) {
     return {
       message: "misc.error.maxOptionPerArmy",

--- a/src/utils/option-restrictions.js
+++ b/src/utils/option-restrictions.js
@@ -85,13 +85,29 @@ export const checkOptionRestrictions = (unitId, option, list, optionType) => {
   if (option.restrictions.requires) {
     if (option.restrictions.requires.unitIds) {
       max = 0;
-      message = "misc.error.optionRequiresUnit";
-      for (let unitCandidate of list[option.restrictions.requires.type]) {
+      if (option.restrictions.requires.option) {
+        message = "misc.error.optionRequiresUnitWithOption";
+      } else {
+        message = "misc.error.optionRequiresUnit";
+      }
+      for (let unitCandidate of list[option.restrictions.requires.type] || []) {
         if (option.restrictions.requires.unitIds.includes(unitCandidate.id.split('.')[0])) {
-          max = option.restrictions.perUnit
-            ? max + 1
-            : option.restrictions.max;
-          message = "misc.error.maxOptionPerArmy";
+          if (option.restrictions.requires.option) {
+            const hasOption = unitCandidate[option.restrictions.requires.optionType || "options"]
+              .reduce((prev, current) => 
+                prev || (current.active && current.id === option.restrictions.requires.option), false);
+            if (hasOption) {
+              max = option.restrictions.requires.perUnit
+                ? max + 1
+                : option.restrictions.max;
+              message = "misc.error.maxOptionPerArmy";
+            }
+          } else {
+            max = option.restrictions.requires.perUnit
+              ? max + 1
+              : option.restrictions.max;
+            message = "misc.error.maxOptionPerArmy";
+          }
         }
       }
     }

--- a/src/utils/option-restrictions.js
+++ b/src/utils/option-restrictions.js
@@ -1,4 +1,12 @@
-
+/**
+ * Finds all active options with restrictions and checks them against the
+ * army list to find any violations.
+ * 
+ * @param {object} unit The unit to be checked
+ * @param {object} list The army list the unit is part of
+ * @returns {object} A dictionary of the errors found. key is the option's id,
+ * value is an error message object of type {message: string, otherUnits: string[]}
+ */
 export const checkUnitOptionRestrictions = (unit, list) => {
   const errors = {};
   const categories = [
@@ -11,7 +19,7 @@ export const checkUnitOptionRestrictions = (unit, list) => {
   for (let category of categories) {
     if (unit[category] && unit[category].length) {
       for (let option of unit.options) {
-        if (option.active && option.restrictions) {
+        if (option.active && option.restrictions && option.id) {
           errors[option.id] = checkOptionRestrictions(unit.id, option, list, "options");
         }
       }
@@ -20,10 +28,22 @@ export const checkUnitOptionRestrictions = (unit, list) => {
   return errors;
 }
 
+/**
+ * Checks whether a specific option's restrictions are violated by other units in the
+ * army list
+ * 
+ * @param {string} unitId The id of the unit with the option
+ * @param {object} option The object definition of the option
+ * @param {object} list The army list the unit is a part of
+ * @param {string} optionType The category of the option, ie "command", "armor", "options"
+ * @returns {{message: string, otherUnits: {url: string, unit: object}[]} || undefined} An error message
+ * object, with a list of the other units that violate the option's restrictions. If there is no
+ * error, returns undefined.
+ */
 export const checkOptionRestrictions = (unitId, option, list, optionType) => {
   if (option.id === undefined) {
     console.log("Options with restrictions require ids");
-    return null;
+    return undefined;
   }
   const type = optionType || "options";
 
@@ -57,6 +77,7 @@ export const checkOptionRestrictions = (unitId, option, list, optionType) => {
   const max = option.restrictions.points
       ? Math.floor(list.points / option.restrictions.points) * option.restrictions.max
       : option.restrictions.max;
+  console.log(`max: ${max}, count: ${count}`)
   if (count > max) {
     return {
       message: "misc.error.maxOptionPerArmy",

--- a/src/utils/option-restrictions.js
+++ b/src/utils/option-restrictions.js
@@ -47,6 +47,7 @@ export const checkOptionRestrictions = (unitId, option, list, optionType) => {
   }
   const type = optionType || "options";
 
+  // Count how many units have this option
   const unitCategories = [
     "characters",
     "core",
@@ -62,10 +63,10 @@ export const checkOptionRestrictions = (unitId, option, list, optionType) => {
       if (targetUnit.id !== unitId) {
         if (targetUnit[type]) {
           for (let targetOption of targetUnit[type]) {
-            const violation = targetOption.active && option.restrictions.ids
+            const hasOption = targetOption.active && (option.restrictions.ids
               ? option.restrictions.ids.includes(targetOption.id)
-              : targetOption.id === option.id
-            if (violation) {
+              : targetOption.id === option.id);
+            if (hasOption) {
               count += 1;
               otherUnits.push({
                 url: `/editor/${list.id}/${targetCategory}/${targetUnit.id}/`,
@@ -77,12 +78,31 @@ export const checkOptionRestrictions = (unitId, option, list, optionType) => {
       }
     }
   }
-  const max = option.restrictions.points
-      ? Math.floor(list.points / option.restrictions.points) * option.restrictions.max
-      : option.restrictions.max;
+  // Determine if that count exceeds the maximum number allowed.
+  // If restriction is poorly formatted and max can't be determined, allow any number.
+  let max = Infinity;
+  let message = "misc.error.maxOptionPerArmy";
+  if (option.restrictions.requires) {
+    if (option.restrictions.requires.unitIds) {
+      max = 0;
+      message = "misc.error.optionRequiresUnit";
+      for (let unitCandidate of list[option.restrictions.requires.type]) {
+        if (option.restrictions.requires.unitIds.includes(unitCandidate.id.split('.')[0])) {
+          max = option.restrictions.perUnit
+            ? max + 1
+            : option.restrictions.max;
+          message = "misc.error.maxOptionPerArmy";
+        }
+      }
+    }
+  } else if (option.restrictions.points) {
+    max = Math.floor(list.points / option.restrictions.points) * option.restrictions.max;
+  } else if (option.restrictions.max) {
+    max = option.restrictions.max;
+  }
   if (count > max) {
     return {
-      message: "misc.error.maxOptionPerArmy",
+      message,
       otherUnits
     }
   } else {

--- a/src/utils/option-restrictions.js
+++ b/src/utils/option-restrictions.js
@@ -18,7 +18,7 @@ export const checkUnitOptionRestrictions = (unit, list) => {
   ]
   for (let category of categories) {
     if (unit[category] && unit[category].length) {
-      for (let option of unit.options) {
+      for (let option of unit[category]) {
         if (option.active && option.restrictions && option.id) {
           errors[option.id] = checkOptionRestrictions(unit.id, option, list, category);
         }

--- a/src/utils/option-restrictions.js
+++ b/src/utils/option-restrictions.js
@@ -1,6 +1,6 @@
 /**
- * Finds all active options with restrictions and checks them against the
- * army list to find any violations.
+ * Finds all active options with restrictions and checks them against the army list to
+ * find any violations.
  * 
  * @param {object} unit The unit to be checked
  * @param {object} list The army list the unit is part of
@@ -29,20 +29,23 @@ export const checkUnitOptionRestrictions = (unit, list) => {
 }
 
 /**
- * Checks whether a specific option's restrictions are violated by other units in the
- * army list
+ * Checks whether a specific active option's restrictions are violated by other units in
+ * the army list
  * 
  * @param {string} unitId The id of the unit with the option
  * @param {object} option The object definition of the option
  * @param {object} list The army list the unit is a part of
  * @param {string} optionType The category of the option, ie "command", "armor", "options"
- * @returns {{message: string, otherUnits: {url: string, unit: object}[]} || undefined} An error message
- * object, with a list of the other units that violate the option's restrictions. If there is no
- * error, returns undefined.
+ * @returns {{message: string, otherUnits: {url: string, unit: object}[]} || undefined} 
+ *    An error message object, with a list of the other units that violate the option's 
+ *    restrictions. If there is no error, returns undefined.
  */
 export const checkOptionRestrictions = (unitId, option, list, optionType) => {
   if (option.id === undefined) {
     console.log("Options with restrictions require ids");
+    return undefined;
+  }
+  if (option.restrictions?.restrictMagicItems && (option.magic?.selected?.length || 0) < 1) {
     return undefined;
   }
   const type = optionType || "options";
@@ -63,9 +66,12 @@ export const checkOptionRestrictions = (unitId, option, list, optionType) => {
       if (targetUnit.id !== unitId) {
         if (targetUnit[type]) {
           for (let targetOption of targetUnit[type]) {
-            const hasOption = targetOption.active && (option.restrictions.ids
+            let hasOption = targetOption.active && (option.restrictions.ids 
               ? option.restrictions.ids.includes(targetOption.id)
               : targetOption.id === option.id);
+            if (option.restrictions.restrictMagicItems) {
+              hasOption = hasOption && targetOption.magic?.selected?.length > 0;
+            }
             if (hasOption) {
               count += 1;
               otherUnits.push({
@@ -85,11 +91,9 @@ export const checkOptionRestrictions = (unitId, option, list, optionType) => {
   if (option.restrictions.requires) {
     if (option.restrictions.requires.unitIds) {
       max = 0;
-      if (option.restrictions.requires.option) {
-        message = "misc.error.optionRequiresUnitWithOption";
-      } else {
-        message = "misc.error.optionRequiresUnit";
-      }
+      message = option.restrictions.requires.option
+        ? "misc.error.optionRequiresUnitWithOption"
+        : "misc.error.optionRequiresUnit";
       for (let unitCandidate of list[option.restrictions.requires.type] || []) {
         if (option.restrictions.requires.unitIds.includes(unitCandidate.id.split('.')[0])) {
           if (option.restrictions.requires.option) {

--- a/src/utils/option-restrictions.test.js
+++ b/src/utils/option-restrictions.test.js
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "vitest";
+import { checkOptionRestrictions } from "./option-restrictions";
+
+const baseList = {
+  armyComposition: "unknown-composition",
+  points: 2000,
+  characters: [],
+  core: [
+    { id: "badlands-ogre-bulls.1", name_en: "Badlands Ogre Bulls" },
+    { id: "battle-pilgrims.1", name_en: "Battle Pilgrims" },
+    { id: "black-guard-of-naggarond.1", name_en: "Black Guard of Naggarond" },
+  ],
+  special: [],
+  rare: [],
+  mercenaries: [],
+  allies: [],
+};
+
+const getMessages = (errors) => errors.map((error) => error.message);
+
+describe("checkOptionRestrictions", () => {
+  test("adds maxOptionPerArmy when two units have a max 1 option", () => {
+    const orcMob1 = {
+      id: "orc-mob.1",
+      name_en: "Orc Mob",
+      options: [{
+        id: "orc-mob-biguns",
+        active: true,
+        name_en: "Big 'Uns",
+        notes: {
+          name_en: "0-1 per army",
+        },
+        restrictions: {
+          max: 1
+        },
+      }]
+    }
+    const orcMob2 = {
+      id: "orc-mob.2",
+      name_en: "Orc Mob",
+      options: [{
+        id: "orc-mob-biguns",
+        active: true,
+        name_en: "Big 'Uns",
+        notes: {
+          name_en: "0-1 per army",
+        },
+        restrictions: {
+          max: 1
+        },
+      }]
+    }
+    const list = {
+      ...baseList,
+      core: [...baseList.core, orcMob1, orcMob2]
+    }
+
+    const errors = checkOptionRestrictions(orcMob1.id, orcMob1.options[0], list, "options");
+    expect(errors).toEqual({
+      message: "misc.error.maxOptionPerArmy",
+      otherUnits: ["orc-mob.2"],
+    });
+  });
+});
+
+describe("checkOptionRestrictions", () => {
+  test("adds maxOptionPerArmy when exceeding a max 1 per 1000 option", () => {
+    const orcMob1 = {
+      id: "orc-mob.1",
+      name_en: "Orc Mob",
+      options: [{
+        id: "orc-mob-frenzy",
+        active: true,
+        name_en: "Frenzy",
+        notes: {
+          name_en: "0-1 per 1,000 points",
+        },
+        restrictions: {
+          max: 1,
+          points: 1000
+        },
+      }]
+    }
+    const orcMob2 = {
+      id: "orc-mob.2",
+      name_en: "Orc Mob",
+      options: [{
+        id: "orc-mob-frenzy",
+        active: true,
+        name_en: "Frenzy",
+        notes: {
+          name_en: "0-1 per 1,000 points",
+        },
+        restrictions: {
+          max: 1,
+          points: 1000
+        },
+      }]
+    }
+    const list = {
+      ...baseList,
+      core: [...baseList.core, orcMob1, orcMob2]
+    }
+
+    const errors1 = checkOptionRestrictions(orcMob1.id, orcMob1.options[0], list, "options");
+    expect(errors1).toEqual([]);
+
+    list.points = 1000;
+
+    const errors2 = checkOptionRestrictions(orcMob1.id, orcMob1.options[0], list, "options");
+    expect(errors2).toEqual({
+      message: "misc.error.maxOptionPerArmy",
+      otherUnits: ["orc-mob.2"],
+    });
+  });
+});

--- a/src/utils/option-restrictions.test.js
+++ b/src/utils/option-restrictions.test.js
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import { checkOptionRestrictions } from "./option-restrictions";
 
 const baseList = {
+  id: "test-army",
   armyComposition: "unknown-composition",
   points: 2000,
   characters: [],
@@ -15,8 +16,6 @@ const baseList = {
   mercenaries: [],
   allies: [],
 };
-
-const getMessages = (errors) => errors.map((error) => error.message);
 
 describe("checkOptionRestrictions", () => {
   test("adds maxOptionPerArmy when two units have a max 1 option", () => {
@@ -56,10 +55,8 @@ describe("checkOptionRestrictions", () => {
     }
 
     const errors = checkOptionRestrictions(orcMob1.id, orcMob1.options[0], list, "options");
-    expect(errors).toEqual({
-      message: "misc.error.maxOptionPerArmy",
-      otherUnits: ["orc-mob.2"],
-    });
+    expect(errors.message).toEqual("misc.error.maxOptionPerArmy");
+    expect(errors.otherUnits[0].url).toEqual("/editor/test-army/core/orc-mob.2/")
   });
 });
 
@@ -103,14 +100,12 @@ describe("checkOptionRestrictions", () => {
     }
 
     const errors1 = checkOptionRestrictions(orcMob1.id, orcMob1.options[0], list, "options");
-    expect(errors1).toEqual([]);
+    expect(errors1).toEqual(undefined);
 
     list.points = 1000;
 
     const errors2 = checkOptionRestrictions(orcMob1.id, orcMob1.options[0], list, "options");
-    expect(errors2).toEqual({
-      message: "misc.error.maxOptionPerArmy",
-      otherUnits: ["orc-mob.2"],
-    });
+    expect(errors2.message).toEqual("misc.error.maxOptionPerArmy");
+    expect(errors2.otherUnits[0].url).toEqual("/editor/test-army/core/orc-mob.2/")
   });
 });

--- a/src/utils/option-restrictions.test.js
+++ b/src/utils/option-restrictions.test.js
@@ -35,19 +35,8 @@ describe("checkOptionRestrictions", () => {
       }]
     }
     const orcMob2 = {
+      ...orcMob1,
       id: "orc-mob.2",
-      name_en: "Orc Mob",
-      options: [{
-        id: "orc-mob-biguns",
-        active: true,
-        name_en: "Big 'Uns",
-        notes: {
-          name_en: "0-1 per army",
-        },
-        restrictions: {
-          max: 1
-        },
-      }]
     }
     const list = {
       ...baseList,
@@ -56,11 +45,9 @@ describe("checkOptionRestrictions", () => {
 
     const errors = checkOptionRestrictions(orcMob1.id, orcMob1.options[0], list, "options");
     expect(errors.message).toEqual("misc.error.maxOptionPerArmy");
-    expect(errors.otherUnits[0].url).toEqual("/editor/test-army/core/orc-mob.2/")
+    expect(errors.otherUnits[0].url).toEqual("/editor/test-army/core/orc-mob.2/");
   });
-});
 
-describe("checkOptionRestrictions", () => {
   test("adds maxOptionPerArmy when exceeding a max 1 per 1000 option", () => {
     const orcMob1 = {
       id: "orc-mob.1",
@@ -109,5 +96,90 @@ describe("checkOptionRestrictions", () => {
     expect(errors3.message).toEqual("misc.error.maxOptionPerArmy");
     expect(errors3.otherUnits.length).toEqual(2);
     expect(errors3.otherUnits[0].url).toEqual("/editor/test-army/core/orc-mob.2/");
+  });
+
+  test("works with other option types like weapon and armour", () => {
+    const orcMob1 = {
+      id: "orc-mob.1",
+      name_en: "Orc Mob",
+      weapons: [{
+        id: "orc-mob-big-guns",
+        active: true,
+        name_en: "Big Guns",
+        notes: {
+          name_en: "0-1 per army",
+        },
+        restrictions: {
+          max: 1
+        },
+      }]
+    }
+    const orcMob2 = {
+      ...orcMob1,
+      id: "orc-mob.2",
+    }
+    const list = {
+      ...baseList,
+      core: [...baseList.core, orcMob1, orcMob2]
+    }
+
+    const errors = checkOptionRestrictions(orcMob1.id, orcMob1.weapons[0], list, "weapons");
+    expect(errors.message).toEqual("misc.error.maxOptionPerArmy");
+    expect(errors.otherUnits[0].url).toEqual("/editor/test-army/core/orc-mob.2/");
+  });
+
+  test("options with an id in 'restrictions.ids' are counted", () => {
+    const orcChariot1 = {
+      id: "orc-chariot.1",
+      name_en: "Orc Chariot",
+      options: [{
+        id: "orc-chariot-frenzy-2",
+        active: true,
+        name_en: "Frenzy with two crew",
+        notes: {
+          name_en: "0-1 per army",
+        },
+        restrictions: {
+          max: 1,
+          ids: ["orc-chariot-frenzy-2", "orc-chariot-frenzy-3"]
+        },
+      }]
+    }
+    const orcChariot2 = {
+      id: "orc-chariot.2",
+      name_en: "Orc Chariot",
+      options: [{
+        id: "orc-chariot-frenzy-3",
+        active: true,
+        name_en: "Frenzy with three crew",
+        notes: {
+          name_en: "0-1 per army",
+        },
+        restrictions: {
+          max: 1,
+          ids: ["orc-chariot-frenzy-2", "orc-chariot-frenzy-3"]
+        },
+      }]
+    }
+    const list = {
+      ...baseList,
+      core: [...baseList.core, orcChariot1, orcChariot2]
+    }
+
+    const errors = checkOptionRestrictions(orcChariot1.id, orcChariot1.options[0], list, "options");
+    expect(errors.message).toEqual("misc.error.maxOptionPerArmy");
+    expect(errors.otherUnits[0].url).toEqual("/editor/test-army/core/orc-chariot.2/");
+  });
+
+  test("adds maxOptionPerArmy if requires character max limit is exceeded", () => {
+    // TO DO
+  });
+
+  test("adds maxOptionPerArmy if requires character with specific option max limit is exceeded", () => {
+    // TO DO
+  });
+
+  test("adds maxOptionPerArmy if subOption: magic (command banners)", () => {
+    // TO DO
   });
 });

--- a/src/utils/option-restrictions.test.js
+++ b/src/utils/option-restrictions.test.js
@@ -79,33 +79,35 @@ describe("checkOptionRestrictions", () => {
       }]
     }
     const orcMob2 = {
+      ...orcMob1,
       id: "orc-mob.2",
-      name_en: "Orc Mob",
-      options: [{
-        id: "orc-mob-frenzy",
-        active: true,
-        name_en: "Frenzy",
-        notes: {
-          name_en: "0-1 per 1,000 points",
-        },
-        restrictions: {
-          max: 1,
-          points: 1000
-        },
-      }]
     }
     const list = {
       ...baseList,
       core: [...baseList.core, orcMob1, orcMob2]
     }
 
+    // No errors with 2 units at 2000 points
     const errors1 = checkOptionRestrictions(orcMob1.id, orcMob1.options[0], list, "options");
     expect(errors1).toEqual(undefined);
 
+    // Error with 2 units at 1000 points
     list.points = 1000;
 
     const errors2 = checkOptionRestrictions(orcMob1.id, orcMob1.options[0], list, "options");
     expect(errors2.message).toEqual("misc.error.maxOptionPerArmy");
-    expect(errors2.otherUnits[0].url).toEqual("/editor/test-army/core/orc-mob.2/")
+    expect(errors2.otherUnits[0].url).toEqual("/editor/test-army/core/orc-mob.2/");
+
+    // Error with 3 units at 2000 points
+    const orcMob3 = {
+      ...orcMob1,
+      id: "orc-mob.3",
+    }
+    list.points = 2000;
+    list.core.push(orcMob3);
+    const errors3 = checkOptionRestrictions(orcMob1.id, orcMob1.options[0], list, "options");
+    expect(errors3.message).toEqual("misc.error.maxOptionPerArmy");
+    expect(errors3.otherUnits.length).toEqual(2);
+    expect(errors3.otherUnits[0].url).toEqual("/editor/test-army/core/orc-mob.2/");
   });
 });

--- a/src/utils/option-restrictions.test.js
+++ b/src/utils/option-restrictions.test.js
@@ -175,7 +175,7 @@ describe("checkOptionRestrictions", () => {
     expect(errors.otherUnits[0].url).toEqual("/editor/test-army/core/orc-chariot.2/");
   });
 
-  test("adds maxOptionPerArmy if requires character max limit is exceeded", () => {
+  test("adds errors if requires character max limit is exceeded", () => {
     const wolfRiders1 = {
       id: "goblin-wolf-riders.1",
       name: "Goblin Wolf Riders",
@@ -227,8 +227,90 @@ describe("checkOptionRestrictions", () => {
     expect(errors3.otherUnits.length).toEqual(1);
   });
 
-  test.todo("adds maxOptionPerArmy if requires character with specific option max limit is exceeded", () => {
-    // TO DO
+  test("adds errors if requires character with specific option max limit is exceeded", () => {
+    const freebladeKnights1 = {
+      id: "freebladeKnights.1",
+      name: "Freeblade Knights",
+      options: [
+        {
+          "id": "knights-lance-noble-disdain",
+          "name_en": "Lance Formation, Noble Disdain",
+          "active": true,
+          "notes": {
+            "name_en": "0-1 unit for each character with the Renegade Knight Infamous Origin",
+          },
+          "restrictions": {
+            "requires": {
+              "unitIds": ["renegade-prince", "renegade-captain", "outcast-wizard"],
+              "option": "renegade-knight",
+              "optionType": "command",
+              "perUnit": true,
+              "type": "characters"
+            },
+            "max": 1
+          }
+        }
+      ]
+    }
+    const list = {
+      ...baseList,
+      core: [...baseList.core, freebladeKnights1]
+    }
+    // Without a Renegade Knight, having the option enabled throws throws an error
+    const errors1 = checkOptionRestrictions(freebladeKnights1.id, freebladeKnights1.options[0], list, "options");
+    expect(errors1).toBeDefined();
+    expect(errors1.message).toEqual("misc.error.optionRequiresUnitWithOption");
+    expect(errors1.otherUnits.length).toEqual(0);
+
+    // Error still occurs if a character of the right type is added who doesn't have the option
+    const prince1 = {
+      id: "renegade-prince.1",
+      name_en: "Renegade Prince",
+      command: []
+    }
+    list.characters = [prince1];
+    const errors2 = checkOptionRestrictions(freebladeKnights1.id, freebladeKnights1.options[0], list, "options");
+    expect(errors2).toBeDefined();
+    expect(errors2.message).toEqual("misc.error.optionRequiresUnitWithOption");
+    expect(errors2.otherUnits.length).toEqual(0);
+
+    // Adding required option makes error go away
+    list.characters[0].command = [
+      {
+        id: "renegade-knight",
+        name_en: "Renegade Knight",
+        active: true
+      }
+    ]
+    const errors3 = checkOptionRestrictions(freebladeKnights1.id, freebladeKnights1.options[0], list, "options");
+    expect(errors3).toBeUndefined();
+
+    // Adding another unit with the option throws a different error
+    const freebladeKnights2 = {
+      ...freebladeKnights1,
+      id: "freebladeKnights.2"
+    }
+    list.core.push(freebladeKnights2);
+    const errors4 = checkOptionRestrictions(freebladeKnights1.id, freebladeKnights1.options[0], list, "options");
+    expect(errors4).toBeDefined();
+    expect(errors4.message).toEqual("misc.error.maxOptionPerArmy");
+    expect(errors4.otherUnits.length).toEqual(1);
+
+    // Adding another character with the required option makes error go away
+    const captain1 = {
+      id: "renegade-captain.1",
+      name_en: "Renegade Captain",
+      command: [
+        {
+          id: "renegade-knight",
+          name_en: "Renegade Knight",
+          active: true
+        }
+      ]
+    }
+    list.characters.push(captain1);
+    const errors5 = checkOptionRestrictions(freebladeKnights1.id, freebladeKnights1.options[0], list, "options");
+    expect(errors5).toBeUndefined();
   });
 
   test.todo("adds maxOptionPerArmy if subOption: magic (command banners)", () => {

--- a/src/utils/option-restrictions.test.js
+++ b/src/utils/option-restrictions.test.js
@@ -76,12 +76,13 @@ describe("checkOptionRestrictions", () => {
 
     // No errors with 2 units at 2000 points
     const errors1 = checkOptionRestrictions(orcMob1.id, orcMob1.options[0], list, "options");
-    expect(errors1).toEqual(undefined);
+    expect(errors1).toBeUndefined();
 
     // Error with 2 units at 1000 points
     list.points = 1000;
 
     const errors2 = checkOptionRestrictions(orcMob1.id, orcMob1.options[0], list, "options");
+    expect(errors2).toBeDefined();
     expect(errors2.message).toEqual("misc.error.maxOptionPerArmy");
     expect(errors2.otherUnits[0].url).toEqual("/editor/test-army/core/orc-mob.2/");
 
@@ -93,6 +94,7 @@ describe("checkOptionRestrictions", () => {
     list.points = 2000;
     list.core.push(orcMob3);
     const errors3 = checkOptionRestrictions(orcMob1.id, orcMob1.options[0], list, "options");
+    expect(errors3).toBeDefined();
     expect(errors3.message).toEqual("misc.error.maxOptionPerArmy");
     expect(errors3.otherUnits.length).toEqual(2);
     expect(errors3.otherUnits[0].url).toEqual("/editor/test-army/core/orc-mob.2/");
@@ -124,6 +126,7 @@ describe("checkOptionRestrictions", () => {
     }
 
     const errors = checkOptionRestrictions(orcMob1.id, orcMob1.weapons[0], list, "weapons");
+    expect(errors).toBeDefined();
     expect(errors.message).toEqual("misc.error.maxOptionPerArmy");
     expect(errors.otherUnits[0].url).toEqual("/editor/test-army/core/orc-mob.2/");
   });
@@ -167,19 +170,68 @@ describe("checkOptionRestrictions", () => {
     }
 
     const errors = checkOptionRestrictions(orcChariot1.id, orcChariot1.options[0], list, "options");
+    expect(errors).toBeDefined();
     expect(errors.message).toEqual("misc.error.maxOptionPerArmy");
     expect(errors.otherUnits[0].url).toEqual("/editor/test-army/core/orc-chariot.2/");
   });
 
   test("adds maxOptionPerArmy if requires character max limit is exceeded", () => {
+    const wolfRiders1 = {
+      id: "goblin-wolf-riders.1",
+      name: "Goblin Wolf Riders",
+      options: [
+        {
+          "id": "wolf-rider-kiknik-ambushers",
+          "name_en": "Ambushers",
+          "active": true,
+          "notes": {
+            "name_en": "0-1 Goblin Wolf Rider Mob if Kiknik is in the army",
+          },
+          "restrictions": {
+            "requires": {
+              "unitIds": ["kiknik-toofsnatcha"],
+              "type": "characters"
+            },
+            "max": 1
+          }
+        }
+      ]
+    }
+    const list = {
+      ...baseList,
+      core: [...baseList.core, wolfRiders1]
+    }
+    // Without Kiknik, having the option enabled throws throws an error
+    const errors1 = checkOptionRestrictions(wolfRiders1.id, wolfRiders1.options[0], list, "options");
+    expect(errors1).toBeDefined();
+    expect(errors1.message).toEqual("misc.error.optionRequiresUnit");
+    expect(errors1.otherUnits.length).toEqual(0);
+
+    // With Kiknik, the error goes away
+    list.characters = [{
+      id: "kiknik-toofsnatcha.1",
+      name_en: "Kiknik Toofsnatcha",
+    }];
+    const errors2 = checkOptionRestrictions(wolfRiders1.id, wolfRiders1.options[0], list, "options");
+    expect(errors2).toBeUndefined();
+
+    // With another wolf rider with the option, throws a different error
+    const wolfRiders2 = {
+      ...wolfRiders1,
+      id: "wolfRiders2"
+    }
+    list.core.push(wolfRiders2);
+    const errors3 = checkOptionRestrictions(wolfRiders1.id, wolfRiders1.options[0], list, "options");
+    expect(errors3).toBeDefined();
+    expect(errors3.message).toEqual("misc.error.maxOptionPerArmy");
+    expect(errors3.otherUnits.length).toEqual(1);
+  });
+
+  test.todo("adds maxOptionPerArmy if requires character with specific option max limit is exceeded", () => {
     // TO DO
   });
 
-  test("adds maxOptionPerArmy if requires character with specific option max limit is exceeded", () => {
-    // TO DO
-  });
-
-  test("adds maxOptionPerArmy if subOption: magic (command banners)", () => {
+  test.todo("adds maxOptionPerArmy if subOption: magic (command banners)", () => {
     // TO DO
   });
 });

--- a/src/utils/option-restrictions.test.js
+++ b/src/utils/option-restrictions.test.js
@@ -181,18 +181,18 @@ describe("checkOptionRestrictions", () => {
       name: "Goblin Wolf Riders",
       options: [
         {
-          "id": "wolf-rider-kiknik-ambushers",
-          "name_en": "Ambushers",
-          "active": true,
-          "notes": {
-            "name_en": "0-1 Goblin Wolf Rider Mob if Kiknik is in the army",
+          id: "wolf-rider-kiknik-ambushers",
+          name_en: "Ambushers",
+          active: true,
+          notes: {
+            name_en: "0-1 Goblin Wolf Rider Mob if Kiknik is in the army",
           },
-          "restrictions": {
-            "requires": {
-              "unitIds": ["kiknik-toofsnatcha"],
-              "type": "characters"
+          restrictions: {
+            requires: {
+              unitIds: ["kiknik-toofsnatcha"],
+              type: "characters"
             },
-            "max": 1
+            max: 1
           }
         }
       ]
@@ -233,21 +233,21 @@ describe("checkOptionRestrictions", () => {
       name: "Freeblade Knights",
       options: [
         {
-          "id": "knights-lance-noble-disdain",
-          "name_en": "Lance Formation, Noble Disdain",
-          "active": true,
-          "notes": {
-            "name_en": "0-1 unit for each character with the Renegade Knight Infamous Origin",
+          id: "knights-lance-noble-disdain",
+          name_en: "Lance Formation, Noble Disdain",
+          active: true,
+          notes: {
+            name_en: "0-1 unit for each character with the Renegade Knight Infamous Origin",
           },
-          "restrictions": {
-            "requires": {
-              "unitIds": ["renegade-prince", "renegade-captain", "outcast-wizard"],
-              "option": "renegade-knight",
-              "optionType": "command",
-              "perUnit": true,
-              "type": "characters"
+          restrictions: {
+            requires: {
+              unitIds: ["renegade-prince", "renegade-captain", "outcast-wizard"],
+              option: "renegade-knight",
+              optionType: "command",
+              perUnit: true,
+              type: "characters"
             },
-            "max": 1
+            max: 1
           }
         }
       ]
@@ -313,7 +313,62 @@ describe("checkOptionRestrictions", () => {
     expect(errors5).toBeUndefined();
   });
 
-  test.todo("adds maxOptionPerArmy if subOption: magic (command banners)", () => {
-    // TO DO
+  test("adds maxOptionPerArmy if subOption: magic (command banners)", () => {
+    const orcMob1 = {
+      id: "orc-mob.1",
+      name_en: "Orc Mob",
+      command: [{
+        id: "orc-mob-standard-bearer",
+        name_en: "Standard Bearer",
+        active: true,
+        magic: {
+          types: ["banner"],
+          selected: [
+            {
+              name_en: "War Banner",
+              points: 25
+            }
+          ]
+        },
+        notes: {
+          name_en: "0-1 unit per 1000 points may purchase a magic standard",
+        },
+        restrictions: {
+          restrictMagicItems: true,
+          max: 1,
+          points: 1000
+        }
+      }],
+    }
+    const orcMob2 = {
+      ...orcMob1,
+      id: "orc-mob.2",
+    }
+    // One mob with a standard bearer but no magic banner
+    const orcMob3 = {
+      ...orcMob1,
+      id: "orc-mob.3",
+      command: [{
+        id: "orc-mob-standard-bearer",
+        name_en: "Standard Bearer",
+        active: true,
+      }]
+    }
+    const list = {
+      ...baseList,
+      core: [...baseList.core, orcMob1, orcMob2, orcMob3]
+    }
+
+    // No errors with 2 units at 2000 points
+    const errors1 = checkOptionRestrictions(orcMob1.id, orcMob1.command[0], list, "command");
+    expect(errors1).toBeUndefined();
+
+    // Error with 2 units at 1000 points
+    list.points = 1000;
+
+    const errors2 = checkOptionRestrictions(orcMob1.id, orcMob1.command[0], list, "command");
+    expect(errors2).toBeDefined();
+    expect(errors2.message).toEqual("misc.error.maxOptionPerArmy");
+    expect(errors2.otherUnits[0].url).toEqual("/editor/test-army/core/orc-mob.2/");
   });
 });


### PR DESCRIPTION
I've added checks for the various types of restrictions the game has on unit options. The spec is detailed in a doc; to summarize, an option with a restriction must have an `id`, which is used to find other instances of units taking that option, and a `restrictions` object detailing the rules of the restriction. Checks are done by running through the army looking for any other active options that match the id of the current option. 

The only units I've added the rules to are Orc Boy Mobs, Goblin Wolf Riders, and the Renegade Crowns units; however I've included unit tests that helped a lot with development.

Gaps/next steps:
* Error messages could probably be improved.
* I've only added rules to a few units so far, but have at least one example of each general type of restriction. Thanks to my other PRs all the options with restrictions should at least have some notes describing them, so maybe task for a model to go and add the required `ids` and `restrictions`. 
* Sub options are currently not checked. I know of at least one instance, Orc Boar Chariots as mounts for characters, where there is an option that should be restricted.
* Performance might be an issue in bigger lists. Currently the useEffect checks and updates every option the unit has active against all other active options in the list on every update to the unit's definition when we really just need to check an option when its status is toggled.
* This opens the door for proper "1 per 1000 pts" checks for Battle March, but that needs to be done still. 

<img width="659" height="539" alt="OptionsRestrictions" src="https://github.com/user-attachments/assets/2cfd39df-d460-4e8e-afc3-3147f4f3486a" />