### PR TITLE
Make Vampire wizard levels exclusive

### DIFF
--- a/public/games/the-old-world/vampire-counts.json
+++ b/public/games/the-old-world/vampire-counts.json
@@ -118,7 +118,8 @@
           "points": 30,
           "perModel": true,
           "minimum": 0,
-          "maximum": 0
+          "maximum": 0,
+          "exclusive": true
         },
         {
           "name_en": "Level 2 Wizard",
@@ -129,7 +130,8 @@
           "points": 60,
           "perModel": true,
           "minimum": 0,
-          "maximum": 0
+          "maximum": 0,
+          "exclusive": true
         }
       ],
       "mounts": [
@@ -729,7 +731,8 @@
           "points": 30,
           "perModel": true,
           "minimum": 0,
-          "maximum": 0
+          "maximum": 0,
+          "exclusive": true
         },
         {
           "name_en": "Level 2 Wizard",
@@ -740,7 +743,8 @@
           "points": 60,
           "perModel": true,
           "minimum": 0,
-          "maximum": 0
+          "maximum": 0,
+          "exclusive": true
         }
       ],
       "mounts": [


### PR DESCRIPTION
Add `exclusive: true` to the wizard options on Vampire Counts and Strigoi Ghoul Kings. I _think_ these are the only units that have optional wizard levels like this, but if there are others this should probably be added to those too.