### PR TITLE
Unit Strength > 20 for Battle March

### DIFF
--- a/public/games/the-old-world/beastmen-brayherds.json
+++ b/public/games/the-old-world/beastmen-brayherds.json
@@ -1606,6 +1606,7 @@
       "regimentalUnit": true,
       "minDetachments": 2,
       "maxDetachments": 2,
+      "detachmentsInUnitStr": true,
       "armyComposition": {
         "wild-herd": {
           "category": "core"
@@ -1665,6 +1666,7 @@
           "id": "gors.gxjrykvifu",
           "name_de": "Gors",
           "name_en": "Gors",
+          "name_fr": "Gors",
           "points": 7,
           "strength": 10,
           "minDetachmentSize": 10,
@@ -1715,13 +1717,13 @@
               }
             }
           ],
-          "specialRules": {},
-          "name_fr": "Gors"
+          "specialRules": {}
         },
         {
           "id": "ungors.xtxqwnwp",
           "name_de": "Ungors",
           "name_en": "Ungors",
+          "name_fr": "Ungors",
           "points": 6,
           "strength": 10,
           "minDetachmentSize": 10,
@@ -1772,8 +1774,7 @@
               }
             }
           ],
-          "specialRules": {},
-          "name_fr": "Ungors"
+          "specialRules": {}
         }
       ],
       "specialRules": {

--- a/src/i18n/cn.json
+++ b/src/i18n/cn.json
@@ -230,6 +230,7 @@
   "unit.category": "类型",
   "unit.troopType": "兵种类型",
   "unit.baseSize": "底盘尺寸",
+  "unit.battleMarchUnitStrErr": "Units may not have a Unit Strength higher than 20 in Battle March.",
   "black-orc-warboss": "黑兽人战将",
   "black-orc-bigboss": "黑兽人老大",
   "night-goblin-warboss": "夜地精战将",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -230,6 +230,7 @@
   "unit.category": "Kategorie",
   "unit.troopType": "Truppentyp",
   "unit.baseSize": "Base-Größe",
+  "unit.battleMarchUnitStrErr": "Units may not have a Unit Strength higher than 20 in Battle March.",
   "black-orc-warboss": "Schwarzork-Waaaghboss",
   "black-orc-bigboss": "Schwarzork-Gargboss",
   "night-goblin-warboss": "Nachtgoblin-Waaaghboss",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -230,6 +230,7 @@
   "unit.category": "Category",
   "unit.troopType": "Troop type",
   "unit.baseSize": "Base size",
+  "unit.battleMarchUnitStrErr": "Units may not have a Unit Strength higher than 20 in Battle March.",
   "black-orc-warboss": "Black Orc Warboss",
   "black-orc-bigboss": "Black Orc Bigboss",
   "night-goblin-warboss": "Night Goblin Warboss",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -230,6 +230,7 @@
   "unit.category": "Categoría",
   "unit.troopType": "Tipo de tropa",
   "unit.baseSize": "Tamaño de base",
+  "unit.battleMarchUnitStrErr": "Units may not have a Unit Strength higher than 20 in Battle March.",
   "black-orc-warboss": "Kaudillo Orco Negro",
   "black-orc-bigboss": "Gran Jefe Orco Negro",
   "night-goblin-warboss": "Kaudillo Goblin Nocturno",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -230,6 +230,7 @@
   "unit.category": "Category",
   "unit.troopType": "Troop type",
   "unit.baseSize": "Base size",
+  "unit.battleMarchUnitStrErr": "Units may not have a Unit Strength higher than 20 in Battle March.",
   "black-orc-warboss": "Chef de Guerre Orque Noir",
   "black-orc-bigboss": "Grand Chef Orque Noir",
   "night-goblin-warboss": "Chef de Guerre Gobelin de la Nuit",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -230,6 +230,7 @@
   "unit.category": "Category",
   "unit.troopType": "Troop type",
   "unit.baseSize": "Base size",
+  "unit.battleMarchUnitStrErr": "Units may not have a Unit Strength higher than 20 in Battle March.",
   "black-orc-warboss": "Black Orc Warboss",
   "black-orc-bigboss": "Black Orc Bigboss",
   "night-goblin-warboss": "Night Goblin Warboss",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -230,6 +230,7 @@
   "unit.category": "Category",
   "unit.troopType": "Troop type",
   "unit.baseSize": "Base size",
+  "unit.battleMarchUnitStrErr": "Units may not have a Unit Strength higher than 20 in Battle March.",
   "black-orc-warboss": "Black Orc Warboss",
   "black-orc-bigboss": "Black Orc Bigboss",
   "night-goblin-warboss": "Night Goblin Warboss",

--- a/src/pages/unit/Unit.css
+++ b/src/pages/unit/Unit.css
@@ -95,6 +95,12 @@
   margin-left: 5px;
 }
 
+.unit__error {
+  color: var(--color-error);
+  display: flex;
+  align-items: center;
+}
+
 .editor__error {
   color: var(--color-error);
   font-weight: bold;

--- a/src/pages/unit/Unit.jsx
+++ b/src/pages/unit/Unit.jsx
@@ -38,6 +38,7 @@ import {
   unitHasItem,
   isWizard,
   getStats,
+  getUnitStrength,
 } from "../../utils/unit";
 import { getGameSystems, getCustomDatasetData } from "../../utils/game-systems";
 
@@ -64,6 +65,7 @@ export const Unit = ({ isMobile, previewData = {} }) => {
   const unit = units ? units.find(({ id }) => id === unitId) : previewUnit;
   const army = useSelector((state) => state.army);
   const settings = useSelector((state) => state.settings);
+  const currentUnitStrength = getUnitStrength(unit, false);
   const detachmentActive =
     unit &&
     unit?.options?.length > 0 &&
@@ -724,6 +726,12 @@ export const Unit = ({ isMobile, previewData = {} }) => {
             />
           </>
         ) : null}
+        {currentUnitStrength > 20 && list.compositionRule && list.compositionRule.includes("battle-march") && (
+          <p className="unit__error">
+            <Icon symbol="error" className="unit__notes-icon" />
+            <FormattedMessage id="unit.battleMarchUnitStrErr" />
+          </p>
+        )}
         {unit.command && unit.command.length > 0 && (
           <>
             {type !== "characters" && (

--- a/src/utils/unit.jsx
+++ b/src/utils/unit.jsx
@@ -743,7 +743,6 @@ export const getUnitStrength = (unit, includeDetachments) => {
       }, 0);
       str += additionalWounds;
     }
-    console.log(unit);
     // Usually a unit no strength defined has one model in it, but "detachment only"
     // units like Primal Warherds or Skeleton Cohorts have their model counts entirely
     // in the detachments.

--- a/src/utils/unit.jsx
+++ b/src/utils/unit.jsx
@@ -720,17 +720,14 @@ const unitStrengthByType = {
   WM: "w",
 }
 
-export const getUnitStrength = (unit) => {
+/**
+ * Returns the unit's total unit strength, based on the troop type.
+ */
+export const getUnitStrength = (unit, includeDetachments) => {
   if (unit) {
-    const unitName =
-      unit.name_en.includes("renegade")
-        ? unit.name_en
-        : unit.name_en.replace(" {renegade}", "");
-    const unitRules = getUnitRuleData(unitName);
-    const activeMount = unit.mounts
-      ? unit.mounts.find((mount) => mount.active)
-      : null;
-    const mountRules = activeMount ? getUnitRuleData(activeMount.name_en) : null;
+    const unitRules = getUnitRuleData(unit.name_en);
+    const activeMount = unit.mounts?.find((mount) => mount.active);
+    const mountRules = activeMount ? getUnitRuleData(activeMount.name_en) : undefined;
     const unitType = mountRules?.troopType || unitRules?.troopType || "RI";
     let str = unitStrengthByType[unitType];
     if (str === "w") {
@@ -741,11 +738,21 @@ export const getUnitStrength = (unit) => {
           additionalWounds += parseInt(cur["W"].slice(2));
           return prev;
         } else {
-          return (Math.max(parseInt(cur["W"]) || 1, prev));
+          return Math.max(parseInt(cur["W"]) || 1, prev);
         }
       }, 0);
       str += additionalWounds;
     }
-    return str * (unit.strength || 1);
+    str = str * (unit.strength || 1);
+    if (includeDetachments && unit.detachments) {
+      unit.detachments.forEach((detachment) => {
+        const detachmentRules = getUnitRuleData(detachment.name_en);
+        const detachmentType = detachmentRules?.troopType || "RI";
+        str += unitStrengthByType[detachmentType] * (detachment.strength || 1);
+      });
+    }
+    return str;
+  } else {
+    return 0;
   }
 }

--- a/src/utils/unit.jsx
+++ b/src/utils/unit.jsx
@@ -743,8 +743,12 @@ export const getUnitStrength = (unit, includeDetachments) => {
       }, 0);
       str += additionalWounds;
     }
-    str = str * (unit.strength || 1);
-    if (includeDetachments && unit.detachments) {
+    console.log(unit);
+    // Usually a unit no strength defined has one model in it, but "detachment only"
+    // units like Primal Warherds or Skeleton Cohorts have their model counts entirely
+    // in the detachments.
+    str = str * (unit.strength || (unit.detachmentsInUnitStr ? 0 : 1));
+    if ((includeDetachments || unit.detachmentsInUnitStr) && unit.detachments) {
       unit.detachments.forEach((detachment) => {
         const detachmentRules = getUnitRuleData(detachment.name_en);
         const detachmentType = detachmentRules?.troopType || "RI";

--- a/src/utils/unit.jsx
+++ b/src/utils/unit.jsx
@@ -703,3 +703,49 @@ export const getUnitGeneratedSpellCount = (unit) => {
 
   return Math.min(generatedSpellsCount, 6);
 };
+
+const unitStrengthByType = {
+  RI: 1,
+  HI: 1,
+  MI: 3,
+  Sw: 3,
+  LCa: 2,
+  HCa: 2,
+  MCa: 3,
+  WB: 1,
+  LCh: 3,
+  HCh: 5,
+  MCr: "w",
+  Be: "w",
+  WM: "w",
+}
+
+export const getUnitStrength = (unit) => {
+  if (unit) {
+    const unitName =
+      unit.name_en.includes("renegade")
+        ? unit.name_en
+        : unit.name_en.replace(" {renegade}", "");
+    const unitRules = getUnitRuleData(unitName);
+    const activeMount = unit.mounts
+      ? unit.mounts.find((mount) => mount.active)
+      : null;
+    const mountRules = activeMount ? getUnitRuleData(activeMount.name_en) : null;
+    const unitType = mountRules?.troopType || unitRules?.troopType || "RI";
+    let str = unitStrengthByType[unitType];
+    if (str === "w") {
+      const stats = unitRules?.stats.concat(mountRules?.stats || []);
+      let additionalWounds = 0;
+      str = stats.reduce((prev, cur) => {
+        if (cur["W"].startsWith("(+")) {
+          additionalWounds += parseInt(cur["W"].slice(2));
+          return prev;
+        } else {
+          return (Math.max(parseInt(cur["W"]) || 1, prev));
+        }
+      }, 0);
+      str += additionalWounds;
+    }
+    return str * (unit.strength || 1);
+  }
+}

--- a/src/utils/unit.test.js
+++ b/src/utils/unit.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest";
+import { getUnitStrength } from "./unit";
+
+describe("getUnitStrength", () => {
+  test("Returns correct unit strength of regular infantry", () => {
+    const unitStr = getUnitStrength({
+      name_en: "State Troops",
+      strength: 10
+    });
+    expect(unitStr).toBe(10);
+  });
+
+  test("Treats unknown units as unit strength 1 per model", () => {
+    const unitStr = getUnitStrength({
+      name_en: "Made Up Unit",
+      strength: 10
+    });
+    expect(unitStr).toBe(10);
+  });
+
+  test("Uses initial wounds for behemoths", () => {
+    const unitStr = getUnitStrength({
+      name_en: "Giant",
+    });
+    expect(unitStr).toBe(6);
+  });
+
+  test("Uses initial wounds for war machines with multiple stat lines", () => {
+    const unitStr = getUnitStrength({
+      name_en: "Great Cannon {empire}",
+    });
+    expect(unitStr).toBe(3);
+  });
+
+  test("When a character is mounted, use the mount's model type", () => {
+    const unitStr = getUnitStrength({
+      name_en: "General of the Empire",
+      mounts: [
+        {
+          name_en: "On foot",
+          active: false,
+        },
+        {
+          name_en: "Barded Warhorse",
+          active: true,
+        }
+      ],
+    });
+    expect(unitStr).toBe(2);
+  });
+
+  test("When a character is mounted on a monster, add the model's wounds together", () => {
+    const unitStr = getUnitStrength({
+      name_en: "General of the Empire",
+      mounts: [
+        {
+          name_en: "On foot",
+          active: false,
+        },
+        {
+          name_en: "Griffon {empire}",
+          active: true,
+        }
+      ],
+    });
+    expect(unitStr).toBe(6);
+  });
+});

--- a/src/utils/unit.test.js
+++ b/src/utils/unit.test.js
@@ -80,7 +80,25 @@ describe("getUnitStrength", () => {
           strength: 5
         },
       ],
-    }, true);
+    }, true, false);
     expect(unitStr).toBe(30);
+  });
+  
+  test("Can get correct strength for detachment only units", () => {
+    const unitStr = getUnitStrength({
+      name_en: "Primal Warherd",
+      detachmentsInUnitStr: true,
+      detachments: [
+        {
+          name_en: "Gors",
+          strength: 10
+        },
+        {
+          name_en: "Ungors",
+          strength: 12
+        },
+      ],
+    }, true);
+    expect(unitStr).toBe(22);
   });
 });

--- a/src/utils/unit.test.js
+++ b/src/utils/unit.test.js
@@ -65,4 +65,22 @@ describe("getUnitStrength", () => {
     });
     expect(unitStr).toBe(6);
   });
+
+  test("Includes detachment strength when parameter is true", () => {
+    const unitStr = getUnitStrength({
+      name_en: "Nuln State Troops",
+      strength: 20,
+      detachments: [
+        {
+          name_en: "State Troops",
+          strength: 5
+        },
+        {
+          name_en: "State Missile Troops",
+          strength: 5
+        },
+      ],
+    }, true);
+    expect(unitStr).toBe(30);
+  });
 });


### PR DESCRIPTION
The new Battle March rules have a new requirement that no unit can have a unit strength of more than 20 when creating the list. I have added a function that takes a unit object and computes its unit strength, based on its unit type and current strength. Optionally I have added a parameter to include any detachments that are included in the unit. 

I also got the Primal Warband to work, but wasn't able to get the Royal Host Cohorts to work; when I started to adjust them to be detachments instead of options, I ran into some issues, like if I add royal host wariors, archers, horsemen, and horse archers as dummy detachment entries in the tomb kings list, they show up in both types of cohort, since the detachment rules currently let any unit that can be a detachment attach to any regimental unit. 

There may be some other weird units that don't compute unit strength correctly, but since the only use case right now is checking if it's above 20 for Battle March, hopefully those won't be too big of an issue.
<img width="630" height="532" alt="image" src="https://github.com/user-attachments/assets/374e735b-a6d0-4a31-b033-9120f2df4d0d" />
