### PR TITLE
Better checking for allied characters in Unit component

### DIFF
--- a/src/pages/unit/Unit.jsx
+++ b/src/pages/unit/Unit.jsx
@@ -64,6 +64,9 @@ export const Unit = ({ isMobile, previewData = {} }) => {
   const unit = units ? units.find(({ id }) => id === unitId) : previewUnit;
   const army = useSelector((state) => state.army);
   const settings = useSelector((state) => state.settings);
+  const isCharacter = 
+    type === "characters" || 
+    (!!unit.unitType && unit.unitType === "characters");
   const detachmentActive =
     unit &&
     unit?.options?.length > 0 &&
@@ -475,7 +478,7 @@ export const Unit = ({ isMobile, previewData = {} }) => {
               })
         }`}
         {perModel &&
-          type !== "characters" &&
+          !isCharacter &&
           ` ${intl.formatMessage({
             id: "unit.perModel",
           })}`}
@@ -726,7 +729,7 @@ export const Unit = ({ isMobile, previewData = {} }) => {
         ) : null}
         {unit.command && unit.command.length > 0 && (
           <>
-            {type !== "characters" && (
+            {!isCharacter && (
               <h2 className="unit__subline">
                 <FormattedMessage id="unit.command" />
               </h2>
@@ -771,7 +774,7 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                       <div
                         className={classNames(
                           "checkbox",
-                          type === "characters" && "unit__bsb",
+                          isCharacter && "unit__bsb",
                         )}
                       >
                         <input
@@ -786,7 +789,7 @@ export const Unit = ({ isMobile, previewData = {} }) => {
                           disabled={
                             detachmentActive ||
                             alwaysActive ||
-                            (type === "characters" &&
+                            (isCharacter &&
                               exclusive &&
                               unit.command.find(
                                 (commandUnit) =>


### PR DESCRIPTION
In the Unit component, characters added as allies are not being treated as characters, particularly in the command section. This means that exclusive options like General and BSB don't disable each other. I've used the same code as in the Magic component.