### PR TITLE
Slayers Host can have Miner's Carts as well as Bugman's

### DIFF
--- a/public/games/the-old-world/dwarfen-mountain-holds.json
+++ b/public/games/the-old-world/dwarfen-mountain-holds.json
@@ -2380,13 +2380,6 @@
       "armyComposition": {
         "royal-clan": {
           "category": "special"
-        },
-        "slayer-host": {
-          "category": "rare",
-          "notes": {
-            "name_en": "0-1 Dwarf Cart per 1000 points",
-            "name_fr": "0-1 Chariot Nain par tranche de 1000 points"
-          }
         }
       }
     },
@@ -2438,6 +2431,13 @@
         },
         "expeditionary-force": {
           "category": "core"
+        },
+        "slayer-host": {
+          "category": "rare",
+          "notes": {
+            "name_en": "0-1 Dwarf Cart per 1000 points",
+            "name_fr": "0-1 Chariot Nain par tranche de 1000 points"
+          }
         }
       }
     }


### PR DESCRIPTION
There are two entries for Dwarf Carts, one for the Royal Host that can only have the Bugman's option, and the other one for the other compositions that can be Bugman's or Miner's. The Slayer's Host incorrectly had the Bugman's only one.