### PR TITLE
Cathay items that generate more spells, check command magic items in unitHasItems

### DIFF
--- a/src/pages/game-view/GameView.jsx
+++ b/src/pages/game-view/GameView.jsx
@@ -252,7 +252,6 @@ export const GameView = () => {
       <ul>
         {units.map((unit, index) => {
           const stats = unit.profile?.stats || getStats(unit, armyComposition);
-          // TODO: update for Wizards outside of standard Options (Flamers, Burning Chariots, Multi-Caster Models, etc)
           const unitGeneratedSpellCount = getUnitGeneratedSpellCount(unit);
           const specialRules =
             unit.armyComposition?.[armyComposition]?.specialRules ||

--- a/src/utils/unit.jsx
+++ b/src/utils/unit.jsx
@@ -439,6 +439,17 @@ export const unitHasItem = (unit, itemName) => {
       }
     }
   }
+  if (unit.command) {
+    for (const commandOption of unit.command) {
+      if (
+        commandOption.magic?.selected?.find(
+          ({ name_en }) => name_en.toLowerCase() === itemName.toLowerCase(),
+        )
+      ) {
+        return true;
+      }
+    }
+  }
   return false;
 };
 
@@ -653,17 +664,23 @@ export const getUnitGeneratedSpellCount = (unit) => {
   if (unitHasItem(unit, "Wizarding Hat")) {
     generatedSpellsCount += 1;
   }
-  if (unitHasItem(unit, "Spell Familiar*")) {
-    generatedSpellsCount += 1;
-  }
   if (
+    unitHasItem(unit, "Spell Familiar*") ||
     unitHasItem(unit, "Twin Heads") ||
     unitHasItem(unit, "Silvery Wand") ||
     unitHasItem(unit, "Tome Of Furion") ||
-    unitHasItem(unit, "Tome Of Midnight")
+    unitHasItem(unit, "Tome Of Midnight") ||
+    unitHasItem(unit, "Scrolls of Wei-jin")
   ) {
     generatedSpellsCount += 1;
   }
+  if (unitHasItem(unit, "Learned Feng Shi Bo*")) {
+    generatedSpellsCount += unit.items.find(
+      ({ name_en }) => name_en.toLowerCase() === "magic items"
+    ).selected?.find(
+      ({ name_en }) => name_en.toLowerCase() === "Learned Feng Shi Bo*".toLowerCase(),
+    )?.amount || 0;
+  }
 
-  return generatedSpellsCount;
+  return Math.min(generatedSpellsCount, 6);
 };


### PR DESCRIPTION
Fixes for a few spell selection bugs that were raised on the Discord. Specifically, adding the two Cathay items that allow casters to have more spells to the getUnitGeneratedSpellCount function, and adjust the unitHasItems function so it looks in the command options for the requested item, so Flamers of Tzeentch will properly get another spell for having Twin Heads.

I'm not 100% sure that the various "take another spell" items are supposed to stack, since they all say the owner "knows one more spell (chosen in the usual way) than is normal for their Level of Wizardry." That could be interpreted essentially as calling `generatedSpells = wizardLevel + 1` for each of these items, rather than `if(hasItem) generatedSpells += 1`. But I've implemented it such that if you buy multiple Learned Feng Shi Bo, each gives the wizard an additional spell; it'll be easy to roll back if it's FAQ'd, undoubtedly users will think that's how it's supposed to be implemented, and frankly it seems funner to be able to have all 6 spells.

<img width="700" height="322" alt="Screenshot from 2026-05-21 18-14-47" src="https://github.com/user-attachments/assets/1ebf8914-8fe6-4c53-b9dd-5a39463b7703" />
<img width="779" height="202" alt="Screenshot from 2026-05-21 18-15-41" src="https://github.com/user-attachments/assets/94fdae20-6930-4ce8-af4d-5e919cfef93b" />

