### PR TITLE
Add 'Regimental Unit' special rule to Sea Guard in Sea Guard Garrison

### DIFF
--- a/public/games/the-old-world/high-elf-realms.json
+++ b/public/games/the-old-world/high-elf-realms.json
@@ -2975,7 +2975,15 @@
           "category": "core"
         },
         "sea-guard-garrison": {
-          "category": "core"
+          "category": "core",
+          "specialRules": {
+            "name_en": "Close Order, Elven Reflexes, Martial Prowess, Naval Discipline, Valour of Ages, Regimental Unit",
+            "name_cn": "紧密阵型, 精灵反应, 精湛武艺, 海军纪律, 岁月的荣耀, 主团单位",
+            "name_it": "Formazione Serrata, Riflessi Elfici, Martial Prowess, Naval Discipline, Valore delle Ere, Unità Madre",
+            "name_fr": "Ordre Serré, Réflexes Elfiques, Prouesses Martiales, Discipline Navale, Valeur des Âges, Unité Régimentaire",
+            "name_es": "Formación Cerrada, Reflejos Élficos, Destreza Marcial, Disciplina Naval, Valor de las Eras, Unidad Regimental",
+            "name_de": "Geschlossene Ränge, Elfenreflexe, Kriegerisches Können, Flottendisziplin, Mut der Zeitalter, Hauptregiment"
+          }
         }
       },
       "points": 10,


### PR DESCRIPTION
In the Sea Guard Garrison army comp, Lothern Sea Guard get Regimental Unit. Brought up on discord.