### PR TITLE
Fix for Skaven renegades clan rare units limits

### DIFF
--- a/src/utils/rules.js
+++ b/src/utils/rules.js
@@ -3848,7 +3848,7 @@ export const rules = {
           points: 1000,
         },
         {
-          ids: ["doomwheel", "warp-lightning-cannon"],
+          ids: ["doomwheel"],
           min: 0,
           max: 1,
           requiresType: "characters",
@@ -3856,7 +3856,23 @@ export const rules = {
           points: 1000,
         },
         {
-          ids: ["plagueclaw-catapult", "plague-censer-bearers"],
+          ids: ["warp-lightning-cannon"],
+          min: 0,
+          max: 1,
+          requiresType: "characters",
+          requires: ["warlock-engineer"],
+          points: 1000,
+        },
+        {
+          ids: ["plagueclaw-catapult"],
+          min: 0,
+          max: 1,
+          requiresType: "characters",
+          requires: ["plague-priest"],
+          points: 1000,
+        },
+        {
+          ids: ["plague-censer-bearers"],
           min: 0,
           max: 1,
           requiresType: "characters",


### PR DESCRIPTION
The 1.5 (and draft for 2.0) Renegades rules changed how the rare choices for Skaven are limited; in the regular legacy rules the clan based rare options (Doomwheel and Warp Lightning Cannon for engineers, Plagueclaw Catapults and Plague Censor Bearers for Plague Monks) shared the 0-1 per 1000 limits, but the Renegades rules made it so each unit can be taken 0-1 per 1000 if the character requirement is fulfilled.