### PR TITLE
Adjust rules dialog width so it doesn't shrink too much on small screens

### DIFF
--- a/src/components/rules-index/RulesIndex.css
+++ b/src/components/rules-index/RulesIndex.css
@@ -5,6 +5,7 @@
 }
 
 .rules-index__iframe {
+  min-width: 100%;
   max-width: 70vw;
   max-height: 70vh;
   opacity: 0;


### PR DESCRIPTION
On small screens, the rules dialog iframe is shrinking too much when the screen is below a certain width. Adding a `min-width: 100%` seems to fix it.

Before:
<img width="326" height="599" alt="image" src="https://github.com/user-attachments/assets/f64c1734-d589-44c5-a2c4-d56f76ff98b0" />

After:
<img width="327" height="600" alt="image" src="https://github.com/user-attachments/assets/98ce9601-de4e-44cc-8ef6-969ff70b0db2" />
