### PR TITLE
Add army groups to allow for easier selection of armies from dropdown

### DIFF
--- a/src/assets/the-old-world.json
+++ b/src/assets/the-old-world.json
@@ -9,6 +9,7 @@
       "name_cn": "Renegade Crowns",
       "name_es": "Coronas Renegadas",
       "name_fr": "Couronnes Renégates",
+      "group": "forces-of-fantasy",
       "items": ["general"],
       "armyComposition": ["renegade-crowns"],
       "mercenaries": {
@@ -46,6 +47,7 @@
       "name_cn": "人类帝国",
       "name_es": "Imperio del Hombre",
       "name_fr": "Empire de l'Homme",
+      "group": "forces-of-fantasy",
       "items": ["general", "empire-of-man"],
       "armyComposition": [
         "empire-of-man",
@@ -148,6 +150,7 @@
       "name_cn": "兽人&地精部落",
       "name_es": "Tribus de Orcos y Goblins",
       "name_fr": "Tribus des Orques & Gobelins",
+      "group": "ravening-hordes",
       "items": ["general", "orc-and-goblin-tribes"],
       "armyComposition": [
         "orc-and-goblin-tribes",
@@ -206,6 +209,7 @@
       "name_cn": "矮人群山王国",
       "name_es": "Bastiones Enanos",
       "name_fr": "Forteresses Naines",
+      "group": "forces-of-fantasy",
       "items": ["dwarfen-mountain-holds"],
       "armyComposition": [
         "dwarfen-mountain-holds",
@@ -295,6 +299,7 @@
       "name_cn": "混沌勇士",
       "name_es": "Guerreros del Caos",
       "name_fr": "Guerriers du Chaos",
+      "group": "ravening-hordes",
       "items": [
         "general",
         "warriors-of-chaos",
@@ -364,6 +369,7 @@
       "name_cn": "巴托尼亚王国",
       "name_es": "Reino de Bretonia",
       "name_fr": "Royaume de Bretonnie",
+      "group": "forces-of-fantasy",
       "items": ["general", "kingdom-of-bretonnia", "knightly-virtues"],
       "armyComposition": [
         "kingdom-of-bretonnia",
@@ -426,6 +432,7 @@
       "name_cn": "野兽人嘶叫兽群",
       "name_es": "Rebaños de Hombres Bestia",
       "name_fr": "Braillehardes Hommes-bêtes",
+      "group": "ravening-hordes",
       "items": [
         "general",
         "beastmen-brayherds",
@@ -472,6 +479,7 @@
       "name_cn": "木精灵王国",
       "name_es": "Reinos de los Elfos Silvanos",
       "name_fr": "Royaumes Elfes Sylvains",
+      "group": "forces-of-fantasy",
       "items": ["general", "wood-elf-realms", "forest-spites", "kindreds"],
       "armyComposition": [
         "wood-elf-realms",
@@ -516,6 +524,7 @@
       "name_cn": "喀穆里古墓王",
       "name_es": "Reyes Funerarios de Khemri",
       "name_fr": "Rois des Tombes de Khemri",
+      "group": "ravening-hordes",
       "items": ["general", "tomb-kings-of-khemri", "incantation-scrolls"],
       "armyComposition": [
         "tomb-kings-of-khemri",
@@ -557,6 +566,7 @@
       "name_cn": "高等精灵王国",
       "name_es": "Reinos de los Altos Elfos",
       "name_fr": "Royaumes Hauts Elfes",
+      "group": "forces-of-fantasy",
       "items": ["general", "high-elf-realms", "elven-honours"],
       "armyComposition": [
         "high-elf-realms",
@@ -601,6 +611,7 @@
       "name_cn": "黑暗精灵",
       "name_es": "Elfos Oscuros",
       "name_fr": "Elfes Noirs",
+      "group": "legends",
       "items": [
         "general",
         "dark-elves",
@@ -646,6 +657,7 @@
       "name_cn": "斯卡文",
       "name_es": "Skaven",
       "name_fr": "Skavens",
+      "group": "legends",
       "items": ["general", "skaven"],
       "armyComposition": ["skaven", "sk-renegade"],
       "versions": {
@@ -686,6 +698,7 @@
       "name_cn": "吸血鬼公爵",
       "name_es": "Condes Vampiro",
       "name_fr": "Comtes Vampires",
+      "group": "legends",
       "items": ["general", "vampire-counts", "vampiric-powers"],
       "armyComposition": ["vampire-counts", "vc-renegade"],
       "versions": {
@@ -709,6 +722,7 @@
       "name_cn": "混沌恶魔",
       "name_es": "Demonios del Caos",
       "name_fr": "Démons du Chaos",
+      "group": "legends",
       "armyComposition": ["daemons-of-chaos", "doc-renegade"],
       "versions": {
         "doc-renegade": [
@@ -765,6 +779,7 @@
       "name_cn": "食人魔王国",
       "name_es": "Reinos Ogros",
       "name_fr": "Royaumes Ogres",
+      "group": "legends",
       "items": ["general", "ogre-kingdoms", "big-names"],
       "armyComposition": ["ogre-kingdoms", "ok-renegade"],
       "versions": {
@@ -809,6 +824,7 @@
       "name_cn": "蜥蜴人",
       "name_es": "Hombres Lagarto",
       "name_fr": "Hommes-Lézards",
+      "group": "legends",
       "items": ["general", "lizardmen", "disciplines-old-ones"],
       "armyComposition": ["lizardmen", "lm-renegade"],
       "versions": {
@@ -849,6 +865,7 @@
       "name_cn": "混沌矮人",
       "name_es": "Enanos del Caos",
       "name_fr": "Nains du Chaos",
+      "group": "legends",
       "items": ["general", "chaos-dwarfs"],
       "armyComposition": ["chaos-dwarfs", "cd-renegade"],
       "versions": {
@@ -909,6 +926,7 @@
       "name_cn": "震旦天朝",
       "name_es": "Gran Catai",
       "name_fr": "Grand Cathay",
+      "group": "forces-of-fantasy",
       "items": ["general", "grand-cathay"],
       "armyComposition": [
         "grand-cathay",
@@ -969,6 +987,32 @@
           }
         ]
       }
+    }
+  ],
+  "armyGroups": [
+    {
+      "id": "forces-of-fantasy",
+      "name_en": "Forces of Fantasy",
+      "name_de": "Strahlende Heere",
+      "name_cn": "Forces of Fantasy",
+      "name_es": "Forces of Fantasy",
+      "name_fr": "Forces Fantastiques"
+    },
+    {
+      "id": "ravening-hordes",
+      "name_en": "Ravening Hordes",
+      "name_de": "Kriegerische Horden",
+      "name_cn": "Ravening Hordes",
+      "name_es": "Ravening Hordes",
+      "name_fr": "Hordes Sauvages"
+    },
+    {
+      "id": "legends",
+      "name_en": "Legends",
+      "name_de": "Legends",
+      "name_cn": "Legends",
+      "name_es": "Legends",
+      "name_fr": "Legends"
     }
   ]
 }

--- a/src/components/select/Select.jsx
+++ b/src/components/select/Select.jsx
@@ -26,30 +26,23 @@ export const Select = ({
   };
 
   let innerElements;
+  const mapSelectElements = ({ id: optionValue, ...option }) => (
+    <option key={optionValue} value={optionValue}>
+      {option[`name_${language}`] || option.name_en}
+    </option>
+  );
   if (optionGroups) {
     innerElements = optionGroups.map(({ id: groupId, ...group }) => (
       <optgroup label={group[`name_${language}`] || group.name_en} key={groupId}>
-        {options.filter((option) => option.group === groupId).map(({ id: optionValue, ...option }) => (
-          <option key={optionValue} value={optionValue}>
-            {option[`name_${language}`] || option.name_en}
-          </option>
-        ))}
+        {options.filter((option) => option.group === groupId).map(mapSelectElements)}
       </optgroup>
     ));
     innerElements = innerElements.concat(
       options.filter((option) => !option.group || optionGroups.findIndex((group) => group.id === option.group) < 0)
-        .map(({ id: optionValue, ...option }) => (
-          <option key={optionValue} value={optionValue}>
-            {option[`name_${language}`] || option.name_en}
-          </option>
-        ))
+        .map(mapSelectElements)
     );
   } else {
-    innerElements = options.map(({ id: optionValue, ...option }) => (
-      <option key={optionValue} value={optionValue}>
-        {option[`name_${language}`] || option.name_en}
-      </option>
-    ));
+    innerElements = options.map(mapSelectElements);
   }
 
   return (

--- a/src/components/select/Select.jsx
+++ b/src/components/select/Select.jsx
@@ -8,6 +8,7 @@ import "./Select.css";
 
 export const Select = ({
   options,
+  optionGroups,
   className,
   id,
   name,
@@ -23,6 +24,33 @@ export const Select = ({
   const handleOnChange = (event) => {
     onChange(event.target.value);
   };
+
+  let innerElements;
+  if (optionGroups) {
+    innerElements = optionGroups.map(({ id: groupId, ...group }) => (
+      <optgroup label={group[`name_${language}`] || group.name_en} key={groupId}>
+        {options.filter((option) => option.group === groupId).map(({ id: optionValue, ...option }) => (
+          <option key={optionValue} value={optionValue}>
+            {option[`name_${language}`] || option.name_en}
+          </option>
+        ))}
+      </optgroup>
+    ));
+    innerElements = innerElements.concat(
+      options.filter((option) => !option.group || optionGroups.findIndex((group) => group.id === option.group) < 0)
+        .map(({ id: optionValue, ...option }) => (
+          <option key={optionValue} value={optionValue}>
+            {option[`name_${language}`] || option.name_en}
+          </option>
+        ))
+    );
+  } else {
+    innerElements = options.map(({ id: optionValue, ...option }) => (
+      <option key={optionValue} value={optionValue}>
+        {option[`name_${language}`] || option.name_en}
+      </option>
+    ));
+  }
 
   return (
     <select
@@ -40,17 +68,14 @@ export const Select = ({
         className
       )}
     >
-      {options.map(({ id: optionValue, ...option }) => (
-        <option key={optionValue} value={optionValue}>
-          {option[`name_${language}`] || option.name_en}
-        </option>
-      ))}
+      {innerElements}
     </select>
   );
 };
 
 Select.propTypes = {
   options: PropTypes.array.isRequired,
+  optionGroups: PropTypes.array,
   className: PropTypes.string,
   onChange: PropTypes.func,
   id: PropTypes.string,
@@ -58,6 +83,7 @@ Select.propTypes = {
   required: PropTypes.bool,
   selected: PropTypes.string,
   disabled: PropTypes.bool,
+  spaceTop: PropTypes.bool,
   spaceBottom: PropTypes.bool,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };

--- a/src/pages/new-list/NewList.jsx
+++ b/src/pages/new-list/NewList.jsx
@@ -43,6 +43,9 @@ export const NewList = ({ isMobile }) => {
     .filter(({ id }) => id === game)[0]
     .armies.sort((a, b) => a.id.localeCompare(b.id));
   const journalArmies = armies.find(({ id }) => army === id)?.armyComposition;
+  const armyGroups = gameSystems
+    .filter(({ id }) => id === game)[0]
+    .armyGroups;
   const versions = armies.find(({ id }) => army === id)?.versions;
   const compositionRules = [
     {
@@ -246,6 +249,7 @@ export const NewList = ({ isMobile }) => {
           <Select
             id="army"
             options={armies}
+            optionGroups={armyGroups}
             onChange={handleArmyChange}
             selected="empire-of-man"
             spaceBottom


### PR DESCRIPTION
Per discussion on discord. Any army that doesn't have a group is appended to the bottom of the list, so it should work correctly with custom datasets, though I'm not super familiar with how that works and didn't test with them.

<img width="331" height="703" alt="image" src="https://github.com/user-attachments/assets/d8749654-77d5-4504-b745-a52f172a349e" />
